### PR TITLE
Update Checkpointing Docs to include details on initializing model with other hyperparameters

### DIFF
--- a/docs/source-pytorch/common/checkpointing_basic.rst
+++ b/docs/source-pytorch/common/checkpointing_basic.rst
@@ -108,7 +108,7 @@ The LightningModule also has access to the Hyperparameters
 
 Initialize with other parameters
 ================================
-If you used the *self.save_hyperparameters()* method in the init of the LightningModule, you can initialize the model with different hyperparameters.
+If you used the *self.save_hyperparameters()* method in the init of the LightningModule, you can initialize the model with different hyperparameters. Named arguments passed to ``load_from_checkpoint`` will be forwarded to the model's ``__init__`` function, with the exception of arguments named ``strict``, ``map_location``, and ``hparams_file``, which are consumed by ``load_from_checkpoint``. Positional arguments will **not** be forwarded to the model.
 
 .. code-block:: python
 
@@ -123,6 +123,8 @@ If you used the *self.save_hyperparameters()* method in the init of the Lightnin
     model = LitModel.load_from_checkpoint(PATH, in_dim=128, out_dim=10)
 
 ----
+
+
 
 *************************
 nn.Module from checkpoint


### PR DESCRIPTION

## What does this PR do?

Currently, docs do not include information that positional arguments will not be forwarded to the model. All examples include only keyword arguments. This bug causes many wasted hours of debugging every time.


<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ x ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ x ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ N/A docs update only ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
