### PR TITLE
[docs] explain how to use `torchrun` in a SLURM environment

### DIFF
--- a/docs/source-pytorch/clouds/cluster_intermediate_2.rst
+++ b/docs/source-pytorch/clouds/cluster_intermediate_2.rst
@@ -35,3 +35,12 @@ Run the below command with the appropriate variables set on each node.
 .. note::
 
     ``torch.distributed.run`` assumes that you'd like to spawn a process per GPU if GPU devices are found on the node. This can be adjusted with ``-nproc_per_node``.
+
+.. note::
+
+    This approach will not work if attempted to be used in a SLURM environment. To make it work you need to set at the top of your main script:
+
+.. code-block:: python
+
+    import os
+    os.environ["SLURM_JOB_NAME"] = "interactive"

--- a/docs/source-pytorch/clouds/cluster_intermediate_2.rst
+++ b/docs/source-pytorch/clouds/cluster_intermediate_2.rst
@@ -43,4 +43,5 @@ Run the below command with the appropriate variables set on each node.
 .. code-block:: python
 
     import os
+
     os.environ["SLURM_JOB_NAME"] = "interactive"

--- a/docs/source-pytorch/clouds/cluster_intermediate_2.rst
+++ b/docs/source-pytorch/clouds/cluster_intermediate_2.rst
@@ -34,7 +34,7 @@ Run the below command with the appropriate variables set on each node.
 
 .. note::
 
-    ``torch.distributed.run`` assumes that you'd like to spawn a process per GPU if GPU devices are found on the node. This can be adjusted with ``-nproc_per_node``.
+    ``torch.distributed.run`` assumes that you'd like to spawn a process per GPU if GPU devices are found on the node. This can be adjusted with ``--nproc_per_node``.
 
 .. note::
 


### PR DESCRIPTION
PL kept on failing to bind to a port in a slurm environment when I tried switching to `torchrun`. 

I need the latter so that I could use `--role \$(hostname -s): --tee 3` flags - a crucial feature which I can't find in PL's other launchers.

So after reading the source code I found how to hack around it and so documenting the hack for other users to find to save them lost time.

Thank you.


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18614.org.readthedocs.build/en/18614/

<!-- readthedocs-preview pytorch-lightning end -->