### PR TITLE
Hparams should always be an AttributeDict

### DIFF
--- a/src/lightning/app/utilities/data_structures.py
+++ b/src/lightning/app/utilities/data_structures.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 
 class AttributeDict(Dict):
@@ -32,7 +32,7 @@ class AttributeDict(Dict):
 
     """
 
-    def __getattr__(self, key: str) -> Optional[Any]:
+    def __getattr__(self, key: str) -> Any:
         try:
             return self[key]
         except KeyError as exp:

--- a/src/lightning/pytorch/core/mixins/hparams_mixin.py
+++ b/src/lightning/pytorch/core/mixins/hparams_mixin.py
@@ -117,7 +117,7 @@ class HyperparametersMixin:
         if isinstance(hp, dict) and isinstance(self.hparams, dict):
             self.hparams.update(hp)
         else:
-            self._hparams = hp
+            self._hparams: AttributeDict = hp
 
     @staticmethod
     def _to_hparams_dict(hp: Union[MutableMapping, Namespace]) -> AttributeDict:

--- a/src/lightning/pytorch/core/mixins/hparams_mixin.py
+++ b/src/lightning/pytorch/core/mixins/hparams_mixin.py
@@ -111,7 +111,7 @@ class HyperparametersMixin:
                 frame = current_frame.f_back
         save_hyperparameters(self, *args, ignore=ignore, frame=frame)
 
-    def _set_hparams(self, hp: Union[MutableMapping, Namespace, str]) -> None:
+    def _set_hparams(self, hp: Union[MutableMapping, Namespace]) -> None:
         hp = self._to_hparams_dict(hp)
 
         if isinstance(hp, dict) and isinstance(self.hparams, dict):
@@ -120,10 +120,10 @@ class HyperparametersMixin:
             self._hparams = hp
 
     @staticmethod
-    def _to_hparams_dict(hp: Union[MutableMapping, Namespace, str]) -> AttributeDict:
+    def _to_hparams_dict(hp: Union[MutableMapping, Namespace]) -> AttributeDict:
         if isinstance(hp, Namespace):
             hp = vars(hp)
-        if isinstance(hp, dict):
+        if isinstance(hp, MutableMapping):
             hp = AttributeDict(hp)
         elif isinstance(hp, _PRIMITIVE_TYPES):
             raise ValueError(f"Primitives {_PRIMITIVE_TYPES} are not allowed.")

--- a/src/lightning/pytorch/core/mixins/hparams_mixin.py
+++ b/src/lightning/pytorch/core/mixins/hparams_mixin.py
@@ -120,7 +120,7 @@ class HyperparametersMixin:
             self._hparams = hp
 
     @staticmethod
-    def _to_hparams_dict(hp: Union[MutableMapping, Namespace, str]) -> Union[MutableMapping, AttributeDict]:
+    def _to_hparams_dict(hp: Union[MutableMapping, Namespace, str]) -> AttributeDict:
         if isinstance(hp, Namespace):
             hp = vars(hp)
         if isinstance(hp, dict):
@@ -132,7 +132,7 @@ class HyperparametersMixin:
         return hp
 
     @property
-    def hparams(self) -> Union[AttributeDict, MutableMapping]:
+    def hparams(self) -> AttributeDict:
         """The collection of hyperparameters saved with :meth:`save_hyperparameters`. It is mutable by the user. For
         the frozen set of initial hyperparameters, use :attr:`hparams_initial`.
 


### PR DESCRIPTION
## What does this PR do?

Fix for: Loose type annotation for `hparams` causes false positives in type checkers if hyperparameters are accessed as attributes.

Fixes #18972
Fixes #17852

No breaking changes

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)  (Issue is opened but no discussion so far)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18973.org.readthedocs.build/en/18973/

<!-- readthedocs-preview pytorch-lightning end -->