### PR TITLE
Fix the "our" word duplication in the docs

### DIFF
--- a/docs/source-fabric/fundamentals/installation.rst
+++ b/docs/source-fabric/fundamentals/installation.rst
@@ -38,7 +38,7 @@ Fabric is part of the `Lightning <https://lightning.ai>`_ package. Here is how y
 
 If you don't already have it, this command will also install the latest `stable PyTorch version <https://pytorch.org/>`_.
 
-You can find our the list of supported PyTorch versions in our `compatibility matrix <https://lightning.ai/docs/pytorch/stable/versioning.html#compatibility-matrix>`__.
+You can find the list of supported PyTorch versions in our :ref:`compatibility matrix <versioning:Compatibility matrix>`.
 
 
 ----

--- a/docs/source-fabric/index.rst
+++ b/docs/source-fabric/index.rst
@@ -62,7 +62,7 @@ Conda users
 
 Or read the :doc:`advanced install guide <fundamentals/installation>`.
 
-You can find our the list of supported PyTorch versions in our :ref:`compatibility matrix <versioning:Compatibility matrix>`.
+You can find the list of supported PyTorch versions in our :ref:`compatibility matrix <versioning:Compatibility matrix>`.
 
 .. raw:: html
 

--- a/docs/source-pytorch/index.rst
+++ b/docs/source-pytorch/index.rst
@@ -60,7 +60,7 @@ Conda users
 
 Or read the `advanced install guide <starter/installation.html>`_
 
-You can find our the list of supported PyTorch versions in our :ref:`compatibility matrix <versioning:Compatibility matrix>`.
+You can find the list of supported PyTorch versions in our :ref:`compatibility matrix <versioning:Compatibility matrix>`.
 
 .. raw:: html
 

--- a/docs/source-pytorch/starter/installation.rst
+++ b/docs/source-pytorch/starter/installation.rst
@@ -68,6 +68,8 @@ Custom PyTorch Version
 ^^^^^^^^^^^^^^^^^^^^^^
 To use any PyTorch version visit the `PyTorch Installation Page <https://pytorch.org/get-started/locally/#start-locally>`_.
 
+You can find the list of supported PyTorch versions in our :ref:`compatibility matrix <versioning:Compatibility matrix>`.
+
 ----
 
 


### PR DESCRIPTION
## What does this PR do?

There are a bit inconsistent sentences with a word duplication issue in the documentation, so this PR:
  * fixes the word duplication issue
  * unifies references to the [Compatibility matrix](https://lightning.ai/docs/pytorch/stable/versioning.html#compatibility-matrix)
  * add a reference to the Compatibility matrix
    into PyTorch Lightning's [Installation Docs](https://pytorch-lightning--19055.org.readthedocs.build/en/19055/pytorch/starter/installation.html#custom-pytorch-version)

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- `[kinda]` Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--19055.org.readthedocs.build/en/19055/

<!-- readthedocs-preview pytorch-lightning end -->