### PR TITLE
[WIP] Enable mmap in `torch.load()`

### DIFF
--- a/src/lightning/fabric/utilities/cloud_io.py
+++ b/src/lightning/fabric/utilities/cloud_io.py
@@ -25,14 +25,12 @@ from fsspec.implementations.local import AbstractFileSystem
 from lightning_utilities.core.imports import module_available
 
 from lightning.fabric.utilities.types import _MAP_LOCATION_TYPE, _PATH
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 
 log = logging.getLogger(__name__)
 
 
-def _load(
-    path_or_url: Union[IO, _PATH],
-    map_location: _MAP_LOCATION_TYPE = None,
-) -> Any:
+def _load(path_or_url: Union[IO, _PATH], map_location: _MAP_LOCATION_TYPE = None) -> Any:
     """Loads a checkpoint.
 
     Args:
@@ -51,6 +49,10 @@ def _load(
             str(path_or_url),
             map_location=map_location,  # type: ignore[arg-type]
         )
+    if _is_local_file_protocol(path_or_url):
+        kwargs = {"mmap": True} if _TORCH_GREATER_EQUAL_2_1 else {}
+        return torch.load(str(path_or_url), map_location=map_location, **kwargs)
+
     fs = get_filesystem(path_or_url)
     with fs.open(path_or_url, "rb") as f:
         return torch.load(f, map_location=map_location)  # type: ignore[arg-type]

--- a/src/lightning/fabric/utilities/cloud_io.py
+++ b/src/lightning/fabric/utilities/cloud_io.py
@@ -24,8 +24,8 @@ from fsspec.core import url_to_fs
 from fsspec.implementations.local import AbstractFileSystem
 from lightning_utilities.core.imports import module_available
 
-from lightning.fabric.utilities.types import _MAP_LOCATION_TYPE, _PATH
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_1
+from lightning.fabric.utilities.types import _MAP_LOCATION_TYPE, _PATH
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## What does this PR do?

WIP

1. Run with mmap=True by default across all tests in CI.


There is a hint in the PyTorch code base that `mmap=True` could become the default in the future:
https://github.com/pytorch/pytorch/blob/f93ea143097716dac0bf1a7c3d89b6a6e3a4e1d0/torch/serialization.py#L989-L991




<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--19087.org.readthedocs.build/en/19087/

<!-- readthedocs-preview pytorch-lightning end -->