### PR TITLE
 Add `@override` for files in `src/lightning/fabric/plugins/environments`

### DIFF
--- a/src/lightning/fabric/plugins/environments/kubeflow.py
+++ b/src/lightning/fabric/plugins/environments/kubeflow.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+from typing_extensions import override
 
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
 
@@ -32,35 +33,45 @@ class KubeflowEnvironment(ClusterEnvironment):
     """
 
     @property
+    @override
     def creates_processes_externally(self) -> bool:
         return True
 
     @property
+    @override
     def main_address(self) -> str:
         return os.environ["MASTER_ADDR"]
 
     @property
+    @override
     def main_port(self) -> int:
         return int(os.environ["MASTER_PORT"])
 
     @staticmethod
+    @override
     def detect() -> bool:
         raise NotImplementedError("The Kubeflow environment can't be detected automatically.")
 
+    @override
     def world_size(self) -> int:
         return int(os.environ["WORLD_SIZE"])
 
+    @override
     def set_world_size(self, size: int) -> None:
         log.debug("KubeflowEnvironment.set_world_size was called, but setting world size is not allowed. Ignored.")
 
+    @override
     def global_rank(self) -> int:
         return int(os.environ["RANK"])
 
+    @override
     def set_global_rank(self, rank: int) -> None:
         log.debug("KubeflowEnvironment.set_global_rank was called, but setting global rank is not allowed. Ignored.")
 
+    @override
     def local_rank(self) -> int:
         return 0
 
+    @override
     def node_rank(self) -> int:
         return self.global_rank()

--- a/src/lightning/fabric/plugins/environments/kubeflow.py
+++ b/src/lightning/fabric/plugins/environments/kubeflow.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+
 from typing_extensions import override
 
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment

--- a/src/lightning/fabric/plugins/environments/lightning.py
+++ b/src/lightning/fabric/plugins/environments/lightning.py
@@ -14,7 +14,7 @@
 
 import os
 import socket
-
+from typing_extensions import override
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
 from lightning.fabric.utilities.rank_zero import rank_zero_only
 
@@ -42,6 +42,7 @@ class LightningEnvironment(ClusterEnvironment):
         self._world_size: int = 1
 
     @property
+    @override
     def creates_processes_externally(self) -> bool:
         """Returns whether the cluster creates the processes or not.
 
@@ -52,10 +53,12 @@ class LightningEnvironment(ClusterEnvironment):
         return "LOCAL_RANK" in os.environ
 
     @property
+    @override
     def main_address(self) -> str:
         return os.environ.get("MASTER_ADDR", "127.0.0.1")
 
     @property
+    @override
     def main_port(self) -> int:
         if self._main_port == -1:
             self._main_port = (
@@ -64,29 +67,37 @@ class LightningEnvironment(ClusterEnvironment):
         return self._main_port
 
     @staticmethod
+    @override
     def detect() -> bool:
         return True
 
+    @override
     def world_size(self) -> int:
         return self._world_size
 
+    @override    
     def set_world_size(self, size: int) -> None:
         self._world_size = size
 
+    @override    
     def global_rank(self) -> int:
         return self._global_rank
 
+    @override    
     def set_global_rank(self, rank: int) -> None:
         self._global_rank = rank
         rank_zero_only.rank = rank
 
+    @override
     def local_rank(self) -> int:
         return int(os.environ.get("LOCAL_RANK", 0))
 
+    @override
     def node_rank(self) -> int:
         group_rank = os.environ.get("GROUP_RANK", 0)
         return int(os.environ.get("NODE_RANK", group_rank))
 
+    @override
     def teardown(self) -> None:
         if "WORLD_SIZE" in os.environ:
             del os.environ["WORLD_SIZE"]

--- a/src/lightning/fabric/plugins/environments/lightning.py
+++ b/src/lightning/fabric/plugins/environments/lightning.py
@@ -14,7 +14,9 @@
 
 import os
 import socket
+
 from typing_extensions import override
+
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
 from lightning.fabric.utilities.rank_zero import rank_zero_only
 
@@ -75,15 +77,15 @@ class LightningEnvironment(ClusterEnvironment):
     def world_size(self) -> int:
         return self._world_size
 
-    @override    
+    @override
     def set_world_size(self, size: int) -> None:
         self._world_size = size
 
-    @override    
+    @override
     def global_rank(self) -> int:
         return self._global_rank
 
-    @override    
+    @override
     def set_global_rank(self, rank: int) -> None:
         self._global_rank = rank
         rank_zero_only.rank = rank

--- a/src/lightning/fabric/plugins/environments/lsf.py
+++ b/src/lightning/fabric/plugins/environments/lsf.py
@@ -15,6 +15,7 @@ import logging
 import os
 import socket
 from typing import Dict, List
+from typing_extensions import override
 
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
 from lightning.fabric.utilities.cloud_io import get_filesystem
@@ -62,27 +63,32 @@ class LSFEnvironment(ClusterEnvironment):
         log.debug(f"MASTER_PORT: {os.environ['MASTER_PORT']}")
 
     @property
+    @override
     def creates_processes_externally(self) -> bool:
         """LSF creates subprocesses, i.e., PyTorch Lightning does not need to spawn them."""
         return True
 
     @property
+    @override
     def main_address(self) -> str:
         """The main address is read from an OpenMPI host rank file in the environment variable
         ``LSB_DJOB_RANKFILE``."""
         return self._main_address
 
     @property
+    @override
     def main_port(self) -> int:
         """The main port is calculated from the LSF job ID."""
         return self._main_port
 
     @staticmethod
+    @override
     def detect() -> bool:
         """Returns ``True`` if the current process was launched using the ``jsrun`` command."""
         required_env_vars = {"LSB_JOBID", "LSB_DJOB_RANKFILE", "JSM_NAMESPACE_LOCAL_RANK", "JSM_NAMESPACE_SIZE"}
         return required_env_vars.issubset(os.environ.keys())
 
+    @override
     def world_size(self) -> int:
         """The world size is read from the environment variable ``JSM_NAMESPACE_SIZE``."""
         world_size = os.environ.get("JSM_NAMESPACE_SIZE")
@@ -93,9 +99,11 @@ class LSFEnvironment(ClusterEnvironment):
             )
         return int(world_size)
 
+    @override
     def set_world_size(self, size: int) -> None:
         log.debug("LSFEnvironment.set_world_size was called, but setting world size is not allowed. Ignored.")
 
+    @override
     def global_rank(self) -> int:
         """The world size is read from the environment variable ``JSM_NAMESPACE_RANK``."""
         global_rank = os.environ.get("JSM_NAMESPACE_RANK")
@@ -106,9 +114,11 @@ class LSFEnvironment(ClusterEnvironment):
             )
         return int(global_rank)
 
+    @override
     def set_global_rank(self, rank: int) -> None:
         log.debug("LSFEnvironment.set_global_rank was called, but setting global rank is not allowed. Ignored.")
 
+    @override
     def local_rank(self) -> int:
         """The local rank is read from the environment variable `JSM_NAMESPACE_LOCAL_RANK`."""
         local_rank = os.environ.get("JSM_NAMESPACE_LOCAL_RANK")
@@ -119,6 +129,7 @@ class LSFEnvironment(ClusterEnvironment):
             )
         return int(local_rank)
 
+    @override
     def node_rank(self) -> int:
         """The node rank is determined by the position of the current hostname in the OpenMPI host rank file stored in
         ``LSB_DJOB_RANKFILE``."""

--- a/src/lightning/fabric/plugins/environments/lsf.py
+++ b/src/lightning/fabric/plugins/environments/lsf.py
@@ -15,6 +15,7 @@ import logging
 import os
 import socket
 from typing import Dict, List
+
 from typing_extensions import override
 
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment

--- a/src/lightning/fabric/plugins/environments/mpi.py
+++ b/src/lightning/fabric/plugins/environments/mpi.py
@@ -16,7 +16,7 @@ import logging
 import socket
 from functools import lru_cache
 from typing import Optional
-
+from typing_extensions import override
 from lightning_utilities.core.imports import RequirementCache
 
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
@@ -47,22 +47,26 @@ class MPIEnvironment(ClusterEnvironment):
         self._main_port: Optional[int] = None
 
     @property
+    @override
     def creates_processes_externally(self) -> bool:
         return True
 
     @property
+    @override
     def main_address(self) -> str:
         if self._main_address is None:
             self._main_address = self._get_main_address()
         return self._main_address
 
     @property
+    @override
     def main_port(self) -> int:
         if self._main_port is None:
             self._main_port = self._get_main_port()
         return self._main_port
 
     @staticmethod
+    @override
     def detect() -> bool:
         """Returns ``True`` if the `mpi4py` package is installed and MPI returns a world size greater than 1."""
         if not _MPI4PY_AVAILABLE:
@@ -72,20 +76,25 @@ class MPIEnvironment(ClusterEnvironment):
 
         return MPI.COMM_WORLD.Get_size() > 1
 
+    @override
     @lru_cache(1)
     def world_size(self) -> int:
         return self._comm_world.Get_size()
 
+    @override
     def set_world_size(self, size: int) -> None:
         log.debug("MPIEnvironment.set_world_size was called, but setting world size is not allowed. Ignored.")
 
+    @override
     @lru_cache(1)
     def global_rank(self) -> int:
         return self._comm_world.Get_rank()
 
+    @override
     def set_global_rank(self, rank: int) -> None:
         log.debug("MPIEnvironment.set_global_rank was called, but setting global rank is not allowed. Ignored.")
 
+    @override
     @lru_cache(1)
     def local_rank(self) -> int:
         if self._comm_local is None:
@@ -93,6 +102,7 @@ class MPIEnvironment(ClusterEnvironment):
         assert self._comm_local is not None
         return self._comm_local.Get_rank()
 
+    @override
     def node_rank(self) -> int:
         if self._node_rank is None:
             self._init_comm_local()

--- a/src/lightning/fabric/plugins/environments/mpi.py
+++ b/src/lightning/fabric/plugins/environments/mpi.py
@@ -16,8 +16,9 @@ import logging
 import socket
 from functools import lru_cache
 from typing import Optional
-from typing_extensions import override
+
 from lightning_utilities.core.imports import RequirementCache
+from typing_extensions import override
 
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
 from lightning.fabric.plugins.environments.lightning import find_free_network_port

--- a/src/lightning/fabric/plugins/environments/slurm.py
+++ b/src/lightning/fabric/plugins/environments/slurm.py
@@ -19,7 +19,9 @@ import shutil
 import signal
 import sys
 from typing import Optional
+
 from typing_extensions import override
+
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
 from lightning.fabric.utilities.imports import _IS_WINDOWS
 from lightning.fabric.utilities.rank_zero import rank_zero_warn
@@ -136,7 +138,7 @@ class SLURMEnvironment(ClusterEnvironment):
     def set_world_size(self, size: int) -> None:
         log.debug("SLURMEnvironment.set_world_size was called, but setting world size is not allowed. Ignored.")
 
-    @override    
+    @override
     def global_rank(self) -> int:
         return int(os.environ["SLURM_PROCID"])
 
@@ -148,7 +150,7 @@ class SLURMEnvironment(ClusterEnvironment):
     def local_rank(self) -> int:
         return int(os.environ["SLURM_LOCALID"])
 
-    @override    
+    @override
     def node_rank(self) -> int:
         return int(os.environ["SLURM_NODEID"])
 

--- a/src/lightning/fabric/plugins/environments/slurm.py
+++ b/src/lightning/fabric/plugins/environments/slurm.py
@@ -19,7 +19,7 @@ import shutil
 import signal
 import sys
 from typing import Optional
-
+from typing_extensions import override
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
 from lightning.fabric.utilities.imports import _IS_WINDOWS
 from lightning.fabric.utilities.rank_zero import rank_zero_warn
@@ -52,10 +52,12 @@ class SLURMEnvironment(ClusterEnvironment):
         self._validate_srun_variables()
 
     @property
+    @override
     def creates_processes_externally(self) -> bool:
         return True
 
     @property
+    @override
     def main_address(self) -> str:
         root_node = os.environ.get("MASTER_ADDR")
         if root_node is None:
@@ -67,6 +69,7 @@ class SLURMEnvironment(ClusterEnvironment):
         return root_node
 
     @property
+    @override
     def main_port(self) -> int:
         # -----------------------
         # SLURM JOB = PORT number
@@ -94,6 +97,7 @@ class SLURMEnvironment(ClusterEnvironment):
         return default_port
 
     @staticmethod
+    @override
     def detect() -> bool:
         """Returns ``True`` if the current process was launched on a SLURM cluster.
 
@@ -124,24 +128,31 @@ class SLURMEnvironment(ClusterEnvironment):
         except ValueError:
             return None
 
+    @override
     def world_size(self) -> int:
         return int(os.environ["SLURM_NTASKS"])
 
+    @override
     def set_world_size(self, size: int) -> None:
         log.debug("SLURMEnvironment.set_world_size was called, but setting world size is not allowed. Ignored.")
 
+    @override    
     def global_rank(self) -> int:
         return int(os.environ["SLURM_PROCID"])
 
+    @override
     def set_global_rank(self, rank: int) -> None:
         log.debug("SLURMEnvironment.set_global_rank was called, but setting global rank is not allowed. Ignored.")
 
+    @override
     def local_rank(self) -> int:
         return int(os.environ["SLURM_LOCALID"])
 
+    @override    
     def node_rank(self) -> int:
         return int(os.environ["SLURM_NODEID"])
 
+    @override
     def validate_settings(self, num_devices: int, num_nodes: int) -> None:
         if _is_slurm_interactive_mode():
             return

--- a/src/lightning/fabric/plugins/environments/torchelastic.py
+++ b/src/lightning/fabric/plugins/environments/torchelastic.py
@@ -14,8 +14,9 @@
 
 import logging
 import os
-from typing_extensions import override
+
 import torch.distributed
+from typing_extensions import override
 
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
 from lightning.fabric.utilities.rank_zero import rank_zero_warn
@@ -65,7 +66,7 @@ class TorchElasticEnvironment(ClusterEnvironment):
     def set_world_size(self, size: int) -> None:
         log.debug("TorchElasticEnvironment.set_world_size was called, but setting world size is not allowed. Ignored.")
 
-    @override    
+    @override
     def global_rank(self) -> int:
         return int(os.environ["RANK"])
 

--- a/src/lightning/fabric/plugins/environments/torchelastic.py
+++ b/src/lightning/fabric/plugins/environments/torchelastic.py
@@ -14,7 +14,7 @@
 
 import logging
 import os
-
+from typing_extensions import override
 import torch.distributed
 
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
@@ -27,10 +27,12 @@ class TorchElasticEnvironment(ClusterEnvironment):
     """Environment for fault-tolerant and elastic training with `torchelastic <https://pytorch.org/elastic/>`_"""
 
     @property
+    @override
     def creates_processes_externally(self) -> bool:
         return True
 
     @property
+    @override
     def main_address(self) -> str:
         if "MASTER_ADDR" not in os.environ:
             rank_zero_warn("MASTER_ADDR environment variable is not defined. Set as localhost")
@@ -39,6 +41,7 @@ class TorchElasticEnvironment(ClusterEnvironment):
         return os.environ["MASTER_ADDR"]
 
     @property
+    @override
     def main_port(self) -> int:
         if "MASTER_PORT" not in os.environ:
             rank_zero_warn("MASTER_PORT environment variable is not defined. Set as 12910")
@@ -48,31 +51,39 @@ class TorchElasticEnvironment(ClusterEnvironment):
         return int(os.environ["MASTER_PORT"])
 
     @staticmethod
+    @override
     def detect() -> bool:
         """Returns ``True`` if the current process was launched using the torchelastic command."""
         # if not available (for example on MacOS), `is_torchelastic_launched` is not defined
         return torch.distributed.is_available() and torch.distributed.is_torchelastic_launched()
 
+    @override
     def world_size(self) -> int:
         return int(os.environ["WORLD_SIZE"])
 
+    @override
     def set_world_size(self, size: int) -> None:
         log.debug("TorchElasticEnvironment.set_world_size was called, but setting world size is not allowed. Ignored.")
 
+    @override    
     def global_rank(self) -> int:
         return int(os.environ["RANK"])
 
+    @override
     def set_global_rank(self, rank: int) -> None:
         log.debug(
             "TorchElasticEnvironment.set_global_rank was called, but setting global rank is not allowed. Ignored."
         )
 
+    @override
     def local_rank(self) -> int:
         return int(os.environ["LOCAL_RANK"])
 
+    @override
     def node_rank(self) -> int:
         return int(os.environ.get("GROUP_RANK", 0))
 
+    @override
     def validate_settings(self, num_devices: int, num_nodes: int) -> None:
         if num_devices * num_nodes != self.world_size():
             raise ValueError(

--- a/src/lightning/fabric/plugins/environments/xla.py
+++ b/src/lightning/fabric/plugins/environments/xla.py
@@ -14,7 +14,7 @@
 import functools
 import logging
 from typing import Any
-
+from typing_extensions import override
 from lightning.fabric.accelerators.xla import _XLA_AVAILABLE, _XLA_GREATER_EQUAL_2_1, XLAAccelerator, _using_pjrt
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
 
@@ -35,23 +35,28 @@ class XLAEnvironment(ClusterEnvironment):
         super().__init__(*args, **kwargs)
 
     @property
+    @override
     def creates_processes_externally(self) -> bool:
         return False
 
     @property
+    @override
     def main_address(self) -> str:
         # unused by lightning
         raise NotImplementedError
 
     @property
+    @override
     def main_port(self) -> int:
         # unused by lightning
         raise NotImplementedError
 
     @staticmethod
+    @override
     def detect() -> bool:
         return XLAAccelerator.is_available()
 
+    @override
     @functools.lru_cache(maxsize=1)
     def world_size(self) -> int:
         """The number of processes across all devices and hosts.
@@ -63,9 +68,11 @@ class XLAEnvironment(ClusterEnvironment):
 
         return xm.xrt_world_size()
 
+    @override
     def set_world_size(self, size: int) -> None:
         log.debug("XLAEnvironment.set_world_size was called, but setting world size is not allowed. Ignored.")
 
+    @override
     @functools.lru_cache(maxsize=1)
     def global_rank(self) -> int:
         """The rank (index) of the currently running process across all host and devices.
@@ -77,9 +84,11 @@ class XLAEnvironment(ClusterEnvironment):
 
         return xm.get_ordinal()
 
+    @override
     def set_global_rank(self, rank: int) -> None:
         log.debug("XLAEnvironment.set_global_rank was called, but setting global rank is not allowed. Ignored.")
 
+    @override
     @functools.lru_cache(maxsize=1)
     def local_rank(self) -> int:
         """The rank (index) of the currently running process inside of the current host.
@@ -91,6 +100,7 @@ class XLAEnvironment(ClusterEnvironment):
 
         return xm.get_local_ordinal()
 
+    @override
     @functools.lru_cache(maxsize=1)
     def node_rank(self) -> int:
         """The rank (index) of the host on which the current process runs.

--- a/src/lightning/fabric/plugins/environments/xla.py
+++ b/src/lightning/fabric/plugins/environments/xla.py
@@ -14,7 +14,9 @@
 import functools
 import logging
 from typing import Any
+
 from typing_extensions import override
+
 from lightning.fabric.accelerators.xla import _XLA_AVAILABLE, _XLA_GREATER_EQUAL_2_1, XLAAccelerator, _using_pjrt
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
 


### PR DESCRIPTION
This PR adds the `@override` decorator for all files in `src/lightning/fabric/plugins/environments` (https://github.com/Lightning-AI/pytorch-lightning/issues/18695).

<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--19098.org.readthedocs.build/en/19098/

<!-- readthedocs-preview pytorch-lightning end -->