### PR TITLE
Use `step` parameter when logging metrics with NeptuneLogger

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -65,6 +65,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed broadcast at initialization in `MPIEnvironment` ([#19074](https://github.com/Lightning-AI/lightning/pull/19074))
 
 
+- Fixed NeptuneLogger lack of usage of `step` parameter when logging metrics ([#19126](https://github.com/Lightning-AI/pytorch-lightning/pull/19126))
+
+
 ## [2.1.2] - 2023-11-15
 
 ### Fixed

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -32,6 +32,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The `LightningModule.load_from_checkpoint()` function now calls `.configure_model()` on the model if it is overridden, to ensure all layers can be loaded from the checkpoint ([#19036](https://github.com/Lightning-AI/lightning/pull/19036))
 
 
+- Restored usage of `step` parameter when logging metrics with `NeptuneLogger` ([#19126](https://github.com/Lightning-AI/pytorch-lightning/pull/19126))
+
+
 ### Deprecated
 
 - Deprecated all precision plugin classes under `lightning.pytorch.plugins` with the suffix `Plugin` in the name ([#18840](https://github.com/Lightning-AI/lightning/pull/18840))
@@ -63,9 +66,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - Fixed broadcast at initialization in `MPIEnvironment` ([#19074](https://github.com/Lightning-AI/lightning/pull/19074))
-
-
-- Fixed NeptuneLogger lack of usage of `step` parameter when logging metrics ([#19126](https://github.com/Lightning-AI/pytorch-lightning/pull/19126))
 
 
 ## [2.1.2] - 2023-11-15

--- a/src/lightning/pytorch/loggers/neptune.py
+++ b/src/lightning/pytorch/loggers/neptune.py
@@ -447,7 +447,7 @@ class NeptuneLogger(Logger):
 
         Args:
             metrics: Dictionary with metric names as keys and measured quantities as values.
-            step: Step number at which the metrics should be recorded, currently ignored.
+            step: Step number at which the metrics should be recorded
 
         """
         if rank_zero_only.rank != 0:
@@ -456,9 +456,7 @@ class NeptuneLogger(Logger):
         metrics = _add_prefix(metrics, self._prefix, self.LOGGER_JOIN_CHAR)
 
         for key, val in metrics.items():
-            # `step` is ignored because Neptune expects strictly increasing step values which
-            # Lightning does not always guarantee.
-            self.run[key].append(val)
+            self.run[key].append(val, step=step)
 
     @override
     @rank_zero_only

--- a/tests/tests_pytorch/loggers/test_all.py
+++ b/tests/tests_pytorch/loggers/test_all.py
@@ -307,7 +307,7 @@ def test_logger_with_prefix_all(mlflow_mock, wandb_mock, comet_mock, neptune_moc
     logger.log_metrics({"test": 1.0}, step=0)
     assert logger.experiment.__getitem__.call_count == 1
     logger.experiment.__getitem__.assert_called_with("tmp/test")
-    logger.experiment.__getitem__().append.assert_called_once_with(1.0)
+    logger.experiment.__getitem__().append.assert_called_once_with(1.0, step=0)
 
     # TensorBoard
     if _TENSORBOARD_AVAILABLE:

--- a/tests/tests_pytorch/loggers/test_neptune.py
+++ b/tests/tests_pytorch/loggers/test_neptune.py
@@ -166,7 +166,7 @@ def test_neptune_log_metrics_on_trained_model(neptune_mock, tmp_path):
     logger, run_instance_mock, _ = _get_logger_with_mocks(api_key="test", project="project")
     _fit_and_test(logger=logger, model=LoggingModel(), tmp_path=tmp_path)
     run_instance_mock.__getitem__.assert_any_call("training/some/key")
-    run_instance_mock.__getitem__.return_value.append.assert_has_calls([call(42)])
+    run_instance_mock.__getitem__.return_value.append.assert_has_calls([call(42, step=2)])
 
 
 def test_log_hyperparams(neptune_mock):
@@ -204,7 +204,7 @@ def test_log_metrics(neptune_mock):
         assert run_instance_mock.__getitem__.call_count == 2
         run_instance_mock.__getitem__.assert_any_call(metrics_foo_key)
         run_instance_mock.__getitem__.assert_any_call(metrics_bar_key)
-        run_attr_mock.append.assert_has_calls([call(42), call(555)])
+        run_attr_mock.append.assert_has_calls([call(42, step=None), call(555, step=None)])
 
 
 def test_log_model_summary(neptune_mock):


### PR DESCRIPTION
## What does this PR do?

Neptune has a requirement of strictly increasing steps for series. Back then we've been facing some issues regarding the Lightning integration and the order of steps and we had to leave the default behavior. Looks like Lightning is quite safe now with this assumption and some adjustments were made as well like: https://github.com/Lightning-AI/pytorch-lightning/issues/11616 so we can get back there.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚  Documentation preview 📚 : https://pytorch-lightning--19126.org.readthedocs.build/en/19126/

<!-- readthedocs-preview pytorch-lightning end -->