### PR TITLE
Fixed NeptuneLogger support across different versions of neptune package

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -65,6 +65,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed broadcast at initialization in `MPIEnvironment` ([#19074](https://github.com/Lightning-AI/lightning/pull/19074))
 
 
+- Fixed NeptuneLogger support across different versions of neptune package ([#19131](https://github.com/Lightning-AI/pytorch-lightning/pull/19131))
+
+
 ## [2.1.2] - 2023-11-15
 
 ### Fixed

--- a/src/lightning/pytorch/loggers/neptune.py
+++ b/src/lightning/pytorch/loggers/neptune.py
@@ -41,7 +41,6 @@ log = logging.getLogger(__name__)
 # neptune is available with two names on PyPI : `neptune` and `neptune-client`
 _NEPTUNE_AVAILABLE = bool(RequirementCache("neptune>=1.0")) or bool(RequirementCache("neptune-client>=1.0"))
 _LEGACY_NEPTUNE_CLIENT = bool(RequirementCache("neptune-client<1.0"))
-_GET_ROOT_OBJECT_AVAILABLE = bool(RequirementCache("neptune>=1.1")) or bool(RequirementCache("neptune-client>=1.1"))
 _INTEGRATION_VERSION_KEY = "source_code/integrations/pytorch-lightning"
 
 
@@ -320,8 +319,8 @@ class NeptuneLogger(Logger):
         if run is not None and not isinstance(run, (Run, Handler)):
             raise ValueError("Run parameter expected to be of type `neptune.Run`, or `neptune.handler.Handler`.")
 
-        if isinstance(run, Handler) and not _GET_ROOT_OBJECT_AVAILABLE:
-            raise ValueError("Providing namespace as `run` parameter requires neptune>=1.1.0.")
+        if isinstance(run, Handler) and not _NEPTUNE_AVAILABLE:
+            raise ValueError("Providing namespace as `run` parameter requires neptune>=1.0.0 or neptune-client>=1.0.0.")
 
         # check if user passed redundant neptune.init_run arguments when passed run
         any_neptune_init_arg_passed = any(arg is not None for arg in [api_key, project, name]) or neptune_run_kwargs
@@ -547,7 +546,7 @@ class NeptuneLogger(Logger):
                 self.run[f"{checkpoints_namespace}/{model_name}"] = File.from_stream(fp)
 
         # remove old models logged to experiment if they are not part of best k models at this point
-        root_obj = self.run.get_root_object() if _GET_ROOT_OBJECT_AVAILABLE else self.run
+        root_obj = self.run.get_root_object() if _NEPTUNE_AVAILABLE else self.run
 
         if root_obj.exists(checkpoints_namespace):
             exp_structure = root_obj.get_structure()

--- a/src/lightning/pytorch/loggers/neptune.py
+++ b/src/lightning/pytorch/loggers/neptune.py
@@ -40,7 +40,7 @@ log = logging.getLogger(__name__)
 
 # neptune is available with two names on PyPI : `neptune` and `neptune-client`
 _NEPTUNE_AVAILABLE = bool(RequirementCache("neptune>=1.0")) or bool(RequirementCache("neptune-client>=1.0"))
-_LEGACY_NEPTUNE_CLIENT = bool(RequirementCache("neptune-client<1.0"))
+_LEGACY_NEPTUNE_CLIENT_AVAILABLE = bool(RequirementCache("neptune-client<1.0"))
 _INTEGRATION_VERSION_KEY = "source_code/integrations/pytorch-lightning"
 
 
@@ -223,8 +223,8 @@ class NeptuneLogger(Logger):
         prefix: str = "training",
         **neptune_run_kwargs: Any,
     ):
-        if not _NEPTUNE_AVAILABLE and not _LEGACY_NEPTUNE_CLIENT:
-            raise ModuleNotFoundError("`neptune` package is required. Run `pip install neptune`")
+        if not _NEPTUNE_AVAILABLE and not _LEGACY_NEPTUNE_CLIENT_AVAILABLE:
+            raise ModuleNotFoundError(str(_NEPTUNE_AVAILABLE))
         # verify if user passed proper init arguments
         self._verify_input_arguments(api_key, project, name, run, neptune_run_kwargs)
         super().__init__()

--- a/tests/tests_pytorch/loggers/conftest.py
+++ b/tests/tests_pytorch/loggers/conftest.py
@@ -146,4 +146,5 @@ def neptune_mock(monkeypatch):
     neptune.utils = neptune_utils
 
     monkeypatch.setattr("lightning.pytorch.loggers.neptune._NEPTUNE_AVAILABLE", True)
+    monkeypatch.setattr("lightning.pytorch.loggers.neptune._GET_ROOT_OBJECT_AVAILABLE", True)
     return neptune

--- a/tests/tests_pytorch/loggers/conftest.py
+++ b/tests/tests_pytorch/loggers/conftest.py
@@ -146,5 +146,4 @@ def neptune_mock(monkeypatch):
     neptune.utils = neptune_utils
 
     monkeypatch.setattr("lightning.pytorch.loggers.neptune._NEPTUNE_AVAILABLE", True)
-    monkeypatch.setattr("lightning.pytorch.loggers.neptune._GET_ROOT_OBJECT_AVAILABLE", True)
     return neptune


### PR DESCRIPTION
## What does this PR do?

Fixes #18555

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚  Documentation preview 📚 : https://pytorch-lightning--19131.org.readthedocs.build/en/19131/

<!-- readthedocs-preview pytorch-lightning end -->