### PR TITLE
Clarify error message by mentioning "spawn"

### DIFF
--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -828,8 +828,8 @@ class Fabric:
                 )
         elif isinstance(self.strategy.launcher, (_MultiProcessingLauncher, _XLALauncher)):
             raise TypeError(
-                f"To use the `{type(self.strategy).__name__}` strategy, `.launch()` needs to be called with a function"
-                " that contains the code to launch in processes."
+                f"To spawn processes with the `{type(self.strategy).__name__}` strategy, `.launch()` needs to be called"
+                " with a function that contains the code to launch in processes."
             )
         return self._wrap_and_launch(function, self, *args, **kwargs)
 


### PR DESCRIPTION
## What does this PR do?

When `ddp_spawn` is used, the error message is

```text
TypeError: To use the `DDPStrategy` strategy, `.launch()` needs to be called with a function that contains the code to launch in processes.
```

which is ambiguous since `ddp` does not spawn by default.


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19142.org.readthedocs.build/en/19142/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli