### PR TITLE
ci: run TPU only with label

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -21,7 +21,7 @@ jobs:
     # run only when the PR title contains 'TPU' or is a merge to master
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
-      (startsWith(github.event_name, 'pull_request') && contains(github.event.pull_request.title, 'TPU'))
+      (startsWith(github.event_name, 'pull_request') && contains(github.event.pull_request.labels.*.name, 'run TPU'))
     strategy:
       fail-fast: false
       matrix:

--- a/tests/tests_fabric/strategies/test_xla.py
+++ b/tests/tests_fabric/strategies/test_xla.py
@@ -180,7 +180,7 @@ def tpu_sync_module_states_fn(sync_module_states, strategy):
 
 
 @RunIf(tpu=True)
-@pytest.mark.parametrize("sync_module_states", [True, False])
+@pytest.mark.parametrize("sync_module_states", [True])  # fixme: add False after fixing the issue, to unblock ci
 @mock.patch.dict(os.environ, os.environ.copy(), clear=True)
 def test_tpu_sync_module_states(sync_module_states):
     """Test sync_module_states."""

--- a/tests/tests_fabric/strategies/test_xla.py
+++ b/tests/tests_fabric/strategies/test_xla.py
@@ -180,7 +180,7 @@ def tpu_sync_module_states_fn(sync_module_states, strategy):
 
 
 @RunIf(tpu=True)
-@pytest.mark.parametrize("sync_module_states", [True])  # fixme: add False after fixing the issue, to unblock ci
+@pytest.mark.parametrize("sync_module_states", [True, False])
 @mock.patch.dict(os.environ, os.environ.copy(), clear=True)
 def test_tpu_sync_module_states(sync_module_states):
     """Test sync_module_states."""


### PR DESCRIPTION
## What does this PR do?

reduce vulnerability

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19143.org.readthedocs.build/en/19143/

<!-- readthedocs-preview pytorch-lightning end -->

cc @tchaton