### PR TITLE
Support 4bit BNB layers meta-device materialization

### DIFF
--- a/requirements/pytorch/extra.txt
+++ b/requirements/pytorch/extra.txt
@@ -8,4 +8,4 @@ hydra-core >=1.0.5, <1.4.0
 jsonargparse[signatures] >=4.26.1, <4.27.0
 rich >=12.3.0, <13.6.0
 tensorboardX >=2.2, <2.7.0  # min version is set by torch.onnx missing attribute
-bitsandbytes <=0.41.1
+bitsandbytes ==0.41.1

--- a/requirements/pytorch/extra.txt
+++ b/requirements/pytorch/extra.txt
@@ -8,4 +8,4 @@ hydra-core >=1.0.5, <1.4.0
 jsonargparse[signatures] >=4.26.1, <4.27.0
 rich >=12.3.0, <13.6.0
 tensorboardX >=2.2, <2.7.0  # min version is set by torch.onnx missing attribute
-bitsandbytes ==0.41.1
+bitsandbytes ==0.41.1  # strict

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `lightning.fabric.utilities.AttributeDict` for convenient dict-attribute access to represent state in script ([#18943](https://github.com/Lightning-AI/lightning/pull/18943))
 
 
+- Added support for meta-device initialization and materialization of 4-bit Bitsandbytes layers ([#19150](https://github.com/Lightning-AI/lightning/pull/19150))
+
+
 ### Changed
 
 - `seed_everything()` without passing in a seed no longer randomly selects a seed, and now defaults to `0` ([#18846](https://github.com/Lightning-AI/lightning/pull/18846))

--- a/src/lightning/fabric/plugins/precision/bitsandbytes.py
+++ b/src/lightning/fabric/plugins/precision/bitsandbytes.py
@@ -263,9 +263,6 @@ def _import_bitsandbytes() -> ModuleType:
             return self
 
         def reset_parameters(self):
-            if self.weight.device.type == "meta":
-                # need custom logic if int8params is on meta device
-                raise NotImplementedError
             # from `torch.nn.Linear.reset_parameters`
             if self.bias is not None:
                 fan_in, _ = torch.nn.init._calculate_fan_in_and_fan_out(self.weight)
@@ -279,6 +276,9 @@ def _import_bitsandbytes() -> ModuleType:
             weight = self.weight.data
             torch.nn.init.kaiming_uniform_(weight, a=math.sqrt(5))
             if linear_init_finished:
+                if self.weight.device.type == "meta":
+                    # need custom logic if int8params is on meta device
+                    raise NotImplementedError
                 if self.weight.device.type == "cuda":  # re-quantize
                     self.quantize(weight)
                 else:

--- a/src/lightning/fabric/utilities/init.py
+++ b/src/lightning/fabric/utilities/init.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import itertools
 from typing import Any, Callable, Dict, Optional, Sequence
+
+import torch
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_13
 
@@ -54,3 +57,16 @@ class _EmptyInit(TorchFunctionMode):
                 return kwargs["tensor"]
             return args[0]
         return func(*args, **kwargs)
+
+
+def materialize(module: torch.nn.Module, device: torch.device) -> None:
+    """Materialize a module."""
+    module.to_empty(device=device, recurse=False)
+    module.reset_parameters()
+
+
+def materialize_meta_tensors(module: torch.nn.Module, device: torch.device) -> None:
+    """Materialize all tensors in a given module."""
+    for module in module.modules():
+        if any(t.is_meta for t in itertools.chain(module.parameters(recurse=False), module.buffers(recurse=False))):
+            materialize(module, device)

--- a/src/lightning/fabric/utilities/init.py
+++ b/src/lightning/fabric/utilities/init.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Dict, Optional, Sequence
 
 import torch
 
-from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_13
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_13, _TORCH_GREATER_EQUAL_2_1
 from lightning.fabric.utilities.types import _DEVICE
 
 if _TORCH_GREATER_EQUAL_1_13:
@@ -62,6 +62,8 @@ class _EmptyInit(TorchFunctionMode):
 
 def _materialize(module: torch.nn.Module, device: _DEVICE) -> None:
     """Materialize a module."""
+    if not _TORCH_GREATER_EQUAL_2_1:
+        raise RuntimeError("recurse=False requires torch 2.1")
     module.to_empty(device=device, recurse=False)  # type: ignore[arg-type]
     if not hasattr(module, "reset_parameters"):
         raise TypeError(

--- a/src/lightning/fabric/utilities/init.py
+++ b/src/lightning/fabric/utilities/init.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Dict, Optional, Sequence
 import torch
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_13
+from lightning.fabric.utilities.types import _DEVICE
 
 if _TORCH_GREATER_EQUAL_1_13:
     from torch.overrides import TorchFunctionMode
@@ -59,7 +60,7 @@ class _EmptyInit(TorchFunctionMode):
         return func(*args, **kwargs)
 
 
-def _materialize(module: torch.nn.Module, device: torch.device) -> None:
+def _materialize(module: torch.nn.Module, device: _DEVICE) -> None:
     """Materialize a module."""
     module.to_empty(device=device, recurse=False)
     if not hasattr(module, "reset_parameters"):
@@ -70,7 +71,7 @@ def _materialize(module: torch.nn.Module, device: torch.device) -> None:
     module.reset_parameters()
 
 
-def _materialize_meta_tensors(module: torch.nn.Module, device: torch.device) -> None:
+def _materialize_meta_tensors(module: torch.nn.Module, device: _DEVICE) -> None:
     """Materialize all tensors in a given module."""
     for module in module.modules():
         if any(t.is_meta for t in itertools.chain(module.parameters(recurse=False), module.buffers(recurse=False))):

--- a/src/lightning/fabric/utilities/init.py
+++ b/src/lightning/fabric/utilities/init.py
@@ -62,7 +62,7 @@ class _EmptyInit(TorchFunctionMode):
 
 def _materialize(module: torch.nn.Module, device: _DEVICE) -> None:
     """Materialize a module."""
-    module.to_empty(device=device, recurse=False)
+    module.to_empty(device=device, recurse=False)  # type: ignore[arg-type]
     if not hasattr(module, "reset_parameters"):
         raise TypeError(
             f"Materialization requires that the `{type(module).__name__}.reset_parameters` method is implemented."

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The Trainer now restores the training mode set through `.train()` or `.eval()` on a submodule-level when switching from validation to training ([#18951](https://github.com/Lightning-AI/lightning/pull/18951))
 
 
+- Added support for meta-device initialization and materialization of 4-bit Bitsandbytes layers ([#19150](https://github.com/Lightning-AI/lightning/pull/19150))
+
+
 ### Changed
 
 - `seed_everything()` without passing in a seed no longer randomly selects a seed, and now defaults to `0` ([#18846](https://github.com/Lightning-AI/lightning/pull/18846))

--- a/tests/tests_fabric/plugins/precision/test_bitsandbytes.py
+++ b/tests/tests_fabric/plugins/precision/test_bitsandbytes.py
@@ -21,7 +21,7 @@ import torch.distributed
 from lightning.fabric import Fabric
 from lightning.fabric.connector import _Connector
 from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
-from lightning.fabric.utilities.init import materialize_meta_tensors
+from lightning.fabric.utilities.init import _materialize_meta_tensors
 
 from tests_fabric.helpers.runif import RunIf
 
@@ -166,7 +166,7 @@ def test_bitsandbytes_layers_meta_device(args, expected):
     assert model.l.weight.device.type == "meta"
     assert model.l.weight.dtype == args[1]
     # materializing performs quantization
-    materialize_meta_tensors(model, "cuda")
+    _materialize_meta_tensors(model, "cuda")
     assert model.l.weight.device.type == "cuda"
     assert model.l.weight.dtype == expected
     # state dict loading still works even thought the weights are quantized

--- a/tests/tests_fabric/plugins/precision/test_bitsandbytes.py
+++ b/tests/tests_fabric/plugins/precision/test_bitsandbytes.py
@@ -146,8 +146,8 @@ def test_bitsandbytes_layers(args, expected):
 @pytest.mark.parametrize(
     ("args", "expected"),
     [
-        (("int8", torch.float16), torch.int8),
-        (("nf4", torch.bfloat16), torch.uint8),
+        pytest.param(("int8", torch.float16), torch.int8, marks=pytest.mark.xfail(raises=NotImplementedError)),
+        pytest.param(("nf4", torch.bfloat16), torch.uint8, marks=RunIf(bf16_cuda=True)),
     ],
 )
 def test_bitsandbytes_layers_meta_device(args, expected):
@@ -164,7 +164,7 @@ def test_bitsandbytes_layers_meta_device(args, expected):
 
     # the model was instantiated on meta and is not quantized
     assert model.l.weight.device.type == "meta"
-    assert model.l.weight.dtype == torch.bfloat16
+    assert model.l.weight.dtype == args[1]
     # materializing performs quantization
     materialize_meta_tensors(model, "cuda")
     assert model.l.weight.device.type == "cuda"

--- a/tests/tests_fabric/plugins/precision/test_bitsandbytes.py
+++ b/tests/tests_fabric/plugins/precision/test_bitsandbytes.py
@@ -39,6 +39,7 @@ def test_bitsandbytes_plugin(monkeypatch):
 
     bitsandbytes_mock.nn.Linear8bitLt = ModuleMock
     bitsandbytes_mock.nn.Linear4bit = ModuleMock
+    bitsandbytes_mock.nn.Params4bit = object
 
     precision = BitsandbytesPrecision("nf4", dtype=torch.float16)
     connector = _Connector(plugins=precision)
@@ -64,7 +65,8 @@ def test_bitsandbytes_plugin(monkeypatch):
             self.l2 = SubModule()
 
     _NF4Linear = vars(module)["_NF4Linear"]
-    _NF4Linear._quantize_weight = Mock()
+    quantize_mock = lambda self, p, w, d: p
+    _NF4Linear._quantize = quantize_mock
 
     with precision.module_init_context():
         assert torch.get_default_dtype() == torch.float16

--- a/tests/tests_fabric/plugins/precision/test_bitsandbytes.py
+++ b/tests/tests_fabric/plugins/precision/test_bitsandbytes.py
@@ -148,7 +148,7 @@ def test_bitsandbytes_layers(args, expected):
     assert model.l.weight.dtype == expected
 
 
-@RunIf(min_cuda_gpus=1)
+@RunIf(min_cuda_gpus=1, min_torch="2.1")
 @pytest.mark.skipif(not _BITSANDBYTES_AVAILABLE, reason="bitsandbytes unavailable")
 @pytest.mark.parametrize(
     ("args", "expected"),

--- a/tests/tests_fabric/utilities/test_init.py
+++ b/tests/tests_fabric/utilities/test_init.py
@@ -61,6 +61,7 @@ def test_empty_init_speed():
     assert normal_init_time > 2 * empty_init_time
 
 
+@RunIf(min_torch="2.1")
 def test_materialize_meta_tensors():
     class Submodule(torch.nn.Module):
         def __init__(self):


### PR DESCRIPTION
## What does this PR do?

Adds support for converting Linear layers on meta-device to Bitsandbytes Linear layers.

Also for materializing and quantizing Bitsandbytes Linear layers on meta-device.

### Scenario 1

```python
fabric = Fabric(plugins=BitsandbytesPrecision(), devices=1)
# empty_init=True with devices=1 doesn't use meta device at the moment
with fabric.init_module(empty_init=False), torch.device("meta"):
    model = LLM()
# this looks stupid, but in reality this uses a custom materialization scheme
materialize_meta_tensors(model, fabric.device)  # quantize here
maybe_install_hooks(model)
load_checkpoint(model)  # quantize here
```

Cons:
- `to_empty` and `reset_parameters` (called from `materialize_meta_tensors`) will create empty tensors and quantize. There's no way to avoid this unless we make `materialize_meta_tensors` aware of bitsandbytes.
- `load_checkpoint` will again quantize weights that were already quantized during materialization.
- we materialized model parts that were going to be loaded anyway

### Scenario 2

```python
fabric = Fabric(plugins=BitsandbytesPrecision(), devices=1)
with fabric.init_module(empty_init=False), torch.device("meta"):
    model = LLM()
maybe_install_hooks(model)
load_checkpoint(model)  # quantize here
materialize_meta_tensors(model, fabric.device)  # quantize here
model = fabric.setup(model, move_to_device=False)
compile(model)
```

I believe this is the ideal scenario.

### Scenario 3

```python
fabric = Fabric(plugins=BitsandbytesPrecision(), devices=1)
with torch.device("meta"):
    model = LLM()
maybe_install_hooks(model)
load_checkpoint(model)
model = fabric.setup(model, move_to_device=False)  # do not quantize, just replace
materialize_meta_tensors(model, fabric.device)  # quantize here
```

Cons:
- If the checkpoint is complete, loading will OOM.
- `fabric.setup` will need to recreate layers so the model hooks are lost.
- `to_empty` and `reset_parameters` (called from `materialize_meta_tensors`) will both create empty tensors and quantize. There's no way to avoid this unless we make `materialize_meta_tensors` aware of bitsandbytes.


### Scenario 4

```python
fabric = Fabric(plugins=BitsandbytesPrecision(), devices=1)
with torch.device("meta"):
    model = LLM()
materialize_meta_tensors(model, fabric.device)
model = fabric.setup(model, move_to_device=False)  # do not quantize, just replace
maybe_install_hooks(model)
load_checkpoint(model)  # quantize here
quantize_unloaded_layers(model)  # quantize here
```

Cons:
- If the checkpoint is incomplete, an extra quantization step would be required. (unimplemented)

----

8-bit layer materialization is not implemented. I only made the minimal changes required for it.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19150.org.readthedocs.build/en/19150/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli