### PR TITLE
Add `@override` for files in `src/lightning/fabric/plugins/collectives`

### DIFF
--- a/src/lightning/fabric/plugins/collectives/single_device.py
+++ b/src/lightning/fabric/plugins/collectives/single_device.py
@@ -2,6 +2,7 @@ from typing import Any, List
 
 from torch import Tensor
 from typing_extensions import override
+
 from lightning.fabric.plugins.collectives.collective import Collective
 from lightning.fabric.utilities.types import CollectibleGroup
 
@@ -66,7 +67,7 @@ class SingleDeviceCollective(Collective):
     @override
     def send(self, *_: Any, **__: Any) -> None:
         pass
-    
+
     @override
     def recv(self, tensor: Tensor, *_: Any, **__: Any) -> Tensor:
         return tensor

--- a/src/lightning/fabric/plugins/collectives/single_device.py
+++ b/src/lightning/fabric/plugins/collectives/single_device.py
@@ -1,7 +1,7 @@
 from typing import Any, List
 
 from torch import Tensor
-
+from typing_extensions import override
 from lightning.fabric.plugins.collectives.collective import Collective
 from lightning.fabric.utilities.types import CollectibleGroup
 
@@ -14,28 +14,36 @@ class SingleDeviceCollective(Collective):
     """
 
     @property
+    @override
     def rank(self) -> int:
         return 0
 
     @property
+    @override
     def world_size(self) -> int:
         return 1
 
+    @override
     def broadcast(self, tensor: Tensor, *_: Any, **__: Any) -> Tensor:
         return tensor
 
+    @override
     def all_reduce(self, tensor: Tensor, *_: Any, **__: Any) -> Tensor:
         return tensor
 
+    @override
     def reduce(self, tensor: Tensor, *_: Any, **__: Any) -> Tensor:
         return tensor
 
+    @override
     def all_gather(self, tensor_list: List[Tensor], tensor: Tensor, **__: Any) -> List[Tensor]:
         return [tensor]
 
+    @override
     def gather(self, tensor: Tensor, *_: Any, **__: Any) -> List[Tensor]:
         return [tensor]
 
+    @override
     def scatter(
         self,
         tensor: Tensor,
@@ -45,43 +53,54 @@ class SingleDeviceCollective(Collective):
     ) -> Tensor:
         return scatter_list[0]
 
+    @override
     def reduce_scatter(self, output: Tensor, input_list: List[Tensor], *_: Any, **__: Any) -> Tensor:
         return input_list[0]
 
+    @override
     def all_to_all(
         self, output_tensor_list: List[Tensor], input_tensor_list: List[Tensor], *_: Any, **__: Any
     ) -> List[Tensor]:
         return input_tensor_list
 
+    @override
     def send(self, *_: Any, **__: Any) -> None:
         pass
-
+    
+    @override
     def recv(self, tensor: Tensor, *_: Any, **__: Any) -> Tensor:
         return tensor
 
+    @override
     def barrier(self, *_: Any, **__: Any) -> None:
         pass
 
     @classmethod
+    @override
     def is_available(cls) -> bool:
         return True  # vacuous truth
 
     @classmethod
+    @override
     def is_initialized(cls) -> bool:
         return True  # vacuous truth
 
     @classmethod
+    @override
     def init_group(cls, **_: Any) -> None:
         pass
 
     @classmethod
+    @override
     def new_group(cls, **_: Any) -> CollectibleGroup:
         return object()  # type: ignore[return-value]
 
     @classmethod
+    @override
     def destroy_group(cls, group: CollectibleGroup) -> None:
         pass
 
     @classmethod
+    @override
     def _convert_to_native_op(cls, op: str) -> str:
         return op

--- a/src/lightning/fabric/plugins/collectives/torch_collective.py
+++ b/src/lightning/fabric/plugins/collectives/torch_collective.py
@@ -89,7 +89,7 @@ class TorchCollective(Collective):
         dist.reduce_scatter(output, input_list, op=op, group=self.group)
         return output
 
-    @override    
+    @override
     def all_to_all(self, output_tensor_list: List[Tensor], input_tensor_list: List[Tensor]) -> List[Tensor]:
         dist.all_to_all(output_tensor_list, input_tensor_list, group=self.group)
         return output_tensor_list
@@ -132,7 +132,7 @@ class TorchCollective(Collective):
     def monitored_barrier(self, timeout: Optional[datetime.timedelta] = None, wait_all_ranks: bool = False) -> None:
         dist.monitored_barrier(group=self.group, timeout=timeout, wait_all_ranks=wait_all_ranks)
 
-    @override    
+    @override
     def setup(self, main_address: Optional[str] = None, main_port: Optional[str] = None, **kwargs: Any) -> Self:
         if self.is_initialized():
             return self


### PR DESCRIPTION
This PR adds the `@override` decorator for all files in `src/lightning/fabric/plugins/collectives` (https://github.com/Lightning-AI/pytorch-lightning/issues/18695).

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19156.org.readthedocs.build/en/19156/

<!-- readthedocs-preview pytorch-lightning end -->