### PR TITLE
 Add `@override` for files in `src/lightning/fabric/plugins/io`

### DIFF
--- a/src/lightning/fabric/plugins/io/torch_io.py
+++ b/src/lightning/fabric/plugins/io/torch_io.py
@@ -14,7 +14,7 @@
 import logging
 import os
 from typing import Any, Callable, Dict, Optional
-
+from typing_extensions import override
 from lightning.fabric.plugins.io.checkpoint_io import CheckpointIO
 from lightning.fabric.utilities.cloud_io import _atomic_save, get_filesystem
 from lightning.fabric.utilities.cloud_io import _load as pl_load
@@ -31,6 +31,7 @@ class TorchCheckpointIO(CheckpointIO):
 
     """
 
+    @override
     def save_checkpoint(self, checkpoint: Dict[str, Any], path: _PATH, storage_options: Optional[Any] = None) -> None:
         """Save model/training states as a checkpoint file through state-dump and file-write.
 
@@ -54,6 +55,7 @@ class TorchCheckpointIO(CheckpointIO):
         fs.makedirs(os.path.dirname(path), exist_ok=True)
         _atomic_save(checkpoint, path)
 
+    @override
     def load_checkpoint(
         self, path: _PATH, map_location: Optional[Callable] = lambda storage, loc: storage
     ) -> Dict[str, Any]:
@@ -78,6 +80,7 @@ class TorchCheckpointIO(CheckpointIO):
 
         return pl_load(path, map_location=map_location)
 
+    @override
     def remove_checkpoint(self, path: _PATH) -> None:
         """Remove checkpoint file from the filesystem.
 

--- a/src/lightning/fabric/plugins/io/torch_io.py
+++ b/src/lightning/fabric/plugins/io/torch_io.py
@@ -14,7 +14,9 @@
 import logging
 import os
 from typing import Any, Callable, Dict, Optional
+
 from typing_extensions import override
+
 from lightning.fabric.plugins.io.checkpoint_io import CheckpointIO
 from lightning.fabric.utilities.cloud_io import _atomic_save, get_filesystem
 from lightning.fabric.utilities.cloud_io import _load as pl_load

--- a/src/lightning/fabric/plugins/io/xla.py
+++ b/src/lightning/fabric/plugins/io/xla.py
@@ -14,6 +14,7 @@
 import logging
 import os
 from typing import Any, Dict, Optional
+from typing_extensions import override
 
 import torch
 from lightning_utilities.core.apply_func import apply_to_collection
@@ -39,6 +40,7 @@ class XLACheckpointIO(TorchCheckpointIO):
             raise ModuleNotFoundError(str(_XLA_AVAILABLE))
         super().__init__(*args, **kwargs)
 
+    @override
     def save_checkpoint(self, checkpoint: Dict[str, Any], path: _PATH, storage_options: Optional[Any] = None) -> None:
         """Save model/training states as a checkpoint file through state-dump and file-write.
 

--- a/src/lightning/fabric/plugins/io/xla.py
+++ b/src/lightning/fabric/plugins/io/xla.py
@@ -14,11 +14,11 @@
 import logging
 import os
 from typing import Any, Dict, Optional
-from typing_extensions import override
 
 import torch
 from lightning_utilities.core.apply_func import apply_to_collection
 from lightning_utilities.core.imports import RequirementCache
+from typing_extensions import override
 
 from lightning.fabric.accelerators.xla import _XLA_AVAILABLE
 from lightning.fabric.plugins.io.torch_io import TorchCheckpointIO


### PR DESCRIPTION
This PR adds the `@override` decorator for all files in `src/lightning/fabric/plugins/io` (https://github.com/Lightning-AI/pytorch-lightning/issues/18695).

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19157.org.readthedocs.build/en/19157/

<!-- readthedocs-preview pytorch-lightning end -->