### PR TITLE
Sort column headers for csv logger

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed the `TransformerEnginePrecision(dtype=)` argument to `weights_dtype` and made it required ([#19082](https://github.com/Lightning-AI/lightning/pull/19082))
 
 
+- The columns in the `metrics.csv` file produced by `CSVLogger` are now sorted alphabetically ([#19159](https://github.com/Lightning-AI/lightning/pull/19159))
+
+
 ### Deprecated
 
 -

--- a/src/lightning/fabric/loggers/csv_logs.py
+++ b/src/lightning/fabric/loggers/csv_logs.py
@@ -235,7 +235,6 @@ class _ExperimentWriter:
         new_keys = self._record_new_keys()
         file_exists = self._fs.isfile(self.metrics_file_path)
 
-        self.metrics_keys = sorted(self.metrics_keys)
         if new_keys and file_exists:
             # we need to re-write the file if the keys (header) change
             self._rewrite_with_new_header(self.metrics_keys)
@@ -254,6 +253,7 @@ class _ExperimentWriter:
         current_keys = set().union(*self.metrics)
         new_keys = current_keys - set(self.metrics_keys)
         self.metrics_keys.extend(new_keys)
+        self.metrics_keys.sort()
         return new_keys
 
     def _rewrite_with_new_header(self, fieldnames: List[str]) -> None:

--- a/src/lightning/fabric/loggers/csv_logs.py
+++ b/src/lightning/fabric/loggers/csv_logs.py
@@ -235,6 +235,7 @@ class _ExperimentWriter:
         new_keys = self._record_new_keys()
         file_exists = self._fs.isfile(self.metrics_file_path)
 
+        self.metrics_keys = sorted(self.metrics_keys)
         if new_keys and file_exists:
             # we need to re-write the file if the keys (header) change
             self._rewrite_with_new_header(self.metrics_keys)

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -41,6 +41,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed the `TransformerEnginePrecision(dtype=)` argument to `weights_dtype` and made it required ([#19082](https://github.com/Lightning-AI/lightning/pull/19082))
 
 
+- The columns in the `metrics.csv` file produced by `CSVLogger` are now sorted alphabetically ([#19159](https://github.com/Lightning-AI/lightning/pull/19159))
+
+
 ### Deprecated
 
 - Deprecated all precision plugin classes under `lightning.pytorch.plugins` with the suffix `Plugin` in the name ([#18840](https://github.com/Lightning-AI/lightning/pull/18840))

--- a/tests/tests_fabric/loggers/test_csv.py
+++ b/tests/tests_fabric/loggers/test_csv.py
@@ -185,17 +185,19 @@ def test_rewrite_with_new_header(tmp_path):
         assert logs == ["0", "1", "22", ""]
 
 
-@pytest.mark.parametrize("step_idx", [10, None])
-def test_log_metrics_column_order_sorted(tmp_path, step_idx):
+def test_log_metrics_column_order_sorted(tmp_path):
+    """Test that the columns in the output metrics file are sorted by name."""
     logger = CSVLogger(tmp_path)
-    metrics = {"float": 0.3, "int": 1, "FloatTensor": torch.tensor(0.1), "IntTensor": torch.tensor(1)}
-    logger.log_metrics(metrics, step_idx)
+    logger.log_metrics({"c": 0.1})
+    logger.log_metrics({"c": 0.2})
+    logger.log_metrics({"b": 0.3})
+    logger.log_metrics({"a": 0.4})
+    logger.save()
+    logger.log_metrics({"d": 0.5})
     logger.save()
 
-    path_csv = os.path.join(logger.log_dir, ExperimentWriter.NAME_METRICS_FILE)
+    path_csv = os.path.join(logger.log_dir, _ExperimentWriter.NAME_METRICS_FILE)
     with open(path_csv) as fp:
         lines = fp.readlines()
 
-    columns = list(metrics.keys()) + ["step"]
-    header = ",".join(sorted(columns))
-    assert lines[0].strip() == header
+    assert lines[0].strip() == "a,b,c,d,step"

--- a/tests/tests_fabric/loggers/test_csv.py
+++ b/tests/tests_fabric/loggers/test_csv.py
@@ -183,3 +183,19 @@ def test_rewrite_with_new_header(tmp_path):
         assert header == new_columns
         logs = file.readline().strip().split(",")
         assert logs == ["0", "1", "22", ""]
+
+
+@pytest.mark.parametrize("step_idx", [10, None])
+def test_log_metrics_column_order_sorted(tmp_path, step_idx):
+    logger = CSVLogger(tmp_path)
+    metrics = {"float": 0.3, "int": 1, "FloatTensor": torch.tensor(0.1), "IntTensor": torch.tensor(1)}
+    logger.log_metrics(metrics, step_idx)
+    logger.save()
+
+    path_csv = os.path.join(logger.log_dir, ExperimentWriter.NAME_METRICS_FILE)
+    with open(path_csv) as fp:
+        lines = fp.readlines()
+
+    columns = list(metrics.keys()) + ["step"]
+    header = ",".join(sorted(columns))
+    assert lines[0].strip() == header

--- a/tests/tests_pytorch/loggers/test_csv.py
+++ b/tests/tests_pytorch/loggers/test_csv.py
@@ -98,9 +98,9 @@ def test_log_metrics_column_order_sorted(tmp_path, step_idx):
     path_csv = os.path.join(logger.log_dir, ExperimentWriter.NAME_METRICS_FILE)
     with open(path_csv) as fp:
         lines = fp.readlines()
-    
-    columns = list(metrics.keys()) + ['step']
-    header = ','.join(sorted(columns))
+
+    columns = list(metrics.keys()) + ["step"]
+    header = ",".join(sorted(columns))
     assert lines[0].strip() == header
 
 

--- a/tests/tests_pytorch/loggers/test_csv.py
+++ b/tests/tests_pytorch/loggers/test_csv.py
@@ -88,22 +88,6 @@ def test_log_metrics(tmp_path, step_idx):
     assert all(n in lines[0] for n in metrics)
 
 
-@pytest.mark.parametrize("step_idx", [10, None])
-def test_log_metrics_column_order_sorted(tmp_path, step_idx):
-    logger = CSVLogger(tmp_path)
-    metrics = {"float": 0.3, "int": 1, "FloatTensor": torch.tensor(0.1), "IntTensor": torch.tensor(1)}
-    logger.log_metrics(metrics, step_idx)
-    logger.save()
-
-    path_csv = os.path.join(logger.log_dir, ExperimentWriter.NAME_METRICS_FILE)
-    with open(path_csv) as fp:
-        lines = fp.readlines()
-
-    columns = list(metrics.keys()) + ["step"]
-    header = ",".join(sorted(columns))
-    assert lines[0].strip() == header
-
-
 def test_log_hyperparams(tmp_path):
     logger = CSVLogger(tmp_path)
     hparams = {

--- a/tests/tests_pytorch/loggers/test_csv.py
+++ b/tests/tests_pytorch/loggers/test_csv.py
@@ -88,6 +88,22 @@ def test_log_metrics(tmp_path, step_idx):
     assert all(n in lines[0] for n in metrics)
 
 
+@pytest.mark.parametrize("step_idx", [10, None])
+def test_log_metrics_column_order_sorted(tmp_path, step_idx):
+    logger = CSVLogger(tmp_path)
+    metrics = {"float": 0.3, "int": 1, "FloatTensor": torch.tensor(0.1), "IntTensor": torch.tensor(1)}
+    logger.log_metrics(metrics, step_idx)
+    logger.save()
+
+    path_csv = os.path.join(logger.log_dir, ExperimentWriter.NAME_METRICS_FILE)
+    with open(path_csv) as fp:
+        lines = fp.readlines()
+    
+    columns = list(metrics.keys()) + ['step']
+    header = ','.join(sorted(columns))
+    assert lines[0].strip() == header
+
+
 def test_log_hyperparams(tmp_path):
     logger = CSVLogger(tmp_path)
     hparams = {


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue (#18978 ) where every time a csv log is written, the column headers are of random order. The fix is sorting the column headers. A new testcase is added to test the implementation.

**Files affected**
* `src/lightning/fabric/loggers/csv_logs.py`
* `tests/tests_pytorch/loggers/test_csv.py`

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19159.org.readthedocs.build/en/19159/

<!-- readthedocs-preview pytorch-lightning end -->