### PR TITLE
Avoid false positive standalone error

### DIFF
--- a/tests/run_standalone_tests.sh
+++ b/tests/run_standalone_tests.sh
@@ -45,7 +45,7 @@ function show_batched_output {
   if [ -f standalone_test_output.txt ]; then  # if exists
     cat standalone_test_output.txt
     # heuristic: stop if there's mentions of errors. this can prevent false negatives when only some of the ranks fail
-    if grep -iE 'error|exception|traceback|failed' standalone_test_output.txt | grep -qvE 'on_exception|xfailed'; then
+    if grep -iE 'error|exception|traceback|failed' standalone_test_output.txt | grep -qvE 'on_exception|xfailed|rm_rf) error'; then
       echo "Potential error! Stopping."
       rm standalone_test_output.txt
       exit 1


### PR DESCRIPTION
## What does this PR do?

Avoids failing on this irrelevant warning: https://github.com/pytest-dev/pytest/blob/047ba83dabe492af938104fe0058597f67a672be/src/_pytest/pathlib.py#L94-L98


cc @carmocca @borda