### PR TITLE
Ignore pytest cleanup warning

### DIFF
--- a/tests/tests_fabric/__init__.py
+++ b/tests/tests_fabric/__init__.py
@@ -1,0 +1,7 @@
+import warnings
+
+from pytest import PytestWarning
+
+
+# Ignore cleanup warnings from pytest (rarely happens due to a race condition when executing pytest in parallel)
+warnings.filterwarnings("ignore", category=PytestWarning, message=r".*\(rm_rf\) error removing.*")

--- a/tests/tests_fabric/__init__.py
+++ b/tests/tests_fabric/__init__.py
@@ -2,6 +2,5 @@ import warnings
 
 from pytest import PytestWarning
 
-
 # Ignore cleanup warnings from pytest (rarely happens due to a race condition when executing pytest in parallel)
 warnings.filterwarnings("ignore", category=PytestWarning, message=r".*\(rm_rf\) error removing.*")

--- a/tests/tests_fabric/__init__.py
+++ b/tests/tests_fabric/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 
-from pytest import PytestWarning
+import pytest
 
 # Ignore cleanup warnings from pytest (rarely happens due to a race condition when executing pytest in parallel)
-warnings.filterwarnings("ignore", category=PytestWarning, message=r".*\(rm_rf\) error removing.*")
+warnings.filterwarnings("ignore", category=pytest.PytestWarning, message=r".*\(rm_rf\) error removing.*")

--- a/tests/tests_pytorch/__init__.py
+++ b/tests/tests_pytorch/__init__.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import re
+import warnings
+
+from pytest import PytestWarning
 
 _TEST_ROOT = os.path.dirname(__file__)
 _PROJECT_ROOT = os.path.dirname(_TEST_ROOT)
@@ -27,3 +31,8 @@ if _PROJECT_ROOT not in os.getenv("PYTHONPATH", ""):
 
 if not os.path.isdir(_TEMP_PATH):
     os.mkdir(_TEMP_PATH)
+
+
+# Ignore cleanup warnings from pytest (rarely happens due to a race condition when executing pytest in parallel)
+warnings.filterwarnings("ignore", category=PytestWarning, message=r".*\(rm_rf\) error removing.*")
+

--- a/tests/tests_pytorch/__init__.py
+++ b/tests/tests_pytorch/__init__.py
@@ -14,7 +14,7 @@
 import os
 import warnings
 
-from pytest import PytestWarning
+import pytest
 
 _TEST_ROOT = os.path.dirname(__file__)
 _PROJECT_ROOT = os.path.dirname(_TEST_ROOT)
@@ -33,4 +33,4 @@ if not os.path.isdir(_TEMP_PATH):
 
 
 # Ignore cleanup warnings from pytest (rarely happens due to a race condition when executing pytest in parallel)
-warnings.filterwarnings("ignore", category=PytestWarning, message=r".*\(rm_rf\) error removing.*")
+warnings.filterwarnings("ignore", category=pytest.PytestWarning, message=r".*\(rm_rf\) error removing.*")

--- a/tests/tests_pytorch/__init__.py
+++ b/tests/tests_pytorch/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import re
 import warnings
 
 from pytest import PytestWarning

--- a/tests/tests_pytorch/__init__.py
+++ b/tests/tests_pytorch/__init__.py
@@ -34,4 +34,3 @@ if not os.path.isdir(_TEMP_PATH):
 
 # Ignore cleanup warnings from pytest (rarely happens due to a race condition when executing pytest in parallel)
 warnings.filterwarnings("ignore", category=PytestWarning, message=r".*\(rm_rf\) error removing.*")
-


### PR DESCRIPTION
## What does this PR do?

In rare cases we get a warning when pytest clean up runs:

```
/usr/local/lib/python3.10/dist-packages/_pytest/pathlib.py:95: PytestWarning: (rm_rf) error removing /tmp/pytest-of-root/garbage-90e3cf71-e5cd-4cbc-91cd-c1104ffb908a
<class 'OSError'>: [Errno 39] Directory not empty: '/tmp/pytest-of-root/garbage-90e3cf71-e5cd-4cbc-91cd-c1104ffb908a'
  warnings.warn(

```

It makes our standalone tests fail because it has OSError in the warning text. But this is a false positive because we don't care about this clean up. 


Seen here first: [https://dev.azure.com/Lightning-AI/lightning/_build/results?buildId=185497&view=log[…]a11-bf5c7745762e&t=bf6093c4-3a5a-5124-a53f-3193bc8a9990&l=5401](https://dev.azure.com/Lightning-AI/lightning/_build/results?buildId=185497&view=logs&j=47e66f3c-897a-5428-da11-bf5c7745762e&t=bf6093c4-3a5a-5124-a53f-3193bc8a9990&l=5401)
Reported by @carmocca 


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19164.org.readthedocs.build/en/19164/

<!-- readthedocs-preview pytorch-lightning end -->

cc @carmocca @justusschock @awaelchli @borda