### PR TITLE
Make saving 'last' checkpoint as symbolic link opt-in

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `TransformerEnginePrecision(fallback_compute_dtype=)` to control the dtype of operations that don't support fp8 ([#19082](https://github.com/Lightning-AI/lightning/pull/19082))
 
 
+- Added the option `ModelCheckpoint(save_last='link')` to create a symbolic link for the 'last.ckpt' file ([#19191](https://github.com/Lightning-AI/lightning/pull/19191))
+
+
 ### Changed
 
 - `seed_everything()` without passing in a seed no longer randomly selects a seed, and now defaults to `0` ([#18846](https://github.com/Lightning-AI/lightning/pull/18846))
@@ -45,6 +48,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - The columns in the `metrics.csv` file produced by `CSVLogger` are now sorted alphabetically ([#19159](https://github.com/Lightning-AI/lightning/pull/19159))
+
+
+- Reverted back to creating a checkpoint copy when `ModelCheckpoint(save_last=True)` instead of creating a symbolic link ([#19191](https://github.com/Lightning-AI/lightning/pull/19191))
 
 
 ### Deprecated

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -26,7 +26,7 @@ import warnings
 from copy import deepcopy
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Dict, Optional, Set, Literal
+from typing import Any, Dict, Literal, Optional, Set
 from weakref import proxy
 
 import torch

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -517,6 +517,12 @@ def test_model_checkpoint_save_last(save_last, tmpdir, monkeypatch):
     assert os.path.realpath(tmpdir / last_filename) == model_checkpoint._last_checkpoint_saved
 
 
+def test_model_checkpoint_save_last_as_link_not_local(tmp_path):
+    callback = ModelCheckpoint(dirpath="memory://not-a-filesystem-path", save_last="link")
+    with pytest.raises(ValueError, match="save_last='link'.* is only supported for local file paths"):
+        callback.setup(trainer=Trainer(), pl_module=BoringModel(), stage="fit")
+
+
 def test_model_checkpoint_link_checkpoint(tmp_path):
     """Test that linking a checkpoint works and overwrites an existing link if present."""
     trainer = Mock()

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -485,13 +485,14 @@ def test_model_checkpoint_file_extension(tmpdir):
     assert set(expected) == set(os.listdir(tmpdir))
 
 
-def test_model_checkpoint_save_last(tmpdir, monkeypatch):
+@pytest.mark.parametrize("save_last", [True, "link"])
+def test_model_checkpoint_save_last(save_last, tmpdir, monkeypatch):
     """Tests that save_last produces only one last checkpoint."""
     seed_everything()
     model = LogInTwoMethods()
     epochs = 3
     monkeypatch.setattr(ModelCheckpoint, "CHECKPOINT_NAME_LAST", "last-{epoch}")
-    model_checkpoint = ModelCheckpoint(monitor="early_stop_on", dirpath=tmpdir, save_top_k=-1, save_last=True)
+    model_checkpoint = ModelCheckpoint(monitor="early_stop_on", dirpath=tmpdir, save_top_k=-1, save_last=save_last)
     trainer = Trainer(
         default_root_dir=tmpdir,
         callbacks=[model_checkpoint],
@@ -509,7 +510,10 @@ def test_model_checkpoint_save_last(tmpdir, monkeypatch):
     assert set(os.listdir(tmpdir)) == set(
         [f"epoch={i}-step={j}.ckpt" for i, j in zip(range(epochs), [10, 20, 30])] + [last_filename]
     )
-    assert os.path.islink(tmpdir / last_filename)
+    if save_last == "link":
+        assert os.path.islink(tmpdir / last_filename)
+    else:
+        assert os.path.isfile(tmpdir / last_filename)
     assert os.path.realpath(tmpdir / last_filename) == model_checkpoint._last_checkpoint_saved
 
 
@@ -676,7 +680,7 @@ def test_model_checkpoint_save_last_none_monitor(tmpdir, caplog):
     expected = [f"epoch={i}-step={j}.ckpt" for i, j in zip(range(epochs), [10, 20])]
     expected.append("last.ckpt")
     assert set(os.listdir(tmpdir)) == set(expected)
-    assert os.path.islink(tmpdir / "last.ckpt")
+    assert os.path.isfile(tmpdir / "last.ckpt")
 
 
 @pytest.mark.parametrize("every_n_epochs", list(range(4)))
@@ -887,7 +891,7 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
     path_last = str(tmpdir / "last.ckpt")
     assert path_last == model_checkpoint.last_model_path
     assert os.path.isfile(path_last_epoch)
-    assert os.path.islink(path_last)
+    assert os.path.isfile(path_last)
 
     ckpt_last_epoch = torch.load(path_last_epoch)
     ckpt_last = torch.load(path_last)


### PR DESCRIPTION
## What does this PR do?

Several complaints from users have made it clear that the feature to save the 'last.ckpt' file as symbolic link is not wanted. In this PR, I'm reverting the decision to make a symbolic link by default, and make the feature opt-in instead.

This is a breaking change, tell me more about it!

Fixes #19189
Fixes #19189
Fixes #19107

This partially reverts #18748


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19191.org.readthedocs.build/en/19191/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @justusschock @carmocca @awaelchli