### PR TITLE
Streaming Dataset: Resolve chunks eviction

### DIFF
--- a/src/lightning/data/streaming/reader.py
+++ b/src/lightning/data/streaming/reader.py
@@ -89,7 +89,6 @@ class PrepareChunksThread(Thread):
         self._to_download_queue.put(_END_TOKEN)
 
     def _maybe_delete_chunks(self) -> None:
-        print(self._pre_download_counter, self._max_pre_download)
         reached_pre_download = self._pre_download_counter == self._max_pre_download
 
         # we have already pre-downloaded some chunks, we just need to wait for them to be processed.
@@ -106,14 +105,12 @@ class PrepareChunksThread(Thread):
         # Get the current cache size and decide whether we need to start cleanup. Otherwise, keep track of it
         while self._max_cache_size and self._chunks_index_to_be_deleted and self._can_delete_chunk():
             # Delete the oldest chunk
-            print("DELETE")
             self._delete(self._chunks_index_to_be_deleted.pop(0))
 
         return
 
     def _can_delete_chunk(self) -> bool:
         if self._delete_chunks_when_processed:
-            print(self._pre_download_counter, self._max_pre_download - 1)
             return self._pre_download_counter >= self._max_pre_download - 1
         return self._max_cache_size is not None and _get_folder_size(self._parent_cache_dir) >= self._max_cache_size
 

--- a/src/lightning/data/streaming/reader.py
+++ b/src/lightning/data/streaming/reader.py
@@ -89,6 +89,7 @@ class PrepareChunksThread(Thread):
         self._to_download_queue.put(_END_TOKEN)
 
     def _maybe_delete_chunks(self) -> None:
+        print(self._pre_download_counter, self._max_pre_download)
         reached_pre_download = self._pre_download_counter == self._max_pre_download
 
         # we have already pre-downloaded some chunks, we just need to wait for them to be processed.
@@ -105,13 +106,15 @@ class PrepareChunksThread(Thread):
         # Get the current cache size and decide whether we need to start cleanup. Otherwise, keep track of it
         while self._max_cache_size and self._chunks_index_to_be_deleted and self._can_delete_chunk():
             # Delete the oldest chunk
+            print("DELETE")
             self._delete(self._chunks_index_to_be_deleted.pop(0))
 
         return
 
     def _can_delete_chunk(self) -> bool:
         if self._delete_chunks_when_processed:
-            return self._pre_download_counter == self._max_pre_download - 1
+            print(self._pre_download_counter, self._max_pre_download - 1)
+            return self._pre_download_counter >= self._max_pre_download - 1
         return self._max_cache_size is not None and _get_folder_size(self._parent_cache_dir) >= self._max_cache_size
 
     def _pre_load_chunk(self, chunk_index: int) -> None:
@@ -120,7 +123,7 @@ class PrepareChunksThread(Thread):
 
     def run(self) -> None:
         while True:
-            if self._pre_download_counter <= self._max_pre_download:
+            if self._pre_download_counter < self._max_pre_download:
                 chunk_index = _get_from_queue(self._to_download_queue)
                 if chunk_index == _END_TOKEN:
                     return

--- a/src/lightning/data/streaming/reader.py
+++ b/src/lightning/data/streaming/reader.py
@@ -68,6 +68,7 @@ class PrepareChunksThread(Thread):
 
         # FIXME: This should be divided by the number of nodes to provide a more granular support with scaling out
         self._delete_chunks_when_processed = self._config.num_bytes > max_cache_size if max_cache_size else False
+        self._has_exited = False
 
     def download(self, chunk_indexes: List[int]) -> None:
         """Receive the list of the chunk indices to download for the current epoch."""
@@ -123,6 +124,7 @@ class PrepareChunksThread(Thread):
             if self._pre_download_counter < self._max_pre_download:
                 chunk_index = _get_from_queue(self._to_download_queue)
                 if chunk_index == _END_TOKEN:
+                    self._has_exited = True
                     return
 
                 if chunk_index is not None:

--- a/tests/tests_data/streaming/test_reader.py
+++ b/tests/tests_data/streaming/test_reader.py
@@ -38,39 +38,10 @@ def test_reader_chunk_removal(tmpdir):
     shutil.rmtree(cache_dir)
     os.makedirs(cache_dir, exist_ok=True)
 
-    generated = []
     for i in range(25):
-        generated.append([i, len(os.listdir(cache_dir))])
+        assert len(os.listdir(cache_dir)) <= 3
         index = ChunkedIndex(i, cache._get_chunk_index_from_index(i), is_last_index=i == 24)
         assert cache[index] == i
-
-    assert generated == [
-        [0, 0],
-        [1, 2],
-        [2, 2],
-        [3, 3],
-        [4, 3],
-        [5, 3],
-        [6, 3],
-        [7, 3],
-        [8, 3],
-        [9, 3],
-        [10, 3],
-        [11, 3],
-        [12, 3],
-        [13, 3],
-        [14, 3],
-        [15, 3],
-        [16, 3],
-        [17, 3],
-        [18, 3],
-        [19, 3],
-        [20, 3],
-        [21, 3],
-        [22, 3],
-        [23, 3],
-        [24, 3],
-    ]
 
     assert len(os.listdir(cache_dir)) == 3
 

--- a/tests/tests_data/streaming/test_reader.py
+++ b/tests/tests_data/streaming/test_reader.py
@@ -116,6 +116,7 @@ def test_prepare_chunks_thread_eviction(tmpdir, monkeypatch):
     sleep(0.25)
 
     assert thread._pre_download_counter == 2
+    assert not thread._has_exited
 
     for i in range(5):
         assert thread._pre_download_counter <= 2
@@ -127,4 +128,5 @@ def test_prepare_chunks_thread_eviction(tmpdir, monkeypatch):
     assert thread._pre_download_counter <= 2
 
     assert len(os.listdir(cache_dir)) == 9
+    assert thread._has_exited
     thread.join()

--- a/tests/tests_data/streaming/test_reader.py
+++ b/tests/tests_data/streaming/test_reader.py
@@ -84,17 +84,15 @@ def test_prepare_chunks_thread_eviction(tmpdir, monkeypatch):
 
     thread.download([0, 1, 2, 3, 4, 5, _END_TOKEN])
 
-    sleep(0.25)
+    while thread._pre_download_counter == 0:
+        sleep(0.01)
 
-    assert thread._pre_download_counter == 2
     assert not thread._has_exited
 
     for i in range(5):
-        assert thread._pre_download_counter <= 2
         thread.delete([i])
-        sleep(0.25)
-        assert len(os.listdir(cache_dir)) == 14 - (i + 1)
-        assert thread._pre_download_counter <= 2
+        while len(os.listdir(cache_dir)) != 14 - (i + 1):
+            sleep(0.01)
 
     assert thread._pre_download_counter <= 2
 

--- a/tests/tests_data/streaming/test_reader.py
+++ b/tests/tests_data/streaming/test_reader.py
@@ -3,6 +3,7 @@ import shutil
 from time import sleep
 
 import numpy as np
+from lightning.data.streaming import reader
 from lightning.data.streaming.cache import Cache
 from lightning.data.streaming.config import ChunkedIndex
 from lightning.data.streaming.item_loader import PyTreeLoader
@@ -83,7 +84,9 @@ def test_get_folder_size(tmpdir):
     assert _get_folder_size(tmpdir) == 928 * 2
 
 
-def test_prepare_chunks_thread_eviction(tmpdir):
+def test_prepare_chunks_thread_eviction(tmpdir, monkeypatch):
+    monkeypatch.setattr(reader, "_LONG_DEFAULT_TIMEOUT", 0.1)
+
     cache_dir = os.path.join(tmpdir, "cache_dir")
     os.makedirs(cache_dir, exist_ok=True)
     cache = Cache(input_dir=cache_dir, chunk_size=2, max_cache_size=28020)
@@ -124,5 +127,4 @@ def test_prepare_chunks_thread_eviction(tmpdir):
     assert thread._pre_download_counter <= 2
 
     assert len(os.listdir(cache_dir)) == 9
-    assert thread._has_exited
     thread.join()


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

This PR fixes a regression with the StreamingDataset where the chunks won't be deleted as we continue training.

The core reason was:

This would lead to download `max_pre_download + 1` chunks

```python
            if self._pre_download_counter <= self._max_pre_download:
                chunk_index = _get_from_queue(self._to_download_queue)
                if chunk_index == _END_TOKEN:
                    return
```

and the condition to delete was too strict, causing it to be false always.

```python
    def _can_delete_chunk(self) -> bool:
        if self._delete_chunks_when_processed:
            return self._pre_download_counter == self._max_pre_download - 1
```

This PR loosen the condition for deletion but also prevents downloading the extra chunk.

Using the lightning.ai platform with this script and this PR:

```python
import os
from torch.utils.data import DataLoader
from lightning_cloud.utils import add_s3_connection
from lightning.data import StreamingDataset
from lightning.data.streaming.item_loader import TokensLoader
from lit_gpt.packed_dataset import CombinedDataset
from tqdm import tqdm

# Add an external S3 bucket containing some data (StarCoder)
add_s3_connection("tinyllama-template")

# Increase by one because we need the next word as well
effective_block_size = 2048 + 1

input_dir = "/teamspace/s3_connections/tinyllama-template"
train_datasets = [
    StreamingDataset(
        input_dir=f"{input_dir}/slimpajama/train",
        item_loader=TokensLoader(block_size=effective_block_size),
        shuffle=True,
        drop_last=True,
    ),
    StreamingDataset(
        input_dir=f"{input_dir}/starcoder/",
        item_loader=TokensLoader(block_size=effective_block_size),
        shuffle=True,
        drop_last=True,
    ),
]

# Mix SlimPajama data and Starcoder data with these proportions:
weights = (0.693584, 0.306416)
combined_dataset = CombinedDataset(datasets=train_datasets, seed=42, weights=weights)
train_dataloader = DataLoader(combined_dataset, batch_size=8, pin_memory=True, num_workers=os.cpu_count())

# Iterate over the train datasets
for batch in tqdm(train_dataloader):
    pass
```

The disk size remains constant.

<img width="2056" alt="Screenshot 2023-12-27 at 09 36 29" src="https://github.com/Lightning-AI/pytorch-lightning/assets/12861981/5d1354ea-19b8-4bc5-a071-a3b533c521fa">

Also, this test would fail on master due to the extra chunk:

```python
        thread.download([0, 1, 2, 3, 4, 5, _END_TOKEN])
    
        sleep(0.25)
    
>       assert thread._pre_download_counter == 2
E       assert 3 == 2
E        +  where 3 = <PrepareChunksThread(Thread-2, started daemon 6292156416)>._pre_download_counter

tests/tests_data/streaming/test_reader.py:118: AssertionError
``` 

Fixes #\<issue_number>

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19214.org.readthedocs.build/en/19214/

<!-- readthedocs-preview pytorch-lightning end -->