### PR TITLE
Fix warning for Dataloader if num_workers = cpu count = 1

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -68,6 +68,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Trainer` not expanding the `default_root_dir` if it has the `~` (home) prefix ([#19179](https://github.com/Lightning-AI/lightning/pull/19179))
 
 
+- Fixed warning for Dataloader if `num_workers=1` and CPU count is 1 ([#19224](https://github.com/Lightning-AI/lightning/pull/19224))
+
+
 ## [2.1.3] - 2023-12-21
 
 ### Changed

--- a/src/lightning/pytorch/trainer/connectors/data_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/data_connector.py
@@ -436,7 +436,7 @@ def _worker_check(trainer: "pl.Trainer", dataloader: object, name: str) -> None:
         rank_zero_warn(
             f"Consider setting `persistent_workers=True` in '{name}' to speed up the dataloader worker initialization."
         )
-    elif dataloader.num_workers < 2:
+    elif dataloader.num_workers < 2 and upper_bound > 1:
         # if changed, update the `filterwarnings` snippet in 'advanced/warnings.rst'
         rank_zero_warn(
             f"The '{name}' does not have many workers which may be a bottleneck. Consider increasing the value of the"

--- a/tests/tests_pytorch/trainer/connectors/test_data_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_data_connector.py
@@ -139,16 +139,25 @@ def test_dataloader_persistent_workers_performance_warning(num_workers, tmp_path
     trainer.fit(model, dataloader)
 
 
-@pytest.mark.parametrize(("num_workers", "expected_warning"), [(0, True), (1, True), (2, False), (3, False)])
+@pytest.mark.parametrize(("num_workers", "cpu_count", "expected_warning"), [
+    (0, 1, False),
+    (1, 1, False),
+    (2, 1, False),
+    (3, 1, False),
+    (0, 8, True),
+    (1, 8, True),
+    (2, 8, False),
+    (3, 8, False),
+])
 @mock.patch("lightning.fabric.utilities.data.os.cpu_count")
 @mock.patch("lightning.pytorch.trainer.connectors.data_connector.mp.get_start_method", return_value="not_spawn")
-def test_worker_check(_, cpu_count_mock, num_workers, expected_warning, monkeypatch):
+def test_worker_check(_, cpu_count_mock, num_workers, cpu_count, expected_warning, monkeypatch):
     monkeypatch.delattr(lightning.fabric.utilities.data.os, "sched_getaffinity", raising=False)
     trainer = Mock(spec=Trainer)
     dataloader = Mock(spec=DataLoader, persistent_workers=False)
     trainer.num_devices = 2
     dataloader.num_workers = num_workers
-    cpu_count_mock.return_value = 8
+    cpu_count_mock.return_value = cpu_count
 
     if expected_warning:
         ctx = pytest.warns(UserWarning, match="Consider increasing the value of the `num_workers` argument`")

--- a/tests/tests_pytorch/trainer/connectors/test_data_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_data_connector.py
@@ -139,16 +139,19 @@ def test_dataloader_persistent_workers_performance_warning(num_workers, tmp_path
     trainer.fit(model, dataloader)
 
 
-@pytest.mark.parametrize(("num_workers", "cpu_count", "expected_warning"), [
-    (0, 1, False),
-    (1, 1, False),
-    (2, 1, False),
-    (3, 1, False),
-    (0, 8, True),
-    (1, 8, True),
-    (2, 8, False),
-    (3, 8, False),
-])
+@pytest.mark.parametrize(
+    ("num_workers", "cpu_count", "expected_warning"),
+    [
+        (0, 1, False),
+        (1, 1, False),
+        (2, 1, False),
+        (3, 1, False),
+        (0, 8, True),
+        (1, 8, True),
+        (2, 8, False),
+        (3, 8, False),
+    ],
+)
 @mock.patch("lightning.fabric.utilities.data.os.cpu_count")
 @mock.patch("lightning.pytorch.trainer.connectors.data_connector.mp.get_start_method", return_value="not_spawn")
 def test_worker_check(_, cpu_count_mock, num_workers, cpu_count, expected_warning, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

This PR checks if the `num_workers` of dataloader should be more than the assigned.
Previously even if the available `num_worker` was 1 and the value in the dataloader was given 1, there was a warning stating to give `num_worker=1`, which is wrong.
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #19223 

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs) - Yes
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary) - Not Necessary
- Did you write any **new necessary tests**? (not for typos and docs) - No
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request? - Yes
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors) - No

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19224.org.readthedocs.build/en/19224/

<!-- readthedocs-preview pytorch-lightning end -->