### PR TITLE
Fix docs build

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,7 @@
 sphinx >5.0, <6.0
 myst-parser >=0.18.1, <3.0.0
 nbsphinx >=0.8.5, <=0.9.2
+nbconvert <7.14
 pandoc >=1.0, <=2.3
 docutils >=0.16, <0.21
 sphinxcontrib-fulltoc >=1.0, <=1.2.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 sphinx >5.0, <6.0
 myst-parser >=0.18.1, <3.0.0
 nbsphinx >=0.8.5, <=0.9.2
-nbconvert <7.14
+nbconvert <7.14  # temporary fix for https://github.com/jupyter/nbconvert/issues/2092
 pandoc >=1.0, <=2.3
 docutils >=0.16, <0.21
 sphinxcontrib-fulltoc >=1.0, <=1.2.0


### PR DESCRIPTION
## What does this PR do?

The docs build has been blocking PRs with this error:
```
/home/runner/work/pytorch-lightning/pytorch-lightning/docs/source-pytorch/notebooks/course_UvA-DL/07-deep-energy-based-generative-models.ipynb:871: ERROR: Content block expected for the "raw" directive; none found.

```

See https://github.com/jupyter/nbconvert/issues/2092


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19241.org.readthedocs.build/en/19241/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @tchaton