### PR TITLE
Fix XLA test for syncing module states

### DIFF
--- a/tests/tests_fabric/strategies/test_xla.py
+++ b/tests/tests_fabric/strategies/test_xla.py
@@ -22,6 +22,7 @@ from lightning.fabric.accelerators.xla import _XLA_GREATER_EQUAL_2_1, XLAAcceler
 from lightning.fabric.strategies import XLAStrategy
 from lightning.fabric.strategies.launchers.xla import _XLALauncher
 from lightning.fabric.utilities.distributed import ReduceOp
+from lightning.fabric.utilities.seed import seed_everything
 from torch.utils.data import DataLoader
 
 from tests_fabric.helpers.models import RandomDataset
@@ -160,6 +161,7 @@ def test_tpu_all_gather():
 
 
 def tpu_sync_module_states_fn(sync_module_states, strategy):
+    seed_everything(strategy.local_rank)  # force the model to have different weights across ranks
     model = torch.nn.Linear(1, 1).to(strategy.root_device)
     model = strategy.setup_module(model)
     gathered = strategy.all_gather(model.weight)


### PR DESCRIPTION
## What does this PR do?

The following test is failing:
https://github.com/Lightning-AI/pytorch-lightning/actions/runs/7478929254/job/20354981655?pr=19181
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/concurrent/futures/process.py", line 239, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/usr/lib/python3.8/concurrent/futures/process.py", line 198, in _process_chunk
    return [fn(*args) for args in chunk]
  File "/usr/lib/python3.8/concurrent/futures/process.py", line 198, in <listcomp>
    return [fn(*args) for args in chunk]
  File "/usr/local/lib/python3.8/dist-packages/torch_xla/experimental/pjrt.py", line 92, in wrapper
    return fn(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/torch_xla/experimental/pjrt.py", line 245, in _run_thread_per_device
    replica_results = list(
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 619, in result_iterator
    yield fs.pop().result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 444, in result
    return self.__get_result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.8/dist-packages/torch_xla/experimental/pjrt.py", line 238, in _thread_fn
    return fn()
  File "/usr/local/lib/python3.8/dist-packages/torch_xla/experimental/pjrt.py", line 341, in __call__
    self.fn(global_ordinal(), *self.args, **self.kwargs)
  File "/home/runner/.local/lib/python3.8/site-packages/lightning/fabric/strategies/launchers/xla.py", line 111, in _wrapping_function
    results = function(*args, **kwargs)
  File "/home/runner/tests/tests_fabric/strategies/test_xla.py", line 35, in wrap_launch_function
    return fn(*args, **kwargs)
  File "/home/runner/tests/tests_fabric/strategies/test_xla.py", line 170, in tpu_sync_module_states_fn
    assert not torch.equal(gathered[0], t)
AssertionError: assert not True
 +  where True = <built-in method equal of type object at 0x7fd121599500>(tensor([-0.4014], device='xla:0', grad_fn=<SelectBackward0>), tensor([-0.4014], device='xla:0', grad_fn=<UnbindBackward0>))
 +    where <built-in method equal of type object at 0x7fd121599500> = torch.equal
 ```

cc @borda