### PR TITLE
Fix: automatically upload config file when using WandbLogger with PTL CLI

### DIFF
--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -14,6 +14,7 @@
 import os
 import sys
 import json
+from pathlib import Path
 from functools import partial, update_wrapper
 from types import MethodType
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
@@ -299,6 +300,19 @@ class SaveConfigCallback(Callback):
             config = self.parser.dump(self.config, skip_none=True, format="json")
             config_dict = json.loads(config)
             trainer.logger.experiment.config.update(config_dict)
+
+            config_path = os.path.join(
+                    trainer.logger.experiment.dir, "lightning_" + self.config_filename
+                )  # Save config locally under wandb_dir_name/wandb/exp_name/files/ 
+
+            Path(config_path).parent.mkdir(parents=True, exist_ok=True)
+            self.parser.save(
+                self.config,
+                config_path,
+                skip_none=False,
+                overwrite=self.overwrite,
+                multifile=self.multifile,
+            )
 
 
 class LightningCLI:

--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import sys
+import json
 from functools import partial, update_wrapper
 from types import MethodType
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
@@ -30,6 +31,7 @@ from lightning.pytorch import Callback, LightningDataModule, LightningModule, Tr
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from lightning.pytorch.utilities.model_helpers import is_overridden
 from lightning.pytorch.utilities.rank_zero import rank_zero_warn
+from lightning.pytorch.loggers.wandb import WandbLogger
 
 _JSONARGPARSE_SIGNATURES_AVAILABLE = RequirementCache("jsonargparse[signatures]>=4.26.1")
 
@@ -293,6 +295,10 @@ class SaveConfigCallback(Callback):
             instead.
 
         """
+        if isinstance(trainer.logger, WandbLogger):
+            config = self.parser.dump(self.config, skip_none=True, format="json")
+            config_dict = json.loads(config)
+            trainer.logger.experiment.config.update(config_dict)
 
 
 class LightningCLI:


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

While using the CLI, the config file is logged to W&B partially ([run page](https://wandb.ai/ayush-thakur/JIRA_WB_16212_PTL_CONFIGS/runs/38p4xw76/overview)). Ideally, it should log the entirety of the config for better reproducibility and comparison of experiments. This PR fixes this issue by modifying the `SaveConfigCallback` to execute some logic only when `WandbLogger` is used ([run page](https://wandb.ai/ayush-thakur/JIRA_WB_16212_PTL_CONFIGS/runs/hjgzmc1o/overview?nw=nwuserayut)).

To further support user convenience, the change saves the config passed to the CLI to the correct `wandb/exp_name` dir. 

Fixes #\<issue_number>

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
