### PR TITLE
Fix typo in kwarg in SpikeDetection

### DIFF
--- a/src/lightning/fabric/utilities/spike.py
+++ b/src/lightning/fabric/utilities/spike.py
@@ -166,7 +166,7 @@ class SpikeDetection:
         self.warmup = state_dict.pop("warmup")
         self.atol = state_dict.pop("atol")
         self.rtol = state_dict.pop("rtol")
-        self.bad_batches = state_dict.pop("bad_bachtes")
+        self.bad_batches = state_dict.pop("bad_batches")
         self.exclude_batches_path = state_dict.pop("bad_batches_path")
         self.running.load_state_dict(state_dict.pop("running"))
         self.running_mean.base_metric.load_state_dict(state_dict.pop("mean"))


### PR DESCRIPTION
## Correct typo: `bad_bachtes` -> `bad_batches` in `kwargs`

Simple fix to resolve kwarg variable name.

### Breaking Changes
* If anyone is relying on the typo, we might want to fall back on `.pop("bad_batches") or .pop("bad_bachtes")` but I'll you decide.

I didn't see any uses of the misspelled kwarg in other Lightning-AI repos.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19282.org.readthedocs.build/en/19282/

<!-- readthedocs-preview pytorch-lightning end -->