### PR TITLE
Assert job id when requeuing SLURM job

### DIFF
--- a/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
@@ -120,6 +120,18 @@ def test_auto_requeue_array_job(call_mock):
     call_mock.assert_called_once_with(["scontrol", "requeue", "12345_2"])
 
 
+@RunIf(skip_windows=True)
+@mock.patch("lightning.pytorch.trainer.connectors.signal_connector.call")
+@mock.patch("lightning.pytorch.trainer.Trainer.save_checkpoint", mock.MagicMock())
+@mock.patch.dict(os.environ, {"SLURM_JOB_ID": "invalid"})
+def test_auto_requeue_invalid_job_id(call_mock):
+    call_mock.return_value = 0
+    trainer = Trainer(plugins=[SLURMEnvironment()])
+    connector = _SignalConnector(trainer)
+    with pytest.raises(AssertionError):
+        connector._slurm_sigusr_handler_fn(None, None)
+
+
 def _registering_signals():
     trainer = Trainer()
     trainer._signal_connector.register_signal_handlers()


### PR DESCRIPTION
## What does this PR do?

Assert that the job id matches a numerical value or array index before executing resubmission command. This is an assertion since the job id should already be valid for the initial submission of the script, and it would not change during execution of the script.
