### PR TITLE
Add `@override` for files in `src/lightning/fabric/utilities`

### DIFF
--- a/src/lightning/fabric/utilities/device_dtype_mixin.py
+++ b/src/lightning/fabric/utilities/device_dtype_mixin.py
@@ -16,7 +16,7 @@ from typing import Any, List, Optional, Union
 
 import torch
 from torch.nn import Module
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 
 class _DeviceDtypeModuleMixin(Module):
@@ -46,6 +46,7 @@ class _DeviceDtypeModuleMixin(Module):
 
         return device
 
+    @override
     def to(self, *args: Any, **kwargs: Any) -> Self:
         """See :meth:`torch.nn.Module.to`."""
         # this converts `str` device to `torch.device`
@@ -53,6 +54,7 @@ class _DeviceDtypeModuleMixin(Module):
         _update_properties(self, device=device, dtype=dtype)
         return super().to(*args, **kwargs)
 
+    @override
     def cuda(self, device: Optional[Union[torch.device, int]] = None) -> Self:
         """Moves all model parameters and buffers to the GPU. This also makes associated parameters and buffers
         different objects. So it should be called before constructing optimizer if the module will live on GPU while
@@ -73,26 +75,31 @@ class _DeviceDtypeModuleMixin(Module):
         _update_properties(self, device=device)
         return super().cuda(device=device)
 
+    @override
     def cpu(self) -> Self:
         """See :meth:`torch.nn.Module.cpu`."""
         _update_properties(self, device=torch.device("cpu"))
         return super().cpu()
 
+    @override
     def type(self, dst_type: Union[str, torch.dtype]) -> Self:
         """See :meth:`torch.nn.Module.type`."""
         _update_properties(self, dtype=dst_type)
         return super().type(dst_type=dst_type)
 
+    @override
     def float(self) -> Self:
         """See :meth:`torch.nn.Module.float`."""
         _update_properties(self, dtype=torch.float)
         return super().float()
 
+    @override
     def double(self) -> Self:
         """See :meth:`torch.nn.Module.double`."""
         _update_properties(self, dtype=torch.double)
         return super().double()
 
+    @override
     def half(self) -> Self:
         """See :meth:`torch.nn.Module.half`."""
         _update_properties(self, dtype=torch.half)

--- a/src/lightning/fabric/utilities/distributed.py
+++ b/src/lightning/fabric/utilities/distributed.py
@@ -12,6 +12,7 @@ from lightning_utilities.core.imports import package_available
 from torch import Tensor
 from torch.utils.data import Dataset, DistributedSampler, Sampler
 from typing_extensions import override
+
 from lightning.fabric.utilities.cloud_io import _is_local_file_protocol
 from lightning.fabric.utilities.data import _num_cpus_available
 from lightning.fabric.utilities.rank_zero import rank_zero_info

--- a/src/lightning/fabric/utilities/distributed.py
+++ b/src/lightning/fabric/utilities/distributed.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 from lightning_utilities.core.imports import package_available
 from torch import Tensor
 from torch.utils.data import Dataset, DistributedSampler, Sampler
-
+from typing_extensions import override
 from lightning.fabric.utilities.cloud_io import _is_local_file_protocol
 from lightning.fabric.utilities.data import _num_cpus_available
 from lightning.fabric.utilities.rank_zero import rank_zero_info
@@ -328,6 +328,7 @@ class _DatasetSamplerWrapper(Dataset):
         # defer materializing an iterator until it is necessary
         self._sampler_list: Optional[List[Any]] = None
 
+    @override
     def __getitem__(self, index: int) -> Any:
         if self._sampler_list is None:
             self._sampler_list = list(self._sampler)
@@ -357,6 +358,7 @@ class DistributedSamplerWrapper(DistributedSampler):
     def __init__(self, sampler: Union[Sampler, Iterable], *args: Any, **kwargs: Any) -> None:
         super().__init__(_DatasetSamplerWrapper(sampler), *args, **kwargs)
 
+    @override
     def __iter__(self) -> Iterator:
         self.dataset.reset()
         return (self.dataset[index] for index in super().__iter__())

--- a/src/lightning/fabric/utilities/init.py
+++ b/src/lightning/fabric/utilities/init.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import itertools
 from typing import Any, Callable, Dict, Optional, Sequence
-
+from typing_extensions import override
 import torch
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_13, _TORCH_GREATER_EQUAL_2_1
@@ -43,6 +43,7 @@ class _EmptyInit(TorchFunctionMode):
         super().__init__()
         self.enabled = enabled
 
+    @override
     def __torch_function__(
         self,
         func: Callable,

--- a/src/lightning/fabric/utilities/init.py
+++ b/src/lightning/fabric/utilities/init.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 import itertools
 from typing import Any, Callable, Dict, Optional, Sequence
-from typing_extensions import override
+
 import torch
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_13, _TORCH_GREATER_EQUAL_2_1
 from lightning.fabric.utilities.types import _DEVICE

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -16,7 +16,7 @@ import warnings
 from functools import partial
 from io import BytesIO
 from typing import IO, TYPE_CHECKING, Any, Callable, Dict, Optional, OrderedDict, Sequence, Set, Union
-
+from typing_extensions import override
 import torch
 from lightning_utilities.core.apply_func import apply_to_collection
 from torch import Tensor
@@ -170,6 +170,7 @@ class _LazyLoadingUnpickler(pickle.Unpickler):
         super().__init__(file)
         self.file_reader = file_reader
 
+    @override
     def find_class(self, module: str, name: str) -> Any:
         if module == "torch._utils" and name == "_rebuild_tensor_v2":
             return partial(_NotYetLoadedTensor.rebuild_tensor_v2, archiveinfo=self)
@@ -179,6 +180,7 @@ class _LazyLoadingUnpickler(pickle.Unpickler):
             return partial(_NotYetLoadedTensor.rebuild_parameter, archiveinfo=self)
         return super().find_class(module, name)
 
+    @override
     def persistent_load(self, pid: tuple) -> "TypedStorage":
         from torch.storage import TypedStorage
 

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -16,12 +16,13 @@ import warnings
 from functools import partial
 from io import BytesIO
 from typing import IO, TYPE_CHECKING, Any, Callable, Dict, Optional, OrderedDict, Sequence, Set, Union
-from typing_extensions import override
+
 import torch
 from lightning_utilities.core.apply_func import apply_to_collection
 from torch import Tensor
 from torch._C import _TensorMeta
 from torch.nn import Parameter
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_0
 from lightning.fabric.utilities.types import _PATH, _Stateful

--- a/src/lightning/fabric/utilities/throughput.py
+++ b/src/lightning/fabric/utilities/throughput.py
@@ -14,8 +14,9 @@
 # Adapted from https://github.com/mosaicml/composer/blob/f2a2dc820/composer/callbacks/speed_monitor.py
 from collections import deque
 from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, List, Optional, TypeVar, Union
-from typing_extensions import override
+
 import torch
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from lightning.fabric.utilities.rank_zero import rank_zero_only, rank_zero_warn

--- a/src/lightning/fabric/utilities/throughput.py
+++ b/src/lightning/fabric/utilities/throughput.py
@@ -14,7 +14,7 @@
 # Adapted from https://github.com/mosaicml/composer/blob/f2a2dc820/composer/callbacks/speed_monitor.py
 from collections import deque
 from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, List, Optional, TypeVar, Union
-
+from typing_extensions import override
 import torch
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_1
@@ -654,6 +654,7 @@ class _MonotonicWindow(List[T]):
             return self[-1]
         return None
 
+    @override
     def append(self, x: T) -> None:
         last = self.last
         if last is not None and last >= x:
@@ -663,6 +664,7 @@ class _MonotonicWindow(List[T]):
         if len(self) > self.maxlen:
             del self[0]
 
+    @override
     def __setitem__(self, key: Any, value: Any) -> None:
         # assigning is not implemented since we don't use it. it could be by checking all previous values
         raise NotImplementedError("__setitem__ is not supported")


### PR DESCRIPTION
This PR adds the `@override` decorator for all files in `src/lightning/fabric/utilities` (https://github.com/Lightning-AI/pytorch-lightning/issues/18695).

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19293.org.readthedocs.build/en/19293/

<!-- readthedocs-preview pytorch-lightning end -->