### PR TITLE
Avoid deprecated `load_state_dict` for distributed checkpoints in PyTorch 2.2+

### DIFF
--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -598,6 +598,7 @@ class FSDPStrategy(ParallelStrategy):
         if _is_sharded_checkpoint(path):
             from torch.distributed.checkpoint import FileSystemReader
             from torch.distributed.checkpoint.optimizer import load_sharded_optimizer_state_dict
+
             if _TORCH_GREATER_EQUAL_2_2:
                 from torch.distributed.checkpoint import load
             else:

--- a/tests/tests_pytorch/conftest.py
+++ b/tests/tests_pytorch/conftest.py
@@ -21,8 +21,6 @@ from pathlib import Path
 from typing import List
 from unittest.mock import Mock
 
-from tqdm import TMonitor
-
 import lightning.fabric
 import lightning.pytorch
 import pytest
@@ -33,6 +31,7 @@ from lightning.fabric.utilities.distributed import _distributed_is_initialized
 from lightning.fabric.utilities.imports import _IS_WINDOWS
 from lightning.pytorch.accelerators import XLAAccelerator
 from lightning.pytorch.trainer.connectors.signal_connector import _SignalConnector
+from tqdm import TMonitor
 
 from tests_pytorch import _PATH_DATASETS
 

--- a/tests/tests_pytorch/conftest.py
+++ b/tests/tests_pytorch/conftest.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import List
 from unittest.mock import Mock
 
+from tqdm import TMonitor
+
 import lightning.fabric
 import lightning.pytorch
 import pytest
@@ -155,6 +157,8 @@ def thread_police_duuu_daaa_duuu_daaa():
             thread.join(timeout=10)
         elif thread.name == "QueueFeederThread":  # tensorboardX
             thread.join(timeout=20)
+        elif isinstance(thread, TMonitor):
+            thread.exit()
         elif (
             sys.version_info >= (3, 9)
             and isinstance(thread, _ExecutorManagerThread)


### PR DESCRIPTION
## What does this PR do?

The `torch.distributed.checkpoint.load_state_dict` was deprecated in favor of `load`.


cc @borda @carmocca @justusschock @awaelchli