### PR TITLE
Remove `__len__` from CombinedStreamingDataset

### DIFF
--- a/src/lightning/data/streaming/combined.py
+++ b/src/lightning/data/streaming/combined.py
@@ -23,9 +23,11 @@ class CombinedStreamingDataset(IterableDataset):
     """The `CombinedStreamingDataset` enables to stream data from multiple StreamingDataset with the sampling ratio of
     your choice.
 
-    Addtionally, the `CombinedStreamingDataset` keeps track of the number of
-    samples fetched to enable resumability of the datasets.
+    Addtionally, the `CombinedStreamingDataset` keeps track of the number of samples fetched to enable resumability
+    of the datasets.
 
+    Note that due to the random sampling, the number of samples returned from the iterator is variable and a function
+    of the given seed. The combined dataset will raise a StopIteration as soon as any of the datasets is exhausted.
     """
 
     def __init__(
@@ -43,10 +45,6 @@ class CombinedStreamingDataset(IterableDataset):
             self._weights = [w / sum(weights) for w in weights]
 
         self._iterator: Optional[_CombinedDatasetIterator] = None
-
-    def __len__(self) -> int:
-        assert self._weights
-        return int(min([1 / w * len(d) for w, d in zip(self._weights, self._datasets) if w > 0]))
 
     def __iter__(self) -> Iterator[Any]:
         assert self._weights

--- a/src/lightning/data/streaming/combined.py
+++ b/src/lightning/data/streaming/combined.py
@@ -28,6 +28,7 @@ class CombinedStreamingDataset(IterableDataset):
 
     Note that due to the random sampling, the number of samples returned from the iterator is variable and a function
     of the given seed. The combined dataset will raise a StopIteration as soon as any of the datasets is exhausted.
+
     """
 
     def __init__(


### PR DESCRIPTION
## What does this PR do?

The combined dataset is an iterable dataset that samples randomly from a list of datasets. Since the termination is non-deterministic, and the datasets can have different lengths, it is not meaningful to define a length. As far as I know, there is no code that depends on this definition, so it's best to remove it.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19321.org.readthedocs.build/en/19321/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda