### PR TITLE
Update Lightning AI multi-node guide

### DIFF
--- a/docs/source-fabric/fundamentals/launch.rst
+++ b/docs/source-fabric/fundamentals/launch.rst
@@ -172,7 +172,7 @@ Choose from the following options based on your expertise level and available in
         <div class="row">
 
 .. displayitem::
-    :header: Lightning Cloud
+    :header: Run single or multi-node on Lightning Studios
     :description: The easiest way to scale models in the cloud. No infrastructure setup required.
     :col_css: col-md-4
     :button_link: ../guide/multi_node/cloud.html

--- a/docs/source-fabric/guide/multi_node/cloud.rst
+++ b/docs/source-fabric/guide/multi_node/cloud.rst
@@ -44,7 +44,6 @@ Launch multi-node training in the cloud
 .. collapse:: Code Example
 
     .. code-block:: python
-        :caption: main.py
 
         import lightning as L
         import torch

--- a/docs/source-fabric/guide/multi_node/cloud.rst
+++ b/docs/source-fabric/guide/multi_node/cloud.rst
@@ -38,7 +38,7 @@ Launch multi-node training in the cloud
 
 |
 
-**Step 2:** Bring your code into the studio. You can clone a GitHub repo, drag and drop local files, or use the following demo example:
+**Step 2:** Bring your code into the Studio. You can clone a GitHub repo, drag and drop local files, or use the following demo example:
 
 .. collapse:: Code Example
 

--- a/docs/source-fabric/guide/multi_node/cloud.rst
+++ b/docs/source-fabric/guide/multi_node/cloud.rst
@@ -19,13 +19,8 @@ Initial Setup
 *************
 
 First, create a free `Lightning AI account <https://lightning.ai/>`_.
-Then, log in from the CLI:
-
-.. code-block:: bash
-
-    lightning login
-
-A page opens in your browser where you can follow the instructions to complete the setup.
+You get free credits every month you can spend on GPU compute.
+To use muliple machines, you need to be on the `Pro or Teams plan <https://lightning.ai/pricing>`_.
 
 
 ----
@@ -35,59 +30,43 @@ A page opens in your browser where you can follow the instructions to complete t
 Launch multi-node training in the cloud
 ***************************************
 
-**Step 1:** Put your code inside a ``lightning.app.core.work.LightningWork``:
+**Step 1:** Start a new studio.
+**Step 2:** Bring your code into the studio. You can clone a GitHub repo, drag and drop local files, or use the following demo example:
+
+.. collapse:: Example
+
+    .. code-block:: python
+        :caption: main.py
+
+        # TODO
+
+**Step 3:** Remove any hardcoded accelerator settings and let Lightning automatically set them for you. **No other changes are required in your script.**
 
 .. code-block:: python
-    :emphasize-lines: 5
-    :caption: app.py
+    :caption: main.py
 
-    import lightning as L
-    from lightning.app.components import FabricMultiNode
+    # These are the defaults
+    fabric = L.Fabric(accelerator="auto", devices="auto")
 
-
-    # 1. Put your code inside a LightningWork
-    class MyTrainingComponent(L.LightningWork):
-        def run(self):
-            # Set up Fabric
-            # The `devices` and `num_nodes` gets set by Lightning automatically
-            fabric = L.Fabric(strategy="ddp", precision="16-mixed")
-
-            # Your training code
-            model = ...
-            optimizer = ...
-            model, optimizer = fabric.setup(model, optimizer)
-            ...
-
-**Step 2:** Init a ``lightning.app.core.app.LightningApp`` with the ``FabricMultiNode`` component.
-Configure the number of nodes, the number of GPUs per node, and the type of GPU:
-
-.. code-block:: python
-    :emphasize-lines: 5,7
-    :caption: app.py
-
-    # 2. Create the app with the FabricMultiNode component inside
-    app = L.LightningApp(
-        FabricMultiNode(
-            MyTrainingComponent,
-            # Run with 2 nodes
-            num_nodes=2,
-            # Each with 4 x V100 GPUs, total 8 GPUs
-            cloud_compute=L.CloudCompute("gpu-fast-multi"),
-        )
-    )
+    # DON'T hardcode these, leave them default/auto
+    # fabric = L.Fabric(accelerator="cpu", devices=3)
 
 
-**Step 3:** Run your code from the CLI:
+**Step 4:** Install dependencies and download all necessary data. Test that your script runs in the studio first. **If it runs in the studio, it will run in multi-node!**
 
-.. code-block:: bash
 
-    lightning run app app.py --cloud
+**Step 5:** Open the Multi-Machine Training (MMT) app. Type the command to run your script, select the machine type and how many machines you want to launch on. Click "Run" to start the job.
 
-This command will upload your Python file and then opens the app admin view, where you can see the logs of what's happening.
 
-.. figure:: https://pl-public-data.s3.amazonaws.com/assets_lightning/fabric/fabric-multi-node-admin.png
-   :alt: The Lightning AI admin page of an app running a multi-node fabric training script
-   :width: 100%
+----
+
+
+****************************
+Bring your own cloud account
+****************************
+
+On the `Teams or Enterprise <https://lightning.ai/pricing>`_ tier, you can connect your own AWS account.
+
 
 
 ----

--- a/docs/source-fabric/guide/multi_node/cloud.rst
+++ b/docs/source-fabric/guide/multi_node/cloud.rst
@@ -113,6 +113,8 @@ Launch multi-node training in the cloud
     :loop:
     :muted:
 
+After submitting the job, you will be redirected to a page where you can monitor the machine metrics and logs in real-time.
+
 
 ----
 
@@ -121,7 +123,7 @@ Launch multi-node training in the cloud
 Bring your own cloud account
 ****************************
 
-On the `Teams or Enterprise <https://lightning.ai/pricing>`_ tier, you can connect your own AWS account.
+As a `Teams or Enterprise <https://lightning.ai/pricing>`_ customer, you have the option to connect your existing AWS account to Lightning AI.
 
 
 

--- a/docs/source-fabric/guide/multi_node/cloud.rst
+++ b/docs/source-fabric/guide/multi_node/cloud.rst
@@ -1,8 +1,8 @@
 :orphan:
 
-##########################
-Run in the Lightning Cloud
-##########################
+#############################################
+Run single or multi-node on Lightning Studios
+#############################################
 
 **Audience**: Users who don't want to waste time on cluster configuration and maintenance.
 

--- a/docs/source-fabric/guide/multi_node/cloud.rst
+++ b/docs/source-fabric/guide/multi_node/cloud.rst
@@ -31,19 +31,69 @@ Launch multi-node training in the cloud
 ***************************************
 
 **Step 1:** Start a new studio.
+
+.. video:: https://pl-public-data.s3.amazonaws.com/assets_lightning/fabric/videos/start-studio-for-mmt.mp4
+    :width: 800
+    :loop:
+    :muted:
+
+|
+
 **Step 2:** Bring your code into the studio. You can clone a GitHub repo, drag and drop local files, or use the following demo example:
 
-.. collapse:: Example
+.. collapse:: Code Example
 
     .. code-block:: python
         :caption: main.py
 
-        # TODO
+        import lightning as L
+        import torch
+        import torch.nn.functional as F
+        from lightning.pytorch.demos import Transformer, WikiText2
+        from torch.utils.data import DataLoader
 
-**Step 3:** Remove any hardcoded accelerator settings and let Lightning automatically set them for you. **No other changes are required in your script.**
+
+        def main():
+            L.seed_everything(42)
+
+            fabric = L.Fabric()
+            fabric.launch()
+
+            # Data
+            with fabric.rank_zero_first():
+                dataset = WikiText2()
+
+            train_dataloader = DataLoader(dataset, batch_size=20, shuffle=True)
+
+            # Model
+            model = Transformer(vocab_size=dataset.vocab_size)
+
+            # Optimizer
+            optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+            model, optimizer = fabric.setup(model, optimizer)
+            train_dataloader = fabric.setup_dataloaders(train_dataloader)
+
+            for batch_idx, batch in enumerate(train_dataloader):
+                input, target = batch
+                output = model(input, target)
+                loss = F.nll_loss(output, target.view(-1))
+                fabric.backward(loss)
+                optimizer.step()
+                optimizer.zero_grad()
+
+                if batch_idx % 10 == 0:
+                    fabric.print(f"iteration: {batch_idx} - loss {loss.item():.4f}")
+
+
+        if __name__ == "__main__":
+            main()
+
+|
+
+**Step 3:** Remove hardcoded accelerator settings if any and let Lightning automatically set them for you. No other changes are required in your script.
 
 .. code-block:: python
-    :caption: main.py
 
     # These are the defaults
     fabric = L.Fabric(accelerator="auto", devices="auto")
@@ -51,11 +101,18 @@ Launch multi-node training in the cloud
     # DON'T hardcode these, leave them default/auto
     # fabric = L.Fabric(accelerator="cpu", devices=3)
 
+|
 
-**Step 4:** Install dependencies and download all necessary data. Test that your script runs in the studio first. **If it runs in the studio, it will run in multi-node!**
+**Step 4:** Install dependencies and download all necessary data. Test that your script runs in the studio first. If it runs in the studio, it will run in multi-node!
 
+|
 
 **Step 5:** Open the Multi-Machine Training (MMT) app. Type the command to run your script, select the machine type and how many machines you want to launch on. Click "Run" to start the job.
+
+.. video:: https://pl-public-data.s3.amazonaws.com/assets_lightning/fabric/videos/lightning-ai-mmt-demo-fabric.mp4
+    :width: 800
+    :loop:
+    :muted:
 
 
 ----

--- a/docs/source-fabric/guide/multi_node/cloud.rst
+++ b/docs/source-fabric/guide/multi_node/cloud.rst
@@ -6,9 +6,8 @@ Run in the Lightning Cloud
 
 **Audience**: Users who don't want to waste time on cluster configuration and maintenance.
 
-
-The Lightning AI cloud is a platform where you can build, train, finetune and deploy models without worrying about infrastructure, cost management, scaling, and other technical headaches.
-In this guide, and within just 10 minutes, you will learn how to run a Fabric training script across multiple nodes in the cloud.
+`Lightning AI <https://lightning.ai>`_ is a platform where you can build, train, finetune and deploy models without worrying about infrastructure, cost management, scaling, and other technical headaches.
+This guide shows you how easy it is to run a Fabric training script across multiple machines in the cloud.
 
 
 ----
@@ -139,8 +138,8 @@ Learn more
         <div class="row">
 
 .. displayitem::
-    :header: Lightning Platform
-    :description: Develop, Train and Deploy models on the cloud
+    :header: Lightning AI
+    :description: Code together. Prototype. Train. Deploy. Host AI web apps. From your browser - with zero setup.
     :col_css: col-md-4
     :button_link: https://lightning.ai
     :height: 150

--- a/docs/source-fabric/guide/multi_node/cloud.rst
+++ b/docs/source-fabric/guide/multi_node/cloud.rst
@@ -124,14 +124,13 @@ Bring your own cloud account
 ****************************
 
 As a `Teams or Enterprise <https://lightning.ai/pricing>`_ customer, you have the option to connect your existing AWS account to Lightning AI.
-
+This gives your enterprise greater control and insight into the cluster management, and all data that your team creates in studios and jobs gets stored safely in your AWS account.
 
 
 ----
 
-
 **********
-Next steps
+Learn more
 **********
 
 .. raw:: html

--- a/docs/source-fabric/guide/multi_node/cloud.rst
+++ b/docs/source-fabric/guide/multi_node/cloud.rst
@@ -6,8 +6,8 @@ Run in the Lightning Cloud
 
 **Audience**: Users who don't want to waste time on cluster configuration and maintenance.
 
-`Lightning AI <https://lightning.ai>`_ is a platform where you can build, train, finetune and deploy models without worrying about infrastructure, cost management, scaling, and other technical headaches.
-This guide shows you how easy it is to run a Fabric training script across multiple machines in the cloud.
+`Lightning Studios <https://lightning.ai>`_ is a cloud platform where you can build, train, finetune and deploy models without worrying about infrastructure, cost management, scaling, and other technical headaches.
+This guide shows you how easy it is to run a Fabric training script across multiple machines on Lightning Studios.
 
 
 ----
@@ -19,7 +19,7 @@ Initial Setup
 
 First, create a free `Lightning AI account <https://lightning.ai/>`_.
 You get free credits every month you can spend on GPU compute.
-To use multiple machines, you need to be on the `Pro or Teams plan <https://lightning.ai/pricing>`_.
+To use machines with multiple GPUs or run jobs across machines, you need to be on the `Pro or Teams plan <https://lightning.ai/pricing>`_.
 
 
 ----
@@ -29,7 +29,7 @@ To use multiple machines, you need to be on the `Pro or Teams plan <https://ligh
 Launch multi-node training in the cloud
 ***************************************
 
-**Step 1:** Start a new studio.
+**Step 1:** Start a new Studio.
 
 .. video:: https://pl-public-data.s3.amazonaws.com/assets_lightning/fabric/videos/start-studio-for-mmt.mp4
     :width: 800
@@ -101,11 +101,11 @@ Launch multi-node training in the cloud
 
 |
 
-**Step 4:** Install dependencies and download all necessary data. Test that your script runs in the studio first. If it runs in the studio, it will run in multi-node!
+**Step 4:** Install dependencies and download all necessary data. Test that your script runs in the Studio first. If it runs in the Studio, it will run in multi-node!
 
 |
 
-**Step 5:** Open the Multi-Machine Training (MMT) app. Type the command to run your script, select the machine type and how many machines you want to launch on. Click "Run" to start the job.
+**Step 5:** Open the Multi-Machine Training (MMT) app. Type the command to run your script, select the machine type and how many machines you want to launch it on. Click "Run" to start the job.
 
 .. video:: https://pl-public-data.s3.amazonaws.com/assets_lightning/fabric/videos/lightning-ai-mmt-demo-fabric.mp4
     :width: 800
@@ -122,8 +122,8 @@ After submitting the job, you will be redirected to a page where you can monitor
 Bring your own cloud account
 ****************************
 
-As a `Teams or Enterprise <https://lightning.ai/pricing>`_ customer, you have the option to connect your existing AWS account to Lightning AI.
-This gives your enterprise greater control and insight into the cluster management, and all data that your team creates in studios and jobs gets stored safely in your AWS account.
+As a `Teams or Enterprise <https://lightning.ai/pricing>`_ customer, you have the option to connect your existing cloud account to Lightning AI.
+This gives your organization the ability to keep all compute and data on your own cloud account and your Virtual Private Cloud (VPC).
 
 
 ----
@@ -138,7 +138,7 @@ Learn more
         <div class="row">
 
 .. displayitem::
-    :header: Lightning AI
+    :header: Lightning Studios
     :description: Code together. Prototype. Train. Deploy. Host AI web apps. From your browser - with zero setup.
     :col_css: col-md-4
     :button_link: https://lightning.ai

--- a/docs/source-fabric/guide/multi_node/cloud.rst
+++ b/docs/source-fabric/guide/multi_node/cloud.rst
@@ -20,7 +20,7 @@ Initial Setup
 
 First, create a free `Lightning AI account <https://lightning.ai/>`_.
 You get free credits every month you can spend on GPU compute.
-To use muliple machines, you need to be on the `Pro or Teams plan <https://lightning.ai/pricing>`_.
+To use multiple machines, you need to be on the `Pro or Teams plan <https://lightning.ai/pricing>`_.
 
 
 ----

--- a/examples/fabric/language_model/train.py
+++ b/examples/fabric/language_model/train.py
@@ -11,9 +11,7 @@ def main():
     fabric = L.Fabric()
 
     # Data
-    with fabric.rank_zero_first():
-        dataset = WikiText2()
-
+    dataset = WikiText2()
     train_dataloader, val_dataloader, _ = get_dataloaders(dataset)
 
     # Model

--- a/examples/fabric/language_model/train.py
+++ b/examples/fabric/language_model/train.py
@@ -11,7 +11,9 @@ def main():
     fabric = L.Fabric()
 
     # Data
-    dataset = WikiText2()
+    with fabric.rank_zero_first():
+        dataset = WikiText2()
+
     train_dataloader, val_dataloader, _ = get_dataloaders(dataset)
 
     # Model


### PR DESCRIPTION
## What does this PR do?

Rewrites the docs for the Lightning AI multi-node guide in Fabric. Once this lands, I will update/add the equivalent guide in the Trainer docs as well. 

The generated docs can be viewed here:
https://pytorch-lightning--19324.org.readthedocs.build/en/19324/fabric/guide/multi_node/cloud.html


cc @borda @carmocca @justusschock @awaelchli