### PR TITLE
Clarify return type in `training_step` docs in case of manual optimization

### DIFF
--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -691,8 +691,9 @@ class LightningModule(
             - :class:`~torch.Tensor` - The loss tensor
             - ``dict`` - A dictionary. Can include any keys, but must include the key ``'loss'`` in the case of
               automatic optimization.
-            - ``None`` - In automatic optimization, this will skip to the next batch.
-              For manual optimization, this has no special meaning, as returning the loss is not required.
+            - ``None`` - In automatic optimization, this will skip to the next batch (but is not supported for
+              multi-GPU, TPU, or DeepSpeed). For manual optimization, this has no special meaning, as returning
+              the loss is not required.
 
         In this step you'd normally do the forward pass and calculate the loss for a batch.
         You can also do fancier things like multiple forward passes or something model specific.

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -689,7 +689,7 @@ class LightningModule(
 
         Return:
             - :class:`~torch.Tensor` - The loss tensor
-            - ``dict`` - A dictionary. Can include any keys, but must include the key ``'loss'``.
+            - ``dict`` - A dictionary. Can include any keys, but must include the key ``'loss'`` in the case of automatic optimization.
             - ``None`` - In automatic optimization, this will skip to the next batch.
               For manual optimization, this has no special meaning, as returning the loss is not required.
 

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -689,7 +689,8 @@ class LightningModule(
 
         Return:
             - :class:`~torch.Tensor` - The loss tensor
-            - ``dict`` - A dictionary. Can include any keys, but must include the key ``'loss'`` in the case of automatic optimization.
+            - ``dict`` - A dictionary. Can include any keys, but must include the key ``'loss'`` in the case of
+              automatic optimization.
             - ``None`` - In automatic optimization, this will skip to the next batch.
               For manual optimization, this has no special meaning, as returning the loss is not required.
 

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -688,10 +688,10 @@ class LightningModule(
                 (only if multiple dataloaders used)
 
         Return:
-            - :class:`~torch.Tensor`: The loss tensor
-            - ``dict``: A dictionary. Can include any keys, but must include the key ``'loss'``.
-            - ``None``: In automatic optimization, this will skip to the next batch. For manual optimization, this
-              has no special meaning, as returning the loss is not required.
+            - :class:`~torch.Tensor` - The loss tensor
+            - ``dict`` - A dictionary. Can include any keys, but must include the key ``'loss'``.
+            - ``None`` - In automatic optimization, this will skip to the next batch.
+              For manual optimization, this has no special meaning, as returning the loss is not required.
 
         In this step you'd normally do the forward pass and calculate the loss for a batch.
         You can also do fancier things like multiple forward passes or something model specific.

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -688,10 +688,10 @@ class LightningModule(
                 (only if multiple dataloaders used)
 
         Return:
-            - :class:`~torch.Tensor` - The loss tensor
-            - ``dict`` - A dictionary. Can include any keys, but must include the key ``'loss'``.
-            - ``None`` - Skip to the next batch. This is only supported for automatic optimization.
-                This is not supported for multi-GPU, TPU, IPU, or DeepSpeed.
+            - :class:`~torch.Tensor`: The loss tensor
+            - ``dict``: A dictionary. Can include any keys, but must include the key ``'loss'``.
+            - ``None``: In automatic optimization, this will skip to the next batch. For manual optimization, this
+              has no special meaning, as returning the loss is not required.
 
         In this step you'd normally do the forward pass and calculate the loss for a batch.
         You can also do fancier things like multiple forward passes or something model specific.

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -689,7 +689,7 @@ class LightningModule(
 
         Return:
             - :class:`~torch.Tensor` - The loss tensor
-            - ``dict`` - A dictionary. Can include any keys, but must include the key ``'loss'`` in the case of
+            - ``dict`` - A dictionary which can include any keys, but must include the key ``'loss'`` in the case of
               automatic optimization.
             - ``None`` - In automatic optimization, this will skip to the next batch (but is not supported for
               multi-GPU, TPU, or DeepSpeed). For manual optimization, this has no special meaning, as returning


### PR DESCRIPTION
## What does this PR do?

Fixes a small confusion in #19311, by clarifying what returning None means. 
Closes #19311



<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19327.org.readthedocs.build/en/19327/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli