### PR TITLE
Error message to inform bitsandbytes is only supported on CUDA

### DIFF
--- a/src/lightning/fabric/connector.py
+++ b/src/lightning/fabric/connector.py
@@ -449,7 +449,9 @@ class _Connector:
 
     def _check_and_init_precision(self) -> Precision:
         if isinstance(self._precision_instance, Precision):
-            if isinstance(self._precision_instance, BitsandbytesPrecision) and not isinstance(self.accelerator, CUDAAccelerator):
+            if isinstance(self._precision_instance, BitsandbytesPrecision) and not isinstance(
+                self.accelerator, CUDAAccelerator
+            ):
                 raise RuntimeError("Bitsandbytes is only supported on CUDA GPUs.")
             return self._precision_instance
         if isinstance(self.strategy, (SingleDeviceXLAStrategy, XLAStrategy, XLAFSDPStrategy)):

--- a/src/lightning/fabric/connector.py
+++ b/src/lightning/fabric/connector.py
@@ -24,6 +24,7 @@ from lightning.fabric.accelerators.cuda import CUDAAccelerator
 from lightning.fabric.accelerators.mps import MPSAccelerator
 from lightning.fabric.accelerators.xla import XLAAccelerator
 from lightning.fabric.plugins import (
+    BitsandbytesPrecision,
     CheckpointIO,
     DeepSpeedPrecision,
     HalfPrecision,
@@ -448,6 +449,8 @@ class _Connector:
 
     def _check_and_init_precision(self) -> Precision:
         if isinstance(self._precision_instance, Precision):
+            if isinstance(self._precision_instance, BitsandbytesPrecision) and not isinstance(self.accelerator, CUDAAccelerator):
+                raise RuntimeError("Bitsandbytes is only supported on CUDA GPUs.")
             return self._precision_instance
         if isinstance(self.strategy, (SingleDeviceXLAStrategy, XLAStrategy, XLAFSDPStrategy)):
             return XLAPrecision(self._precision_input)  # type: ignore

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -566,7 +566,9 @@ class _AcceleratorConnector:
 
     def _validate_precision_choice(self) -> None:
         """Validate the combination of choices for precision, AMP type, and accelerator."""
-        if isinstance(self._precision_plugin_flag, BitsandbytesPrecision) and not isinstance(self.accelerator, CUDAAccelerator):
+        if isinstance(self._precision_plugin_flag, BitsandbytesPrecision) and not isinstance(
+            self.accelerator, CUDAAccelerator
+        ):
             raise RuntimeError("Bitsandbytes is only supported on CUDA GPUs.")
         if _habana_available_and_importable():
             from lightning_habana import HPUAccelerator

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -37,6 +37,7 @@ from lightning.pytorch.accelerators.mps import MPSAccelerator
 from lightning.pytorch.accelerators.xla import XLAAccelerator
 from lightning.pytorch.plugins import (
     _PLUGIN_INPUT,
+    BitsandbytesPrecision,
     CheckpointIO,
     DeepSpeedPrecision,
     DoublePrecision,
@@ -565,6 +566,8 @@ class _AcceleratorConnector:
 
     def _validate_precision_choice(self) -> None:
         """Validate the combination of choices for precision, AMP type, and accelerator."""
+        if isinstance(self._precision_plugin_flag, BitsandbytesPrecision) and not isinstance(self.accelerator, CUDAAccelerator):
+            raise RuntimeError("Bitsandbytes is only supported on CUDA GPUs.")
         if _habana_available_and_importable():
             from lightning_habana import HPUAccelerator
 

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -18,6 +18,7 @@ from typing import Any, Dict
 from unittest import mock
 from unittest.mock import Mock
 
+import lightning.fabric
 import lightning.pytorch
 import pytest
 import torch


### PR DESCRIPTION
## What does this PR do?

Fixes #19359


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19360.org.readthedocs.build/en/19360/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli