### PR TITLE
Fix import error when running examples in fresh environment

### DIFF
--- a/requirements/pytorch/examples.txt
+++ b/requirements/pytorch/examples.txt
@@ -1,6 +1,7 @@
 # NOTE: the upper bound for the package version is only set for CI stability, and it is dropped while installing this package
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
+requests <2.32.0
 torchvision >=0.14.0, <0.17.0
 gym[classic_control] >=0.17.0, <0.27.0
 ipython[all] <8.15.0

--- a/src/lightning/pytorch/demos/transformer.py
+++ b/src/lightning/pytorch/demos/transformer.py
@@ -9,7 +9,6 @@ import os
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-import requests
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -18,6 +17,10 @@ from torch.nn.modules import MultiheadAttention
 from torch.utils.data import DataLoader, Dataset
 
 from lightning.pytorch import LightningModule
+from lightning_utilities.core.imports import RequirementCache
+
+_REQUESTS_AVAILABLE = RequirementCache("requests")
+
 
 if hasattr(MultiheadAttention, "_reset_parameters") and not hasattr(MultiheadAttention, "reset_parameters"):
     # See https://github.com/pytorch/pytorch/issues/107909
@@ -125,6 +128,11 @@ class WikiText2(Dataset):
 
     @staticmethod
     def download(destination: Path) -> None:
+        if not _REQUESTS_AVAILABLE:
+            raise ModuleNotFoundError(str(_REQUESTS_AVAILABLE))
+
+        import requests
+
         os.makedirs(destination.parent, exist_ok=True)
         url = "https://raw.githubusercontent.com/pytorch/examples/main/word_language_model/data/wikitext-2/train.txt"
         if os.path.exists(destination):

--- a/src/lightning/pytorch/demos/transformer.py
+++ b/src/lightning/pytorch/demos/transformer.py
@@ -12,12 +12,12 @@ from typing import Dict, List, Optional, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from lightning_utilities.core.imports import RequirementCache
 from torch import Tensor
 from torch.nn.modules import MultiheadAttention
 from torch.utils.data import DataLoader, Dataset
 
 from lightning.pytorch import LightningModule
-from lightning_utilities.core.imports import RequirementCache
 
 _REQUESTS_AVAILABLE = RequirementCache("requests")
 


### PR DESCRIPTION
## What does this PR do?

Fixes a `requests` import error when running the PyTorch Lightning basic examples from a freshly installed environment.

To reproduce:
```
conda create -n lightning-fresh python=3.11
conda activate lightning-fresh
pip install lightning
python examples/pytorch/basics/autoencoder.py
```

Error:
```
Traceback (most recent call last):
  File "/Users/adrian/repositories/lightning/examples/pytorch/basics/autoencoder.py", line 26, in <module>
    from lightning.pytorch.demos.mnist_datamodule import MNIST
  File "/Users/adrian/repositories/lightning/src/lightning/pytorch/demos/__init__.py", line 1, in <module>
    from lightning.pytorch.demos.transformer import LightningTransformer, Transformer, WikiText2  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/adrian/repositories/lightning/src/lightning/pytorch/demos/transformer.py", line 12, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'

```

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19431.org.readthedocs.build/en/19431/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda