### PR TITLE
Rename Lightning App CLI

### DIFF
--- a/.github/workflows/ci-pkg-install.yml
+++ b/.github/workflows/ci-pkg-install.yml
@@ -79,7 +79,7 @@ jobs:
         if: |
           ((matrix.pkg-name == 'lightning' || matrix.pkg-name == 'notset') && matrix.pkg-extra == 'app') ||
           matrix.pkg-name == 'app'
-        run: lightning --version
+        run: lightning_app --version
 
       - name: DocTests actions
         working-directory: .actions/

--- a/docs/source-app/basics.rst
+++ b/docs/source-app/basics.rst
@@ -85,7 +85,7 @@ And here's the output you get when running the above application using **Lightni
 
 .. code-block:: console
 
-    $ lightning run app docs/source/code_samples/quickstart/app_01.py
+    $ lightning_app run app docs/source/code_samples/quickstart/app_01.py
       INFO: Your app has started. View it in your browser: http://127.0.0.1:7501/view
       State: {'works': {'w_1': {'vars': {'counter': 1}}, 'w_2': {'vars': {'counter': 0}}}}
 
@@ -175,7 +175,7 @@ Here's the output you get when running the above application using **Lightning C
 
 .. code-block:: console
 
-    $ lightning run app docs/source/code_samples/quickstart/app_02.py
+    $ lightning_app run app docs/source/code_samples/quickstart/app_02.py
       INFO: Your app has started. View it in your browser: http://127.0.0.1:7501/view
       # After you have clicked `run` on the UI.
       0.0 0.0
@@ -230,7 +230,7 @@ When running the above app, we see the following logs:
 
 .. code-block:: console
 
-    $ lightning run app docs/source/code_samples/quickstart/app/app_0.py
+    $ lightning_app run app docs/source/code_samples/quickstart/app/app_0.py
       INFO: Your app has started. View it in your browser: http://127.0.0.1:7501/view
       # After you have clicked `run` on the UI.
       0.0, 0.0

--- a/docs/source-app/get_started/go_beyond_training_content.rst
+++ b/docs/source-app/get_started/go_beyond_training_content.rst
@@ -56,7 +56,7 @@ Install this App by typing:
 
 .. code-block:: bash
 
-    lightning install app lightning/quick-start
+    lightning_app install app lightning/quick-start
 
 Verify the App was successfully installed:
 
@@ -74,7 +74,7 @@ Run the app locally with the ``run`` command 🤯
 
 .. code:: bash
 
-    lightning run app app.py
+    lightning_app run app app.py
 
 ----
 
@@ -86,7 +86,7 @@ Add the ``--cloud`` argument to run on the `Lightning.AI cloud <http://lightning
 
 .. code:: bash
 
-    lightning run app app.py --cloud
+    lightning_app run app app.py --cloud
 
 ..
     Your app should look like this one (|qs_live_app|)

--- a/docs/source-app/get_started/jumpstart_from_app_gallery.rst
+++ b/docs/source-app/get_started/jumpstart_from_app_gallery.rst
@@ -54,7 +54,7 @@ User Workflow
 
     .. code-block:: bash
 
-        lightning install app lightning/hackernews-app
+        lightning_app install app lightning/hackernews-app
 
 #. Go through the installation steps.
 
@@ -71,7 +71,7 @@ User Workflow
     .. code-block:: bash
 
         cd LAI-Hackernews-App
-        lightning run app app.py
+        lightning_app run app app.py
 
     .. video:: https://pl-public-data.s3.amazonaws.com/assets_lightning/hackernews.mp4
         :poster: https://pl-public-data.s3.amazonaws.com/assets_lightning/hackernews.png

--- a/docs/source-app/get_started/training_with_apps.rst
+++ b/docs/source-app/get_started/training_with_apps.rst
@@ -65,13 +65,13 @@ To run your app, copy the following command to your local terminal:
 
 .. code-block:: bash
 
-    lightning run app app.py
+    lightning_app run app app.py
 
 Simply add ``--cloud`` to run this application in the cloud with a GPU machine 🤯
 
 .. code-block:: bash
 
-    lightning run app app.py --cloud
+    lightning_app run app app.py --cloud
 
 
 Congratulations! Now, you know how to run a `PyTorch Lightning <https://github.com/Lightning-AI/lightning/tree/master/src/lightning/pytorch>`_ script with Lightning Apps.

--- a/docs/source-app/glossary/command_lines/command_lines.rst
+++ b/docs/source-app/glossary/command_lines/command_lines.rst
@@ -16,7 +16,7 @@ A Command-line Interface (CLI) is an user interface (UI) in a terminal to intera
 
 .. note::
 
-    The Lightning guideline to build CLI is `lightning <VERB> <NOUN> ...` or `<ACTION> <OBJECT> ...`.
+    The Lightning guideline to build CLI is `lightning_app <VERB> <NOUN> ...` or `<ACTION> <OBJECT> ...`.
 
 As an example, Lightning provides a CLI to interact with your Lightning Apps and the `lightning.ai <https://lightning.ai/>`_ platform as follows:
 

--- a/docs/source-app/glossary/environment_variables.rst
+++ b/docs/source-app/glossary/environment_variables.rst
@@ -6,13 +6,13 @@ Environment Variables
 
 If your App is using configuration values you don't want to commit with your App source code, you can use environment variables.
 
-Lightning allows you to set environment variables when running the App from the CLI with the `lightning run app` command. You can use environment variables to pass any values to the App, and avoiding sticking those values in the source code.
+Lightning allows you to set environment variables when running the App from the CLI with the `lightning_app run app` command. You can use environment variables to pass any values to the App, and avoiding sticking those values in the source code.
 
 Set one or multiple variables using the **--env** option:
 
 .. code:: bash
 
-    lightning run app app.py --cloud --env FOO=BAR --env BAZ=FAZ
+    lightning_app run app app.py --cloud --env FOO=BAR --env BAZ=FAZ
 
 Environment variables are available in all Flows and Works, and can be accessed as follows:
 

--- a/docs/source-app/glossary/secrets.rst
+++ b/docs/source-app/glossary/secrets.rst
@@ -45,13 +45,13 @@ Use a secret
 
 .. code:: bash
 
-    lightning run app app.py --cloud --secret <environment-variable>=<secret-name>
+    lightning_app run app app.py --cloud --secret <environment-variable>=<secret-name>
 
 In this example, the command would be:
 
 .. code:: bash
 
-    lightning run app app.py --cloud --secret api_token=github_api_token
+    lightning_app run app app.py --cloud --secret api_token=github_api_token
 
 
 The ``--secret`` option can be used for multiple Secrets, and alongside the ``--env`` option.
@@ -60,7 +60,7 @@ Here's an example:
 
 .. code:: bash
 
-    lightning run app app.py --cloud --env FOO=bar --secret MY_APP_SECRET=my-secret --secret ANOTHER_SECRET=another-secret
+    lightning_app run app app.py --cloud --env FOO=bar --secret MY_APP_SECRET=my-secret --secret ANOTHER_SECRET=another-secret
 
 
 ----

--- a/docs/source-app/glossary/use_local_lightning.rst
+++ b/docs/source-app/glossary/use_local_lightning.rst
@@ -9,7 +9,7 @@ git clone https://github.com/Lightning-AI/lightning.git
 cd lightning
 pip install -e .
 export PACKAGE_LIGHTNING=1  # <- this is the magic to use your version (not mainstream PyPI)!
-lightning run app app.py --cloud
+lightning_app run app app.py --cloud
 ```
 
 By setting `PACKAGE_LIGHTNING=1`, lightning packages the lightning source code in your local directory in addition to your app source code and uploads them to the cloud.

--- a/docs/source-app/landing_app_run.bash
+++ b/docs/source-app/landing_app_run.bash
@@ -2,4 +2,4 @@
 pip install lightning
 
 # run the app on the --cloud (--setup installs deps automatically)
-lightning run app app.py --setup --cloud
+lightning_app run app app.py --setup --cloud

--- a/docs/source-app/levels/basic/hello_components/code_run_cloud.bash
+++ b/docs/source-app/levels/basic/hello_components/code_run_cloud.bash
@@ -1,1 +1,1 @@
-lightning run app app.py --cloud
+lightning_app run app app.py --cloud

--- a/docs/source-app/levels/basic/hello_components/code_run_cloud_setup.bash
+++ b/docs/source-app/levels/basic/hello_components/code_run_cloud_setup.bash
@@ -1,1 +1,1 @@
-lightning run app app.py --setup --cloud
+lightning_app run app app.py --setup --cloud

--- a/docs/source-app/levels/basic/hello_components/code_run_local.bash
+++ b/docs/source-app/levels/basic/hello_components/code_run_local.bash
@@ -1,1 +1,1 @@
-lightning run app app.py
+lightning_app run app app.py

--- a/docs/source-app/levels/basic/hello_components/code_run_local_setup.bash
+++ b/docs/source-app/levels/basic/hello_components/code_run_local_setup.bash
@@ -1,1 +1,1 @@
-lightning run app app.py --setup
+lightning_app run app app.py --setup

--- a/docs/source-app/workflows/add_server/any_server.rst
+++ b/docs/source-app/workflows/add_server/any_server.rst
@@ -121,13 +121,13 @@ Start the app to see your new UI!
 
 .. code:: bash
 
-    lightning run app app.py
+    lightning_app run app app.py
 
 To run the app on the cloud, use the ``--cloud`` argument.
 
 .. code:: bash
 
-    lightning run app app.py --cloud
+    lightning_app run app app.py --cloud
 
 ----
 

--- a/docs/source-app/workflows/add_web_ui/justpy/index.rst
+++ b/docs/source-app/workflows/add_web_ui/justpy/index.rst
@@ -89,4 +89,4 @@ Now, you can run the Lightning App with:
 
 .. code-block::
 
-    lightning run app app.py
+    lightning_app run app app.py

--- a/docs/source-app/workflows/add_web_ui/panel/basic.rst
+++ b/docs/source-app/workflows/add_web_ui/panel/basic.rst
@@ -111,7 +111,7 @@ Run the App locally:
 
 .. code:: bash
 
-    lightning run app app.py
+    lightning_app run app app.py
 
 The App should look like this:
 
@@ -124,7 +124,7 @@ Now, run it on the cloud:
 
 .. code:: bash
 
-    lightning run app app.py --cloud
+    lightning_app run app app.py --cloud
 
 ----
 
@@ -319,7 +319,7 @@ Finally run the App
 
 .. code:: bash
 
-    lightning run app app.py
+    lightning_app run app app.py
 
 .. figure:: https://pl-public-data.s3.amazonaws.com/assets_lightning/panel-lightning-theme.gif
    :alt: Basic Panel Plotly Lightning App with theming

--- a/docs/source-app/workflows/add_web_ui/react/connect_react_and_lightning.rst
+++ b/docs/source-app/workflows/add_web_ui/react/connect_react_and_lightning.rst
@@ -13,11 +13,11 @@ Connect React to a Lightning app
 Example code
 ************
 To illustrate how to connect a React app and a lightning App, we'll be using the `example_app.py` file
-which :doc:`lightning init react-ui <create_react_template>` created:
+which :doc:`lightning_app init react-ui <create_react_template>` created:
 
 .. literalinclude:: ../../../../../src/lightning/app/cli/react-ui-template/example_app.py
 
-and the App.tsx file also created by :doc:`lightning init react-ui <create_react_template>`:
+and the App.tsx file also created by :doc:`lightning_app init react-ui <create_react_template>`:
 
 .. literalinclude:: ../../../../../src/lightning/app/cli/react-ui-template/ui/src/App.tsx
 
@@ -54,7 +54,7 @@ At this point, the React app will render in the Lightning app. Test it out!
 
 .. code:: bash
 
-    lightning run app example_app.py
+    lightning_app run app example_app.py
 
 However, to make powerful React+Lightning apps, you must also connect the Lightning App state to the react app.
 These lines enable two-way communication between the react app and the Lightning app.

--- a/docs/source-app/workflows/build_command_line_interface/cli.rst
+++ b/docs/source-app/workflows/build_command_line_interface/cli.rst
@@ -30,7 +30,7 @@ Execute the following command in a terminal:
 
 .. code-block::
 
-    lightning run app app.py
+    lightning_app run app app.py
 
 The following appears the terminal:
 
@@ -47,19 +47,19 @@ The following appears the terminal:
 ***************************
 
 In another terminal, connect to the running App.
-When you connect to an App, the Lightning CLI is replaced by the App CLI. To exit the App CLI, you need to run ``lightning disconnect``.
+When you connect to an App, the Lightning CLI is replaced by the App CLI. To exit the App CLI, you need to run ``lightning_app disconnect``.
 
 .. code-block::
 
-    lightning connect localhost
+    lightning_app connect localhost
 
 To see a list of available commands:
 
 .. code-block::
 
-    lightning --help
+    lightning_app --help
     You are connected to the cloud Lightning App: localhost.
-    Usage: lightning [OPTIONS] COMMAND [ARGS]...
+    Usage: lightning_app [OPTIONS] COMMAND [ARGS]...
 
     --help     Show this message and exit.
 
@@ -70,9 +70,9 @@ To find the arguments of the commands:
 
 .. code-block::
 
-    lightning add --help
+    lightning_app add --help
     You are connected to the cloud Lightning App: localhost.
-    Usage: lightning add [ARGS]...
+    Usage: lightning_app add [ARGS]...
 
     Options
         name: Add description
@@ -87,7 +87,7 @@ Trigger the command line exposed by your App:
 
 .. code-block::
 
-    lightning add --name=my_name
+    lightning_app add --name=my_name
     WARNING: Lightning Command Line Interface is an experimental feature and unannounced changes are likely.
 
 In your first terminal, **Received name: my_name** and **["my_name"]** are printed.
@@ -106,11 +106,11 @@ In your first terminal, **Received name: my_name** and **["my_name"]** are print
 5. Disconnect from the App
 **************************
 
-To exit the App CLI, you need to run ``lightning disconnect``.
+To exit the App CLI, you need to run ``lightning_app disconnect``.
 
 .. code-block::
 
-    lightning disconnect
+    lightning_app disconnect
     You are disconnected from the local Lightning App.
 
 ----

--- a/docs/source-app/workflows/build_command_line_interface/cli_client.rst
+++ b/docs/source-app/workflows/build_command_line_interface/cli_client.rst
@@ -47,7 +47,7 @@ In a terminal, run the following command and open ``http://127.0.0.1:7501/docs``
 
 .. code-block:: python
 
-    lightning run app app.py
+    lightning_app run app app.py
     Your Lightning App is starting. This won't take long.
     INFO: Your app has started. View it in your browser: http://127.0.0.1:7501/view
 
@@ -58,11 +58,11 @@ In a terminal, run the following command and open ``http://127.0.0.1:7501/docs``
 ***************************
 
 In another terminal, connect to the running App.
-When you connect to an App, the Lightning CLI is replaced by the App CLI. To exit the App CLI, you need to run ``lightning disconnect``.
+When you connect to an App, the Lightning CLI is replaced by the App CLI. To exit the App CLI, you need to run ``lightning_app disconnect``.
 
 .. code-block::
 
-    lightning connect localhost
+    lightning_app connect localhost
 
     Storing `run_notebook` under /Users/thomas/.lightning/lightning_connection/commands/run_notebook.py
     You can review all the downloaded commands under /Users/thomas/.lightning/lightning_connection/commands folder.
@@ -72,10 +72,10 @@ To see a list of available commands:
 
 .. code-block::
 
-    lightning --help
+    lightning_app --help
 
     You are connected to the cloud Lightning App: localhost.
-    Usage: lightning [OPTIONS] COMMAND [ARGS]...
+    Usage: lightning_app [OPTIONS] COMMAND [ARGS]...
 
     --help     Show this message and exit.
 
@@ -87,7 +87,7 @@ To find the arguments of the commands:
 
 .. code-block::
 
-    lightning run notebook --help
+    lightning_app run notebook --help
 
     You are connected to the cloud Lightning App: localhost.
     usage: notebook [-h] [--name NAME] [--cloud_compute CLOUD_COMPUTE]
@@ -111,7 +111,7 @@ Run the first Notebook with the following command:
 
 .. code-block:: python
 
-    lightning run notebook --name="my_notebook"
+    lightning_app run notebook --name="my_notebook"
     WARNING: Lightning Command Line Interface is an experimental feature and unannounced changes are likely.
     The notebook my_notebook was created.
 
@@ -119,7 +119,7 @@ And run a second notebook.
 
 .. code-block:: python
 
-    lightning run notebook --name="my_notebook_2"
+    lightning_app run notebook --name="my_notebook_2"
     WARNING: Lightning Command Line Interface is an experimental feature and unannounced changes are likely.
     The notebook my_notebook_2 was created.
 
@@ -141,7 +141,7 @@ To exit the App CLI, you need to run **lightning disconnect**.
 
 .. code-block::
 
-    lightning disconnect
+    lightning_app disconnect
     You are disconnected from the local Lightning App.
 
 ----

--- a/docs/source-app/workflows/build_command_line_interface/index.rst
+++ b/docs/source-app/workflows/build_command_line_interface/index.rst
@@ -14,7 +14,7 @@ A Command-line Interface (CLI) is an user interface (UI) in a terminal to intera
 
 .. note::
 
-    The Lightning guideline to build CLI is `lightning <VERB> <NOUN> ...` or `<ACTION> <OBJECT> ...`.
+    The Lightning guideline to build CLI is `lightning_app <VERB> <NOUN> ...` or `<ACTION> <OBJECT> ...`.
 
 As an example, Lightning provides a CLI to interact with your Lightning Apps and the `lightning.ai <https://lightning.ai/>`_ platform as follows:
 

--- a/docs/source-app/workflows/build_lightning_app/from_pytorch_lightning_script.rst
+++ b/docs/source-app/workflows/build_lightning_app/from_pytorch_lightning_script.rst
@@ -26,14 +26,14 @@ To develop a template from a PyTorch Lightning script, use this command:
 
 .. code:: bash
 
-    lightning init pl-app path/to/the/pl_script.py
+    lightning_app init pl-app path/to/the/pl_script.py
 
 
 If your script is not at the root of the project folder, and you'd like to include all source files within that folder, you can specify the root path as the first argument:
 
 .. code:: bash
 
-    lightning init pl-app path/to/project/root path/to/the/pl_script.py
+    lightning_app init pl-app path/to/project/root path/to/the/pl_script.py
 
 
 The default trainer App lets you train a model with a beautiful UI locally and on the cloud with zero effort!
@@ -50,13 +50,13 @@ Run the App locally:
 
 .. code:: bash
 
-    lightning run app pl-app/app.py
+    lightning_app run app pl-app/app.py
 
 Or run the App on the cloud so you can share with collaborators and even use all the cloud GPUs you want.
 
 .. code:: bash
 
-    lightning run app pl-app/app.py --cloud
+    lightning_app run app pl-app/app.py --cloud
 
 
 .. figure:: https://storage.googleapis.com/grid-packages/pytorch-lightning-app/docs-thumbnail.png

--- a/docs/source-app/workflows/build_lightning_app/from_scratch_content.rst
+++ b/docs/source-app/workflows/build_lightning_app/from_scratch_content.rst
@@ -51,10 +51,10 @@ Run the Lightning App locally:
 
 .. code:: bash
 
-    lightning run app app.py
+    lightning_app run app app.py
 
 Run the Lightning App on the cloud:
 
 .. code:: bash
 
-    lightning run app app.py --cloud
+    lightning_app run app app.py --cloud

--- a/docs/source-app/workflows/build_lightning_component/from_scratch_component_content.rst
+++ b/docs/source-app/workflows/build_lightning_component/from_scratch_component_content.rst
@@ -91,7 +91,7 @@ run the app
 
 .. code:: bash
 
-    lightning run app app.py
+    lightning_app run app app.py
 
 ----
 
@@ -150,4 +150,4 @@ run the app
 
 .. code:: bash
 
-    lightning run app app.py
+    lightning_app run app app.py

--- a/docs/source-app/workflows/build_rest_api/add_api.rst
+++ b/docs/source-app/workflows/build_rest_api/add_api.rst
@@ -28,7 +28,7 @@ Execute the following command in a terminal:
 
 .. code-block::
 
-     lightning run app app.py
+     lightning_app run app app.py
 
 The following appears:
 

--- a/docs/source-app/workflows/run_app_on_cloud/lightning_cloud.rst
+++ b/docs/source-app/workflows/run_app_on_cloud/lightning_cloud.rst
@@ -13,7 +13,7 @@ To run any app on the public lightning cloud use the ``--cloud`` argument:
 
 .. code:: bash
 
-    lightning run app app.py --cloud
+    lightning_app run app app.py --cloud
 
 
 .. note::
@@ -44,7 +44,7 @@ Simply use the ``--name`` flag when running your app, for example:
 
 .. code:: bash
 
-    lightning run app app.py --cloud --name my-awesome-app
+    lightning_app run app app.py --cloud --name my-awesome-app
 
 Alternatively, you can change the name of the app in the ``.lightning`` file:
 

--- a/docs/source-app/workflows/run_app_snippet.rst
+++ b/docs/source-app/workflows/run_app_snippet.rst
@@ -13,7 +13,7 @@ Run the app with the ``run`` command
 
 .. code:: bash
 
-    lightning run app app.py
+    lightning_app run app app.py
 
 .. raw:: html
 
@@ -25,7 +25,7 @@ Add the ``--cloud`` argument to run on the `lightning cloud <http://lightning.ai
 
 .. code:: bash
 
-    lightning run app app.py --cloud
+    lightning_app run app app.py --cloud
 
 .. raw:: html
 

--- a/src/lightning/__setup__.py
+++ b/src/lightning/__setup__.py
@@ -114,7 +114,7 @@ def _setup_args() -> Dict[str, Any]:
         "python_requires": ">=3.8",  # todo: take the lowes based on all packages
         "entry_points": {
             "console_scripts": [
-                "lightning = lightning:_cli_entry_point",
+                "lightning_app = lightning:_cli_entry_point",
             ],
         },
         "setup_requires": [],

--- a/src/lightning/app/CHANGELOG.md
+++ b/src/lightning/app/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [2.2.0] - 2024-02-09
+
+## Changed
+
+- Renames the `lightning` cli to `lightning_app` ([#19440](https://github.com/Lightning-AI/pytorch-lightning/pull/19440))
+
 
 ## [2.1.4] - 2024-01-31
 

--- a/src/lightning/app/cli/app-template/README.md
+++ b/src/lightning/app/cli/app-template/README.md
@@ -3,7 +3,7 @@
 This ⚡ [Lightning app](https://lightning.ai/) ⚡ was generated automatically with:
 
 ```bash
-lightning init app placeholdername
+lightning_app init app placeholdername
 ```
 
 ## To run placeholdername
@@ -11,19 +11,19 @@ lightning init app placeholdername
 First, install placeholdername (warning: this app has not been officially approved on the lightning gallery):
 
 ```bash
-lightning install app https://github.com/theUser/placeholdername
+lightning_app install app https://github.com/theUser/placeholdername
 ```
 
 Once the app is installed, run it locally with:
 
 ```bash
-lightning run app placeholdername/app.py
+lightning_app run app placeholdername/app.py
 ```
 
 Run it on the [lightning cloud](https://lightning.ai/) with:
 
 ```bash
-lightning run app placeholdername/app.py --cloud
+lightning_app run app placeholdername/app.py --cloud
 ```
 
 ## to test and link

--- a/src/lightning/app/cli/cmd_react_ui_init.py
+++ b/src/lightning/app/cli/cmd_react_ui_init.py
@@ -59,7 +59,7 @@ def _copy_and_setup_react_ui(dest_dir: Optional[str] = None) -> None:
             return la.frontend.StaticWebFrontend(Path(__file__).parent / "react-ui/src/dist")
 
     ⚡ run the example_app.py to see it live!
-    lightning run app {dest_dir}/example_app.py
+    lightning_app run app {dest_dir}/example_app.py
 
     """
     logger.info(m)
@@ -80,7 +80,7 @@ def _check_react_prerequisites() -> None:
 
     if not has_npm:
         m = """
-        This machine is missing 'npm'. Please install npm and rerun 'lightning init react-ui' again.
+        This machine is missing 'npm'. Please install npm and rerun 'lightning_app init react-ui' again.
 
         Install instructions: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
         """
@@ -94,7 +94,7 @@ def _check_react_prerequisites() -> None:
 
     if not has_node:
         m = """
-        This machine is missing 'node'. Please install node and rerun 'lightning init react-ui' again.
+        This machine is missing 'node'. Please install node and rerun 'lightning_app init react-ui' again.
 
         Install instructions: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
         """

--- a/src/lightning/app/cli/commands/app_commands.py
+++ b/src/lightning/app/cli/commands/app_commands.py
@@ -61,7 +61,7 @@ def _run_app_command(app_name: str, app_id: Optional[str]):
                 if value == command and "_" in value:
                     print(
                         f"The command `{value}` was provided with an underscore and it isn't allowed."
-                        f"Instead, use `lightning {value.replace('_', ' ')}`."
+                        f"Instead, use `lightning_app {value.replace('_', ' ')}`."
                     )
                     sys.exit(0)
             break
@@ -88,7 +88,7 @@ def _run_app_command(app_name: str, app_id: Optional[str]):
 def _handle_command_without_client(command: str, metadata: Dict, url: str) -> None:
     supported_params = list(metadata["parameters"])
     if _is_running_help(sys.argv):
-        print(f"Usage: lightning {command} [ARGS]...")
+        print(f"Usage: lightning_app {command} [ARGS]...")
         print(" ")
         print("Options")
         for param in supported_params:

--- a/src/lightning/app/cli/commands/ls.py
+++ b/src/lightning/app/cli/commands/ls.py
@@ -81,7 +81,7 @@ def ls(path: Optional[str] = None, print: bool = True, use_live: bool = True) ->
         # This happens if the user changes cluster and the project doesn't exit.
         if len(project) == 0:
             return _error_and_exit(
-                f"There isn't any Lightning Project matching the name {splits[0]}." " HINT: Use `lightning cd`."
+                f"There isn't any Lightning Project matching the name {splits[0]}." " HINT: Use `lightning_app cd`."
             )
 
         project_id = project[0].project_id

--- a/src/lightning/app/cli/component-template/README.md
+++ b/src/lightning/app/cli/component-template/README.md
@@ -3,7 +3,7 @@
 This ⚡ [Lightning component](https://lightning.ai/) ⚡ was generated automatically with:
 
 ```bash
-lightning init component placeholdername
+lightning_app init component placeholdername
 ```
 
 ## To run placeholdername
@@ -11,7 +11,7 @@ lightning init component placeholdername
 First, install placeholdername (warning: this component has not been officially approved on the lightning gallery):
 
 ```bash
-lightning install component https://github.com/theUser/placeholdername
+lightning_app install component https://github.com/theUser/placeholdername
 ```
 
 Once the app is installed, use it in an app:

--- a/src/lightning/app/cli/component-template/setup.py
+++ b/src/lightning/app/cli/component-template/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name="placeholdername",
     version="0.0.0",
-    description="⚡ Lightning component ⚡ generated with command: lightning init component",
+    description="⚡ Lightning component ⚡ generated with command: lightning_app init component",
     author="",
     author_email="",
     # REPLACE WITH YOUR OWN GITHUB PROJECT LINK

--- a/src/lightning/app/cli/connect/app.py
+++ b/src/lightning/app/cli/connect/app.py
@@ -129,11 +129,11 @@ def connect_app(app_name_or_id: str):
         with open(connected_file, "w") as f:
             f.write(app_name_or_id + "\n")
 
-        click.echo("The lightning CLI now responds to app commands. Use 'lightning --help' to see them.")
+        click.echo("The lightning App CLI now responds to app commands. Use 'lightning_app --help' to see them.")
         click.echo(" ")
 
         Popen(
-            f"LIGHTNING_CONNECT_PPID={_PPID} {sys.executable} -m lightning --help",
+            f"LIGHTNING_CONNECT_PPID={_PPID} {sys.executable} -m lightning_app --help",
             shell=True,
             stdout=sys.stdout,
             stderr=sys.stderr,
@@ -147,11 +147,11 @@ def connect_app(app_name_or_id: str):
             shutil.copytree(matched_commands, commands)
             shutil.copy(matched_connected_file, connected_file)
 
-        click.echo("The lightning CLI now responds to app commands. Use 'lightning --help' to see them.")
+        click.echo("The lightning App CLI now responds to app commands. Use 'lightning_app --help' to see them.")
         click.echo(" ")
 
         Popen(
-            f"LIGHTNING_CONNECT_PPID={_PPID} {sys.executable} -m lightning --help",
+            f"LIGHTNING_CONNECT_PPID={_PPID} {sys.executable} -m lightning_app --help",
             shell=True,
             stdout=sys.stdout,
             stderr=sys.stderr,
@@ -205,11 +205,11 @@ def connect_app(app_name_or_id: str):
             f.write(retriever.app_name + "\n")
             f.write(retriever.app_id + "\n")
 
-        click.echo("The lightning CLI now responds to app commands. Use 'lightning --help' to see them.")
+        click.echo("The lightning App CLI now responds to app commands. Use 'lightning_app --help' to see them.")
         click.echo(" ")
 
         Popen(
-            f"LIGHTNING_CONNECT_PPID={_PPID} {sys.executable} -m lightning --help",
+            f"LIGHTNING_CONNECT_PPID={_PPID} {sys.executable} -m lightning_app --help",
             shell=True,
             stdout=sys.stdout,
             stderr=sys.stderr,
@@ -238,7 +238,7 @@ def disconnect_app(logout: bool = False):
         if not logout:
             click.echo(
                 "You aren't connected to any Lightning App. "
-                "Please use `lightning connect app_name_or_id` to connect to one."
+                "Please use `lightning_app connect app_name_or_id` to connect to one."
             )
 
 

--- a/src/lightning/app/cli/lightning_cli.py
+++ b/src/lightning/app/cli/lightning_cli.py
@@ -104,7 +104,7 @@ def main() -> None:
                     _run_app_command(app_name, app_id)
 
                 click.echo()
-                click.echo(message + " Return to the primary CLI with `lightning disconnect`.")
+                click.echo(message + " Return to the primary CLI with `lightning_app disconnect`.")
         else:
             _main()
 

--- a/src/lightning/app/cli/react-ui-template/README.md
+++ b/src/lightning/app/cli/react-ui-template/README.md
@@ -5,7 +5,7 @@ This is a full react template ready to use in a component
 This UI was automatically generated with:
 
 ```commandline
-lightning init react-ui
+lightning_app init react-ui
 ```
 
 ### Delete files
@@ -26,7 +26,7 @@ This template comes with `example_app.py` to show how to integrate the UI into a
 run it with:
 
 ```bash
-lightning run app react-ui/example_app.py
+lightning_app run app react-ui/example_app.py
 ```
 
 ### Connect React to your component

--- a/src/lightning/app/core/flow.py
+++ b/src/lightning/app/core/flow.py
@@ -716,11 +716,11 @@ class LightningFlow:
 
         .. code-block:: bash
 
-            lightning run app app.py
+            lightning_app run app app.py
 
         .. code-block:: bash
 
-            lightning my_command_name --args name=my_own_name
+            lightning_app my_command_name --args name=my_own_name
 
         """
         raise NotImplementedError

--- a/src/lightning/app/runners/cloud.py
+++ b/src/lightning/app/runners/cloud.py
@@ -131,7 +131,7 @@ class CloudRuntime(Runtime):
             user = self.backend.client.auth_service_get_user()
             if not user.features.code_tab:
                 rich.print(
-                    "[red]The `lightning open` command has not been enabled for your account. "
+                    "[red]The `lightning_app open` command has not been enabled for your account. "
                     "To request access, please contact support@lightning.ai[/red]"
                 )
                 sys.exit(1)

--- a/src/lightning/app/testing/testing.py
+++ b/src/lightning/app/testing/testing.py
@@ -275,7 +275,7 @@ def run_app_in_cloud(
     token = res.json()["token"]
 
     # 3. Disconnect from the App if any.
-    Popen("lightning logout", shell=True).wait()
+    Popen("lightning_app logout", shell=True).wait()
 
     # 4. Launch the application in the cloud from the Lightning CLI.
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/src/lightning/app/utilities/load_app.py
+++ b/src/lightning/app/utilities/load_app.py
@@ -239,7 +239,7 @@ def _patch_sys_argv():
     """This function modifies the ``sys.argv`` by extracting the arguments after ``--app_args`` and removed everything
     else before executing the user app script.
 
-    The command: ``lightning run app app.py --without-server --app_args --use_gpu --env ...`` will be converted into
+    The command: ``lightning_app run app app.py --without-server --app_args --use_gpu --env ...`` will be converted into
     ``app.py --use_gpu``
 
     """

--- a/src/lightning/app/utilities/login.py
+++ b/src/lightning/app/utilities/login.py
@@ -144,7 +144,7 @@ class Auth:
 
         raise ValueError(
             "We couldn't find any credentials linked to your account. "
-            "Please try logging in using the CLI command `lightning login`"
+            "Please try logging in using the CLI command `lightning_app login`"
         )
 
 

--- a/src/lightning_app/__setup__.py
+++ b/src/lightning_app/__setup__.py
@@ -85,7 +85,7 @@ def _setup_args() -> Dict[str, Any]:
         "python_requires": ">=3.8",
         "entry_points": {
             "console_scripts": [
-                "lightning = lightning_app.cli.lightning_cli:main",
+                "lightning_app = lightning_app.cli.lightning_cli:main",
             ],
         },
         "setup_requires": [],

--- a/tests/tests_app/cli/test_cli.py
+++ b/tests/tests_app/cli/test_cli.py
@@ -20,7 +20,7 @@ def test_commands(command):
 
 def test_main_lightning_cli_no_arguments():
     """Validate the Lightning CLI without args."""
-    res = os.popen("lightning").read()
+    res = os.popen("lightning_app").read()
     assert "login   " in res
     assert "logout  " in res
     assert "run     " in res
@@ -31,7 +31,7 @@ def test_main_lightning_cli_no_arguments():
 
 def test_main_lightning_cli_help():
     """Validate the Lightning CLI."""
-    res = os.popen("lightning --help").read()
+    res = os.popen("lightning_app --help").read()
     assert "login   " in res
     assert "logout  " in res
     assert "run     " in res
@@ -39,7 +39,7 @@ def test_main_lightning_cli_help():
     assert "delete  " in res
     assert "show    " in res
 
-    res = os.popen("lightning run --help").read()
+    res = os.popen("lightning_app run --help").read()
     assert "app  " in res
 
     # hidden run commands should not appear in the help text
@@ -49,7 +49,7 @@ def test_main_lightning_cli_help():
     assert "frontend" not in res
 
     # inspect show group
-    res = os.popen("lightning show --help").read()
+    res = os.popen("lightning_app show --help").read()
     assert "logs " in res
 
 
@@ -86,7 +86,7 @@ def test_cli_logout(exists: mock.MagicMock, unlink: mock.MagicMock, creds: bool)
 
 
 def test_lightning_cli_version():
-    res = os.popen("lightning --version").read()
+    res = os.popen("lightning_app --version").read()
     assert __version__ in res
 
 

--- a/tests/tests_app/cli/test_cmd_react_ui_init.py
+++ b/tests/tests_app/cli/test_cmd_react_ui_init.py
@@ -30,7 +30,7 @@ def test_missing_yarn():
 @_RunIf(skip_windows=True)
 def test_copy_and_setup_react_ui(tmpdir):
     dest_dir = os.path.join(tmpdir, "react-ui")
-    os.system(f"lightning init react-ui --dest_dir={dest_dir}")
+    os.system(f"lightning_app init react-ui --dest_dir={dest_dir}")
 
     # make sure package is minimal
     files = sorted(f for f in os.listdir(dest_dir) if f != "__pycache__")

--- a/tests/tests_app/cli/test_connect.py
+++ b/tests/tests_app/cli/test_connect.py
@@ -148,7 +148,7 @@ def test_connect_disconnect_cloud(tmpdir, monkeypatch):
 
     messages = []
     connect_app("example")
-    assert "The lightning CLI now responds to app commands" in messages[0]
+    assert "The lightning App CLI now responds to app commands" in messages[0]
 
     messages = []
     disconnect_app()

--- a/tests/tests_app/cli/test_connect.py
+++ b/tests/tests_app/cli/test_connect.py
@@ -69,7 +69,8 @@ def test_connect_disconnect_local(tmpdir, monkeypatch):
     messages = []
     disconnect_app()
     assert messages == [
-        "You aren't connected to any Lightning App. Please use `lightning_app connect app_name_or_id` to connect to one."
+        "You aren't connected to any Lightning App."
+        " Please use `lightning_app connect app_name_or_id` to connect to one."
     ]
 
     assert _retrieve_connection_to_an_app() == (None, None)
@@ -162,7 +163,8 @@ def test_connect_disconnect_cloud(tmpdir, monkeypatch):
     messages = []
     disconnect_app()
     assert messages == [
-        "You aren't connected to any Lightning App. Please use `lightning_app connect app_name_or_id` to connect to one."
+        "You aren't connected to any Lightning App."
+        " Please use `lightning_app connect app_name_or_id` to connect to one."
     ]
 
     assert _retrieve_connection_to_an_app() == (None, None)

--- a/tests/tests_app/cli/test_connect.py
+++ b/tests/tests_app/cli/test_connect.py
@@ -69,7 +69,7 @@ def test_connect_disconnect_local(tmpdir, monkeypatch):
     messages = []
     disconnect_app()
     assert messages == [
-        "You aren't connected to any Lightning App. Please use `lightning connect app_name_or_id` to connect to one."
+        "You aren't connected to any Lightning App. Please use `lightning_app connect app_name_or_id` to connect to one."
     ]
 
     assert _retrieve_connection_to_an_app() == (None, None)
@@ -162,7 +162,7 @@ def test_connect_disconnect_cloud(tmpdir, monkeypatch):
     messages = []
     disconnect_app()
     assert messages == [
-        "You aren't connected to any Lightning App. Please use `lightning connect app_name_or_id` to connect to one."
+        "You aren't connected to any Lightning App. Please use `lightning_app connect app_name_or_id` to connect to one."
     ]
 
     assert _retrieve_connection_to_an_app() == (None, None)

--- a/tests/tests_app/runners/test_cloud.py
+++ b/tests/tests_app/runners/test_cloud.py
@@ -1565,7 +1565,7 @@ class TestOpen:
         out, _ = capsys.readouterr()
 
         assert exited
-        assert "`lightning open` command has not been enabled" in out
+        assert "`lightning_app open` command has not been enabled" in out
 
 
 class TestCloudspaceDispatch:

--- a/tests/tests_app/utilities/test_safe_pickle.py
+++ b/tests/tests_app/utilities/test_safe_pickle.py
@@ -5,7 +5,8 @@ from pathlib import Path
 def test_safe_pickle_app():
     test_dir = Path(__file__).parent / "testdata"
     proc = subprocess.Popen(
-        ["lightning_app", "run", "app", "safe_pickle_app.py", "--open-ui", "false"], stdout=subprocess.PIPE, cwd=test_dir
+    ["lightning_app", "run", "app", "safe_pickle_app.py", "--open-ui", "false"],
+        stdout=subprocess.PIPE, cwd=test_dir,
     )
     stdout, _ = proc.communicate()
     assert "Exiting the pickling app successfully" in stdout.decode("UTF-8")

--- a/tests/tests_app/utilities/test_safe_pickle.py
+++ b/tests/tests_app/utilities/test_safe_pickle.py
@@ -5,7 +5,7 @@ from pathlib import Path
 def test_safe_pickle_app():
     test_dir = Path(__file__).parent / "testdata"
     proc = subprocess.Popen(
-        ["lightning", "run", "app", "safe_pickle_app.py", "--open-ui", "false"], stdout=subprocess.PIPE, cwd=test_dir
+        ["lightning_app", "run", "app", "safe_pickle_app.py", "--open-ui", "false"], stdout=subprocess.PIPE, cwd=test_dir
     )
     stdout, _ = proc.communicate()
     assert "Exiting the pickling app successfully" in stdout.decode("UTF-8")


### PR DESCRIPTION
## What does this PR do?
Renames the `lightning` cli to `lightning_app` to allow a fresh start for a `lightning` CLI for studios

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19440.org.readthedocs.build/en/19440/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca