### PR TITLE
Remove the Bagua integration

### DIFF
--- a/.azure/gpu-tests-pytorch.yml
+++ b/.azure/gpu-tests-pytorch.yml
@@ -108,7 +108,7 @@ jobs:
       - bash: |
           pip install -q -r .actions/requirements.txt
           python .actions/assistant.py requirements_prune_pkgs \
-            --packages="[lightning-colossalai,lightning-bagua]" \
+            --packages="[lightning-colossalai]" \
             --req_files="[requirements/_integrations/strategies.txt]"
         displayName: "Prune packages" # these have installation issues
 

--- a/requirements/_integrations/strategies.txt
+++ b/requirements/_integrations/strategies.txt
@@ -2,4 +2,3 @@
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
 lightning-colossalai >=0.1.0
-lightning-bagua >=0.1.0

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
--
+- Removed the Bagua integration (`Trainer(strategy="bagua")`) ([#19445](https://github.com/Lightning-AI/lightning/pull/19445))
 
 -
 

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -63,7 +63,6 @@ from lightning.pytorch.strategies import (
 from lightning.pytorch.strategies.ddp import _DDP_FORK_ALIASES
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from lightning.pytorch.utilities.imports import (
-    _LIGHTNING_BAGUA_AVAILABLE,
     _LIGHTNING_COLOSSALAI_AVAILABLE,
     _graphcore_available_and_importable,
     _habana_available_and_importable,
@@ -195,9 +194,6 @@ class _AcceleratorConnector:
 
         if strategy == "colossalai" and not _LIGHTNING_COLOSSALAI_AVAILABLE:
             raise ModuleNotFoundError(str(_LIGHTNING_COLOSSALAI_AVAILABLE))
-
-        if strategy == "bagua" and not _LIGHTNING_BAGUA_AVAILABLE:
-            raise ModuleNotFoundError(str(_LIGHTNING_BAGUA_AVAILABLE))
 
         if strategy != "auto" and strategy not in self._registered_strategies and not isinstance(strategy, Strategy):
             raise ValueError(
@@ -421,11 +417,6 @@ class _AcceleratorConnector:
         ):
             if env_type.detect():
                 return env_type()
-        if _LIGHTNING_BAGUA_AVAILABLE:
-            from lightning_bagua import BaguaEnvironment
-
-            if BaguaEnvironment.detect():
-                return BaguaEnvironment()
         return LightningEnvironment()
 
     def _choose_strategy(self) -> Union[Strategy, str]:
@@ -689,13 +680,6 @@ def _register_external_accelerators_and_strategies() -> None:
         # TODO: Prevent registering multiple times
         if "colossalai" not in StrategyRegistry:
             ColossalAIStrategy.register_strategies(StrategyRegistry)
-
-    if _LIGHTNING_BAGUA_AVAILABLE:
-        from lightning_bagua import BaguaStrategy
-
-        # TODO: Prevent registering multiple times
-        if "bagua" not in StrategyRegistry:
-            BaguaStrategy.register_strategies(StrategyRegistry)
 
     if _habana_available_and_importable():
         from lightning_habana import HPUAccelerator, HPUParallelStrategy, SingleHPUStrategy

--- a/src/lightning/pytorch/utilities/imports.py
+++ b/src/lightning/pytorch/utilities/imports.py
@@ -28,7 +28,6 @@ _TORCHMETRICS_GREATER_EQUAL_1_0_0 = RequirementCache("torchmetrics>=1.0.0")
 _OMEGACONF_AVAILABLE = package_available("omegaconf")
 _TORCHVISION_AVAILABLE = RequirementCache("torchvision")
 _LIGHTNING_COLOSSALAI_AVAILABLE = RequirementCache("lightning-colossalai")
-_LIGHTNING_BAGUA_AVAILABLE = RequirementCache("lightning-bagua")
 
 
 @functools.lru_cache(maxsize=128)

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -872,21 +872,6 @@ def test_colossalai_external_strategy(monkeypatch):
     assert isinstance(trainer.strategy, ColossalAIStrategy)
 
 
-@RunIf(min_cuda_gpus=1)  # trigger this test on our GPU pipeline, because we don't install the package on the CPU suite
-@pytest.mark.xfail(raises=ImportError, reason="Not updated to latest API")
-@pytest.mark.skipif(not package_available("lightning_bagua"), reason="Requires Bagua Strategy")
-def test_bagua_external_strategy(monkeypatch):
-    with mock.patch(
-        "lightning.pytorch.trainer.connectors.accelerator_connector._LIGHTNING_BAGUA_AVAILABLE", False
-    ), pytest.raises(ModuleNotFoundError):
-        Trainer(strategy="bagua")
-
-    from lightning_bagua import BaguaStrategy
-
-    trainer = Trainer(strategy="bagua")
-    assert isinstance(trainer.strategy, BaguaStrategy)
-
-
 class DeviceMock(Mock):
     def __instancecheck__(self, instance):
         return True


### PR DESCRIPTION
## What does this PR do?

Reasons for the removal:

- The [external integration repo](https://github.com/Lightning-Universe/lightning-Bagua) was archived and is unmaintained since 6+ months
- The [bagua package](https://github.com/BaguaSys/bagua) itself is unmaintained since March 2023.
- There are no wheels available for recent CUDA versions. The latest was 11.7, and the latest supported by the lightning-bagua integretion was 11.6.
- I installed bagua-cuda116, lightning 2.0, latest lightning-bagua, pytorch 2.0 with CUDA 11.6, and ran the boring model with `Trainer(strategy="bagua", accelerator="gpu", devices=4)` which results in a connection error:
```
raceback (most recent call last):
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning/pytorch/trainer/call.py", line 42, in _call_and_handle_interrupt
    return trainer.strategy.launcher.launch(trainer_fn, *args, trainer=trainer, **kwargs)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning/pytorch/strategies/launchers/subprocess_script.py", line 92, in launch
    return function(*args, **kwargs)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning/pytorch/trainer/trainer.py", line 559, in _fit_impl
    self._run(model, ckpt_path=ckpt_path)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning/pytorch/trainer/trainer.py", line 911, in _run
    self.strategy.setup(self)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning_bagua/strategy.py", line 226, in setup
    self._configure_bagua_model(trainer)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning_bagua/strategy.py", line 238, in _configure_bagua_model
    self.model = self._setup_model(model)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning_bagua/strategy.py", line 250, in _setup_model
    return BaguaDistributedDataParallel(
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/torch_api/data_parallel/distributed.py", line 148, in __init__
    self.inner = BaguaDistributedDataParallel(
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/torch_api/data_parallel/bagua_distributed.py", line 153, in __init__
    self._bagua_init_algorithm()
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/torch_api/data_parallel/bagua_distributed.py", line 400, in _bagua_init_algorithm
    self._bagua_autotune_register_tensors()
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/torch_api/data_parallel/bagua_distributed.py", line 368, in _bagua_autotune_register_tensors
    rsp = self._bagua_autotune_client.register_tensors(
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/service/autotune_service.py", line 318, in wrap
    raise e
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/service/autotune_service.py", line 314, in wrap
    result = request_func(*args, **kwargs)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/service/autotune_service.py", line 378, in register_tensors
    rsp = self.session.post(
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/requests/sessions.py", line 637, in post
    return self.request("POST", url, data=data, json=json, **kwargs)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/requests/adapters.py", line 519, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='127.0.0.1', port=60785): Max retries exceeded with url: /api/v1/register_tensors (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f61b569ae90>: Failed to establish a new connection: [Errno 111] Connection refused'))
```
With single-gpu operation, you run into a compatibility issue with numpy:
```
Traceback (most recent call last):
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/flask/app.py", line 1463, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/flask/app.py", line 872, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/flask/app.py", line 870, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/flask/app.py", line 855, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/service/autotune_service.py", line 164, in register_tensors
    self.model_dict[model_name] = AutotuneServiceTaskManager(
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/service/autotune_service.py", line 39, in __init__
    self.inner = AutotuneTaskManager(task_name, is_output_autotune_log)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/service/autotune_task_manager.py", line 48, in __init__
    self.bayesian_optimizer = BayesianOptimizer(
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/service/bayesian_optimizer.py", line 51, in __init__
    self.bayesian_optimizer = skopt.Optimizer(
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/skopt/optimizer/optimizer.py", line 279, in __init__
    self._initial_samples = self._initial_point_generator.generate(
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/skopt/sampler/halton.py", line 102, in generate
    out = space.inverse_transform(np.transpose(out))
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/skopt/space/space.py", line 999, in inverse_transform
    columns.append(dim.inverse_transform(Xt[:, start]))
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/skopt/space/space.py", line 528, in inverse_transform
    inv_transform = super(Integer, self).inverse_transform(Xt)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/skopt/space/space.py", line 168, in inverse_transform
    return self.transformer.inverse_transform(Xt)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/skopt/space/transformers.py", line 309, in inverse_transform
    X = transformer.inverse_transform(X)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/skopt/space/transformers.py", line 275, in inverse_transform
    return np.round(X_orig).astype(np.int)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/numpy/__init__.py", line 324, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'inf'?
Traceback (most recent call last):
  File "/home/adrian/repositories/lightning/examples/pytorch/bug_report/bug_report_model.py", line 68, in <module>
    run()
  File "/home/adrian/repositories/lightning/examples/pytorch/bug_report/bug_report_model.py", line 63, in run
    trainer.fit(model, train_dataloaders=train_data, val_dataloaders=val_data)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning/pytorch/trainer/trainer.py", line 520, in fit
    call._call_and_handle_interrupt(
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning/pytorch/trainer/call.py", line 42, in _call_and_handle_interrupt
    return trainer.strategy.launcher.launch(trainer_fn, *args, trainer=trainer, **kwargs)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning/pytorch/strategies/launchers/subprocess_script.py", line 92, in launch
    return function(*args, **kwargs)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning/pytorch/trainer/trainer.py", line 559, in _fit_impl
    self._run(model, ckpt_path=ckpt_path)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning/pytorch/trainer/trainer.py", line 911, in _run
    self.strategy.setup(self)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning_bagua/strategy.py", line 226, in setup
    self._configure_bagua_model(trainer)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning_bagua/strategy.py", line 238, in _configure_bagua_model
    self.model = self._setup_model(model)
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/lightning_bagua/strategy.py", line 250, in _setup_model
    return BaguaDistributedDataParallel(
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/torch_api/data_parallel/distributed.py", line 148, in __init__
    self.inner = BaguaDistributedDataParallel(
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/torch_api/data_parallel/bagua_distributed.py", line 153, in __init__
    self._bagua_init_algorithm()
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/torch_api/data_parallel/bagua_distributed.py", line 400, in _bagua_init_algorithm
    self._bagua_autotune_register_tensors()
  File "/home/adrian/.conda/envs/lightning-bagua/lib/python3.10/site-packages/bagua/torch_api/data_parallel/bagua_distributed.py", line 372, in _bagua_autotune_register_tensors
    assert rsp.status_code == 200, "Unexpected rsp={}".format(rsp)
AssertionError: Unexpected rsp=<Response [500]>
```

This demonstrates that clearly, the integration is no longer usable today, even with older versions of packages.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19445.org.readthedocs.build/en/19445/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca