### PR TITLE
Some clarifications in the torch.compile Fabric docs

### DIFF
--- a/docs/source-fabric/advanced/compile.rst
+++ b/docs/source-fabric/advanced/compile.rst
@@ -54,8 +54,10 @@ The actual optimization will start when calling ``forward()`` on the model for t
     output = model(input)
     ...
 
-This is important to know when you measure the speed of a compiled model and compare it to a regular model.
-You should always *exclude* the first call to ``forward()`` from your measurements, since it includes the compilation time.
+
+When measuring the speed of a compiled model and comparing it to a regular model, it is important to
+always exclude the first call to ``forward()`` from your measurements, since it includes the compilation time.
+
 
 .. collapse:: Full example with benchmark
 
@@ -155,7 +157,7 @@ However, if these properties change across subsequent calls to ``forward()``, Py
 **When your training suddenly becomes slow, it's probably because PyTorch is recompiling the model!**
 Here are some common scenarios when this can happen:
 
-- Your Trainer code switches from training to validation/testing and the input shape changes, triggering a recompilation.
+- Your training code includes an evaluation step on a different dataset, or you are using a ``Trainer`` that switches from training to validation/testing and the input shape changes, triggering a recompilation.
 - Your dataset size is not divisible by the batch size, and the dataloader has ``drop_last=False`` (the default).
   The last batch in your training loop will be smaller and trigger a recompilation.
 


### PR DESCRIPTION
## What does this PR do?

This PR just changes some wordings in the otherwise really excellent `torch.compile` docs for Fabric.  

1. It sounded like one must always exclude the first forward call from any type of measurement (but when measuring the total runtime of the code, I think that's the first forward call should be included). So I reworded the section a bit to make the context (model comparison) more clear:

 > When measuring the speed of a compiled model and comparing it to a regular model, it is important to
always exclude the first call to `forward()` from your measurements, since it includes the compilation time.

2. The doc page is for Fabric, and when using Fabric, many people probably don't use the `Trainer`. So I made the section referring to the `Trainer` a bit more general.

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19456.org.readthedocs.build/en/19456/

<!-- readthedocs-preview pytorch-lightning end -->