### PR TITLE
Adds more robust timer duration parsing

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added `load_from_checkpoint` support for `LightningCLI` when using dependency injection ([#18105](https://github.com/Lightning-AI/lightning/pull/18105))
 
--
+- Added robust timer duration parsing with an informative error message when parsing fails ([#19513](https://github.com/Lightning-AI/pytorch-lightning/pull/19513))
 
 -
 
@@ -68,7 +68,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for saving and loading stateful training DataLoaders ([#19361](https://github.com/Lightning-AI/lightning/pull/19361))
 - Added shortcut name `strategy='deepspeed_stage_1_offload'` to the strategy registry ([#19075](https://github.com/Lightning-AI/lightning/pull/19075))
 - Added support for non-strict state-dict loading in Trainer via the new `LightningModule.strict_loading = True | False` attribute ([#19404](https://github.com/Lightning-AI/lightning/pull/19404))
-- Added robust timer duration parsing with an informative error message when parsing fails ([#19513](https://github.com/Lightning-AI/pytorch-lightning/pull/19513))
 
 
 ### Changed

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for saving and loading stateful training DataLoaders ([#19361](https://github.com/Lightning-AI/lightning/pull/19361))
 - Added shortcut name `strategy='deepspeed_stage_1_offload'` to the strategy registry ([#19075](https://github.com/Lightning-AI/lightning/pull/19075))
 - Added support for non-strict state-dict loading in Trainer via the new `LightningModule.strict_loading = True | False` attribute ([#19404](https://github.com/Lightning-AI/lightning/pull/19404))
+- Added robust timer duration parsing with an informative error message when parsing fails ([#19513](https://github.com/Lightning-AI/pytorch-lightning/pull/19513))
 
 
 ### Changed

--- a/src/lightning/pytorch/callbacks/timer.py
+++ b/src/lightning/pytorch/callbacks/timer.py
@@ -90,15 +90,15 @@ class Timer(Callback):
         super().__init__()
         if isinstance(duration, str):
             duration_match = re.fullmatch(r"(\d+):(\d\d):(\d\d):(\d\d)", duration.strip())
-            if not datematch:
+            if not duration_match:
                 raise MisconfigurationException(
                     f"`Timer(duration={interval!r})` is not a valid duration. Expected a string in the format DD:HH:MM:SS."
                 )
             duration = timedelta(
-                days=int(datematch.group(1)),
-                hours=int(datematch.group(2)),
-                minutes=int(datematch.group(3)),
-                seconds=int(datematch.group(4)),
+                days=int(duration_match.group(1)),
+                hours=int(duration_match.group(2)),
+                minutes=int(duration_match.group(3)),
+                seconds=int(duration_match.group(4)),
             )
         if isinstance(duration, dict):
             duration = timedelta(**duration)

--- a/src/lightning/pytorch/callbacks/timer.py
+++ b/src/lightning/pytorch/callbacks/timer.py
@@ -89,7 +89,7 @@ class Timer(Callback):
     ) -> None:
         super().__init__()
         if isinstance(duration, str):
-            datematch = re.fullmatch(r"(\d+):(\d\d):(\d\d):(\d\d)", timestr.strip()):
+            datematch = re.fullmatch(r"(\d+):(\d\d):(\d\d):(\d\d)", timestr.strip())
             if not datematch:
                 raise MisconfigurationException(
                     f"Parameter value {interval!r} cannot be convert into duration. "

--- a/src/lightning/pytorch/callbacks/timer.py
+++ b/src/lightning/pytorch/callbacks/timer.py
@@ -92,7 +92,8 @@ class Timer(Callback):
             duration_match = re.fullmatch(r"(\d+):(\d\d):(\d\d):(\d\d)", duration.strip())
             if not duration_match:
                 raise MisconfigurationException(
-                    f"`Timer(duration={interval!r})` is not a valid duration. Expected a string in the format DD:HH:MM:SS."
+                    f"`Timer(duration={duration!r})` is not a valid duration. "
+                    "Expected a string in the format DD:HH:MM:SS."
                 )
             duration = timedelta(
                 days=int(duration_match.group(1)),

--- a/src/lightning/pytorch/callbacks/timer.py
+++ b/src/lightning/pytorch/callbacks/timer.py
@@ -101,7 +101,7 @@ class Timer(Callback):
                 minutes=int(duration_match.group(3)),
                 seconds=int(duration_match.group(4)),
             )
-        if isinstance(duration, dict):
+        elif isinstance(duration, dict):
             duration = timedelta(**duration)
         if interval not in set(Interval):
             raise MisconfigurationException(

--- a/src/lightning/pytorch/callbacks/timer.py
+++ b/src/lightning/pytorch/callbacks/timer.py
@@ -92,7 +92,7 @@ class Timer(Callback):
             datematch = re.fullmatch(r"(\d+):(\d\d):(\d\d):(\d\d)", duration.strip())
             if not datematch:
                 raise MisconfigurationException(
-                    f"Parameter value {interval!r} cannot be convert into duration. Expected DD:HH:MM:SS format."
+                    f"`Timer(duration={interval!r})` is not a valid duration. Expected a string in the format DD:HH:MM:SS."
                 )
             duration = timedelta(
                 days=int(datematch.group(1)),

--- a/src/lightning/pytorch/callbacks/timer.py
+++ b/src/lightning/pytorch/callbacks/timer.py
@@ -92,14 +92,13 @@ class Timer(Callback):
             datematch = re.fullmatch(r"(\d+):(\d\d):(\d\d):(\d\d)", timestr.strip())
             if not datematch:
                 raise MisconfigurationException(
-                    f"Parameter value {interval!r} cannot be convert into duration. "
-                    "Expected DD:HH:MM:SS format."
+                    f"Parameter value {interval!r} cannot be convert into duration. " "Expected DD:HH:MM:SS format."
                 )
             duration = timedelta(
                 days=int(match.group(1)),
                 hours=int(match.group(2)),
                 minutes=int(match.group(3)),
-                seconds=int(match.group(4))
+                seconds=int(match.group(4)),
             )
         if isinstance(duration, dict):
             duration = timedelta(**duration)

--- a/src/lightning/pytorch/callbacks/timer.py
+++ b/src/lightning/pytorch/callbacks/timer.py
@@ -89,7 +89,7 @@ class Timer(Callback):
     ) -> None:
         super().__init__()
         if isinstance(duration, str):
-            datematch = re.fullmatch(r"(\d+):(\d\d):(\d\d):(\d\d)", duration.strip())
+            duration_match = re.fullmatch(r"(\d+):(\d\d):(\d\d):(\d\d)", duration.strip())
             if not datematch:
                 raise MisconfigurationException(
                     f"`Timer(duration={interval!r})` is not a valid duration. Expected a string in the format DD:HH:MM:SS."

--- a/src/lightning/pytorch/callbacks/timer.py
+++ b/src/lightning/pytorch/callbacks/timer.py
@@ -17,6 +17,7 @@ Timer
 """
 
 import logging
+import re
 import time
 from datetime import timedelta
 from typing import Any, Dict, Optional, Union
@@ -50,6 +51,8 @@ class Timer(Callback):
         verbose: Set this to ``False`` to suppress logging messages.
 
     Raises:
+        MisconfigurationException:
+            If ``duration`` is not in the expected format.
         MisconfigurationException:
             If ``interval`` is not one of the supported choices.
 
@@ -86,9 +89,18 @@ class Timer(Callback):
     ) -> None:
         super().__init__()
         if isinstance(duration, str):
-            dhms = duration.strip().split(":")
-            dhms = [int(i) for i in dhms]
-            duration = timedelta(days=dhms[0], hours=dhms[1], minutes=dhms[2], seconds=dhms[3])
+            datematch = re.fullmatch(r"(\d+):(\d\d):(\d\d):(\d\d)", timestr.strip()):
+            if not datematch:
+                raise MisconfigurationException(
+                    f"Parameter value {interval!r} cannot be convert into duration. "
+                    "Expected DD:HH:MM:SS format."
+                )
+            duration = timedelta(
+                days=int(match.group(1)),
+                hours=int(match.group(2)),
+                minutes=int(match.group(3)),
+                seconds=int(match.group(4))
+            )
         if isinstance(duration, dict):
             duration = timedelta(**duration)
         if interval not in set(Interval):

--- a/src/lightning/pytorch/callbacks/timer.py
+++ b/src/lightning/pytorch/callbacks/timer.py
@@ -89,16 +89,16 @@ class Timer(Callback):
     ) -> None:
         super().__init__()
         if isinstance(duration, str):
-            datematch = re.fullmatch(r"(\d+):(\d\d):(\d\d):(\d\d)", timestr.strip())
+            datematch = re.fullmatch(r"(\d+):(\d\d):(\d\d):(\d\d)", duration.strip())
             if not datematch:
                 raise MisconfigurationException(
-                    f"Parameter value {interval!r} cannot be convert into duration. " "Expected DD:HH:MM:SS format."
+                    f"Parameter value {interval!r} cannot be convert into duration. Expected DD:HH:MM:SS format."
                 )
             duration = timedelta(
-                days=int(match.group(1)),
-                hours=int(match.group(2)),
-                minutes=int(match.group(3)),
-                seconds=int(match.group(4)),
+                days=int(datematch.group(1)),
+                hours=int(datematch.group(2)),
+                minutes=int(datematch.group(3)),
+                seconds=int(datematch.group(4)),
             )
         if isinstance(duration, dict):
             duration = timedelta(**duration)

--- a/tests/tests_pytorch/callbacks/test_timer.py
+++ b/tests/tests_pytorch/callbacks/test_timer.py
@@ -70,7 +70,7 @@ def test_timer_parse_duration(duration, expected):
 @pytest.mark.parametrize("duration", ["6:00:00", "60 minutes"])
 def test_timer_parse_duration_misconfiguration(duration):
     with pytest.raises(MisconfigurationException, match="Expected DD:HH:MM:SS format"):
-        timer = Timer(duration=duration)
+        Timer(duration=duration)
 
 
 def test_timer_interval_choice():

--- a/tests/tests_pytorch/callbacks/test_timer.py
+++ b/tests/tests_pytorch/callbacks/test_timer.py
@@ -69,7 +69,7 @@ def test_timer_parse_duration(duration, expected):
 
 @pytest.mark.parametrize("duration", ["6:00:00", "60 minutes"])
 def test_timer_parse_duration_misconfiguration(duration):
-    with pytest.raises(MisconfigurationException, match="DD:HH:MM:SS format"):
+    with pytest.raises(MisconfigurationException, match="format DD:HH:MM:SS"):
         Timer(duration=duration)
 
 

--- a/tests/tests_pytorch/callbacks/test_timer.py
+++ b/tests/tests_pytorch/callbacks/test_timer.py
@@ -67,6 +67,12 @@ def test_timer_parse_duration(duration, expected):
     assert (timer.time_remaining() == expected is None) or (timer.time_remaining() == expected.total_seconds())
 
 
+@pytest.mark.parametrize("duration", ["6:00:00", "60 minutes"])
+def test_timer_parse_duration_misconfiguration(duration):
+    with pytest.raises(MisconfigurationException, match="Expected DD:HH:MM:SS format"):
+        timer = Timer(duration=duration)
+
+
 def test_timer_interval_choice():
     Timer(duration=timedelta(), interval="step")
     Timer(duration=timedelta(), interval="epoch")

--- a/tests/tests_pytorch/callbacks/test_timer.py
+++ b/tests/tests_pytorch/callbacks/test_timer.py
@@ -69,7 +69,7 @@ def test_timer_parse_duration(duration, expected):
 
 @pytest.mark.parametrize("duration", ["6:00:00", "60 minutes"])
 def test_timer_parse_duration_misconfiguration(duration):
-    with pytest.raises(MisconfigurationException, match="Expected DD:HH:MM:SS format"):
+    with pytest.raises(MisconfigurationException, match="DD:HH:MM:SS format"):
         Timer(duration=duration)
 
 


### PR DESCRIPTION
## What does this PR do?

Failure to provide the timer duration string (e.g., via `--max_time`) in the appropriate format currently results in an uninformative IndexError. This uses a simple regex (and the built-in `re`) for more robust input validation and instead throws a misconfiguration exception.

I experimented with `datetime.strptime` for this, but it is not well-suited to the job because it is designed for absolute times, not deltas, and therefore does not support the idea of "0 days".

Fixes #19454.

I am submitting as is, but reviewers, feel free to recommend testing. 

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19513.org.readthedocs.build/en/19513/

<!-- readthedocs-preview pytorch-lightning end -->