### PR TITLE
Make `CSVLogger(name: ...)` optional `str`

### DIFF
--- a/src/lightning/pytorch/loggers/csv_logs.py
+++ b/src/lightning/pytorch/loggers/csv_logs.py
@@ -82,7 +82,8 @@ class CSVLogger(Logger, FabricCSVLogger):
 
     Args:
         save_dir: Save directory
-        name: Experiment name. Defaults to ``'lightning_logs'``.
+        name: Experiment name, optional. Defaults to ``'lightning_logs'``. If name is `None`, log
+            (versions) stored to the save dir directly.
         version: Experiment version. If version is not specified the logger inspects the save
             directory for existing versions, then automatically assigns the next available version.
         prefix: A string to put at the beginning of metric keys.
@@ -95,7 +96,7 @@ class CSVLogger(Logger, FabricCSVLogger):
     def __init__(
         self,
         save_dir: _PATH,
-        name: str = "lightning_logs",
+        name: Optional[str] = "lightning_logs",
         version: Optional[Union[int, str]] = None,
         prefix: str = "",
         flush_logs_every_n_steps: int = 100,


### PR DESCRIPTION
This patch adds `Optional` typing to the `name` parameter in `CSVLogger` reflecting the actual behavior. This increases coherence with other loggers and helps with type checking. Additionally documentation is improved.

This patch does NOT change the underlying behavior. Hence no additional tests were added. Tests already can be found in
tests/tests_pytorch/loggers/test_csv.py#L85-L90

Closes https://github.com/Lightning-AI/pytorch-lightning/issues/19433



<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [X] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [X] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
