### PR TITLE
[WIP BUT BLOCKED ON MAINTAINER OPINION] Bugfix/17958 multi optimizer step count behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ test: clean
 
 	# run tests with coverage
 	python -m coverage run --source src/lightning/pytorch -m pytest src/lightning/pytorch tests/tests_pytorch -v
+	python -m coverage run --source lightning/pytorch -m pytest ../tests/tests_pytorch/trainer ../tests/tests_pytorch/loops -v --ignore ../tests/tests_pytorch/models/test_onnx.py
+	python -m coverage run --source lightning/pytorch -m pytest tests/tests_pytorch/loops/optimization/test_manual_loop.py::test_multiple_optimizers -v -s
 	python -m coverage run --source src/lightning/app -m pytest tests/tests/app -v
 	python -m coverage run --source src/lightning/fabric -m pytest src/lightning/fabric tests/tests_fabric -v
 	python -m coverage report

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ test: clean
 
 	# run tests with coverage
 	python -m coverage run --source src/lightning/pytorch -m pytest src/lightning/pytorch tests/tests_pytorch -v
+	# DO NOT SUBMIT
 	python -m coverage run --source lightning/pytorch -m pytest ../tests/tests_pytorch/trainer ../tests/tests_pytorch/loops -v --ignore ../tests/tests_pytorch/models/test_onnx.py
 	python -m coverage run --source lightning/pytorch -m pytest tests/tests_pytorch/loops/optimization/test_manual_loop.py::test_multiple_optimizers -v -s
 	python -m coverage run --source src/lightning/app -m pytest tests/tests/app -v

--- a/docs/source-pytorch/model/manual_optimization.rst
+++ b/docs/source-pytorch/model/manual_optimization.rst
@@ -2,6 +2,7 @@
 Manual Optimization
 *******************
 
+.. DO NOT SUBMIT update + include example.
 For advanced research topics like reinforcement learning, sparse coding, or GAN research, it may be desirable to
 manually manage the optimization process, especially when dealing with multiple optimizers at the same time.
 

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -951,10 +951,15 @@ class LightningModule(
 
             - **Single optimizer**.
             - **List or Tuple** of optimizers.
-            - **Two lists** - The first list has multiple optimizers, and the second has multiple LR schedulers
-              (or multiple ``lr_scheduler_config``).
-            - **Dictionary**, with an ``"optimizer"`` key, and (optionally) a ``"lr_scheduler"``
-              key whose value is a single LR scheduler or ``lr_scheduler_config``.
+            - **Two lists** - The first list has one or more optimizers, and the second has one or more LR schedulers
+              (or ``lr_scheduler_config``s).
+            - **Dictionary**, with:
+                - an ``"optimizer"`` key
+                - an (optional) ``"lr_scheduler"`` key, whose value is an LR scheduler or ``lr_scheduler_config`` (one
+                  or a list of more)
+                - an (optional) ``"should_increment"`` key, which is only relevant for the manual optimization mode, see
+                  :ref:`manual optimization<common/optimization:Manual optimization>` 
+              
             - **None** - Fit will run without any optimizer.
 
         The ``lr_scheduler_config`` is a dictionary which contains the scheduler and its associated configuration.

--- a/src/lightning/pytorch/core/optimizer.py
+++ b/src/lightning/pytorch/core/optimizer.py
@@ -245,6 +245,16 @@ def _configure_optimizers(optim_conf: OptimizerLRScheduler) -> Tuple[List, List,
     # multiple dictionaries
     elif isinstance(optim_conf, (list, tuple)) and all(isinstance(d, dict) for d in optim_conf):
         optimizers, monitor, lr_schedulers, should_increment = [], [], [], []
+        
+        # DO NOT SUBMIT add a test for this case first that breaks
+        # If the user populated some `should_increment` but not all, the rest is assumed as `False`
+        # if (
+        #     any("should_increment" in optim_dict for optim_dict in optim_conf) and not
+        #     all("should_increment" in optim_dict for optim_dict in optim_conf)
+        # ):
+        #     for optim_dict in optim_conf:
+        #         optim_dict["should_increment"] = optim_dict.get("should_increment", False)
+            
         for optim_dict in optim_conf:
             opt, mon, lr_sch, incr = _handle_single_dict(optim_dict)
             optimizers.extend(opt)

--- a/src/lightning/pytorch/core/optimizer.py
+++ b/src/lightning/pytorch/core/optimizer.py
@@ -27,7 +27,7 @@ from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from lightning.pytorch.utilities.model_helpers import is_overridden
 from lightning.pytorch.utilities.rank_zero import rank_zero_warn
 from lightning.pytorch.utilities.signature_utils import is_param_in_hook_signature
-from lightning.pytorch.utilities.types import LRSchedulerConfig, LRSchedulerTypeTuple
+from lightning.pytorch.utilities.types import LRSchedulerConfig, LRSchedulerTypeTuple, OptimizerLRScheduler
 
 
 def do_nothing_closure() -> None:
@@ -50,6 +50,8 @@ class LightningOptimizer:
         # to inject logic around the optimizer step, particularly useful with manual optimization
         self._on_before_step = do_nothing_closure
         self._on_after_step = do_nothing_closure
+        # Only used on manual optimization to decide which optimizers count towards increasing the global step counter.
+        self._should_increment: Optional[bool] = None
         # imitate the class of the wrapped object to make isinstance checks work
         self.__class__ = type("Lightning" + optimizer.__class__.__name__, (self.__class__, optimizer.__class__), {})
 
@@ -157,12 +159,16 @@ class LightningOptimizer:
 
     @classmethod
     def _to_lightning_optimizer(
-        cls, optimizer: Union[Optimizer, "LightningOptimizer"], strategy: "pl.strategies.Strategy"
+        cls,
+        optimizer: Union[Optimizer, "LightningOptimizer"],
+        strategy: "pl.strategies.Strategy",
+        should_increment: Optional[bool] = None
     ) -> "LightningOptimizer":
         # the user could return a `LightningOptimizer` from `configure_optimizers`, see test:
         # tests/core/test_lightning_optimizer.py::test_lightning_optimizer[False]
         lightning_optimizer = optimizer if isinstance(optimizer, LightningOptimizer) else cls(optimizer)
         lightning_optimizer._strategy = proxy(strategy)
+        lightning_optimizer_should_increment = should_increment
         return lightning_optimizer
 
     def __getattr__(self, item: Any) -> Any:
@@ -171,7 +177,7 @@ class LightningOptimizer:
 
 def _init_optimizers_and_lr_schedulers(
     model: "pl.LightningModule",
-) -> Tuple[List[Optimizer], List[LRSchedulerConfig]]:
+) -> Tuple[List[Optimizer], List[LRSchedulerConfig], Optional[List[bool]]]:
     """Calls `LightningModule.configure_optimizers` and parses and validates the output."""
     from lightning.pytorch.trainer import call
 
@@ -183,7 +189,7 @@ def _init_optimizers_and_lr_schedulers(
         )
         optim_conf = _MockOptimizer()
 
-    optimizers, lr_schedulers, monitor = _configure_optimizers(optim_conf)
+    optimizers, lr_schedulers, monitor, should_increment = _configure_optimizers(optim_conf)
     lr_scheduler_configs = (
         _configure_schedulers_automatic_opt(lr_schedulers, monitor)
         if model.automatic_optimization
@@ -192,19 +198,36 @@ def _init_optimizers_and_lr_schedulers(
     _validate_multiple_optimizers_support(optimizers, model)
     _validate_optimizers_attached(optimizers, lr_scheduler_configs)
     _validate_scheduler_api(lr_scheduler_configs, model)
-    return optimizers, lr_scheduler_configs
+    return optimizers, lr_scheduler_configs, should_increment
 
-
-def _configure_optimizers(
-    optim_conf: Union[Dict[str, Any], List, Optimizer, Tuple],
-) -> Tuple[List, List, Optional[str]]:
+def _configure_optimizers(optim_conf: OptimizerLRScheduler) -> Tuple[List, List, Optional[str], Optional[List]]:
     optimizers, lr_schedulers = [], []
     monitor = None
+    should_increment = None
+    _as_list = lambda values : list(values) if isinstance(values, (list, tuple)) else [values]
+
+    def _handle_single_dict(optim_conf: dict)  -> Tuple[List, List, Optional[str], Optional[List]]:
+        _validate_optim_conf_dict(optim_conf)
+        optimizers = _as_list(optim_conf["optimizer"])
+        monitor = optim_conf.get("monitor", None)
+        lr_schedulers = _as_list(optim_conf.get("lr_scheduler", []))
+        should_increment = optim_conf.get("should_increment", None)
+        if should_increment and len(optimizers) > len(_as_list(should_increment)):
+            # `_validate_optim_conf_dict` checks `should_increment` to have length 1 if list
+            single_val = should_increment[0] if isinstance(should_increment, (list, tuple)) else should_increment
+            should_increment = [single_val for _ in optimizers]
+        return optimizers, monitor, lr_schedulers, should_increment
+
 
     # single output, single optimizer
     if isinstance(optim_conf, Optimizable):
         optimizers = [optim_conf]
-    # two lists, optimizer + lr schedulers
+    
+    # single list or tuple of one or more optimizers
+    elif isinstance(optim_conf, (list, tuple)) and all(isinstance(opt, Optimizable) for opt in optim_conf):
+        optimizers = list(optim_conf)
+    
+    # two lists, optimizer(s) + lr scheduler(s)
     elif (
         isinstance(optim_conf, (list, tuple))
         and len(optim_conf) == 2
@@ -214,24 +237,29 @@ def _configure_optimizers(
         opt, sch = optim_conf
         optimizers = opt
         lr_schedulers = sch if isinstance(sch, list) else [sch]
+    
     # single dictionary
     elif isinstance(optim_conf, dict):
-        _validate_optim_conf(optim_conf)
-        optimizers = [optim_conf["optimizer"]]
-        monitor = optim_conf.get("monitor", None)
-        lr_schedulers = [optim_conf["lr_scheduler"]] if "lr_scheduler" in optim_conf else []
+        optimizers, monitor, lr_schedulers, should_increment = _handle_single_dict(optim_conf)
+        
     # multiple dictionaries
     elif isinstance(optim_conf, (list, tuple)) and all(isinstance(d, dict) for d in optim_conf):
-        for opt_dict in optim_conf:
-            _validate_optim_conf(opt_dict)
-        optimizers = [opt_dict["optimizer"] for opt_dict in optim_conf]
-        scheduler_dict = lambda scheduler: dict(scheduler) if isinstance(scheduler, dict) else {"scheduler": scheduler}
-        lr_schedulers = [
-            scheduler_dict(opt_dict["lr_scheduler"]) for opt_dict in optim_conf if "lr_scheduler" in opt_dict
-        ]
-    # single list or tuple, multiple optimizer
-    elif isinstance(optim_conf, (list, tuple)) and all(isinstance(opt, Optimizable) for opt in optim_conf):
-        optimizers = list(optim_conf)
+        optimizers, monitor, lr_schedulers, should_increment = [], [], [], []
+        for optim_dict in optim_conf:
+            opt, mon, lr_sch, incr = _handle_single_dict(optim_dict)
+            optimizers.extend(opt)
+            lr_schedulers.extend(lr_sch)
+            if mon:
+                monitor.extend(mon)
+            if incr:
+                should_increment.extend(incr)
+        
+        # reset empty lists to None
+        if not monitor:
+            monitor = None
+        if not should_increment:
+            should_increment = None
+    
     # unknown configuration
     else:
         raise MisconfigurationException(
@@ -242,7 +270,7 @@ def _configure_optimizers(
             " * ([`Optimizer`], [`LRScheduler`])\n"
             ' * {"optimizer": `Optimizer`, (optional) "lr_scheduler": `LRScheduler`}\n'
         )
-    return optimizers, lr_schedulers, monitor
+    return optimizers, lr_schedulers, monitor, should_increment
 
 
 def _configure_schedulers_automatic_opt(schedulers: list, monitor: Optional[str]) -> List[LRSchedulerConfig]:
@@ -369,13 +397,30 @@ def _validate_optimizers_attached(optimizers: List[Optimizer], lr_scheduler_conf
             )
 
 
-def _validate_optim_conf(optim_conf: Dict[str, Any]) -> None:
-    valid_keys = {"optimizer", "lr_scheduler", "monitor"}
+def _validate_optim_conf_dict(optim_conf: Dict[str, Any]) -> None:
+    # DO NOT SUBMIT there are prob some tests for this, add increments_step there
+    valid_keys = {"optimizer", "lr_scheduler", "monitor", "should_increment"}
     extra_keys = optim_conf.keys() - valid_keys
     if extra_keys:
         rank_zero_warn(
             f"Found unsupported keys in the optimizer configuration: {set(extra_keys)}", category=RuntimeWarning
         )
+    if (
+        "should_increment" in optim_conf and
+        isinstance(optim_conf["should_increment"], (list, tuple)) and
+        len(optim_conf["should_increment"]) > 1
+    ):
+        # length needs to match optimizers length 
+        if (
+            not isinstance(optim_conf["optimizer"], (list, tuple)) or
+            len(optim_conf["should_increment"]) != len(optim_conf["optimizer"])
+        ):
+            num_opt = len(optim_conf["optimizer"]) if isinstance(optim_conf["optimizer"], (list, tuple)) else 1
+            rank_zero_warn(
+                f"`should_increment` values should equal number of optimizers it is passed along with," \
+                f" but found {optim_conf['should_increment']} (len={len(optim_conf["should_increment"])}) and" \
+                f" {num_opt} optimizers", category=RuntimeWarning
+            )
 
 
 class _MockOptimizer(Optimizer):

--- a/src/lightning/pytorch/loops/__init__.py
+++ b/src/lightning/pytorch/loops/__init__.py
@@ -14,6 +14,4 @@
 from lightning.pytorch.loops.loop import _Loop  # noqa: F401 isort: skip (avoids circular imports)
 from lightning.pytorch.loops.evaluation_loop import _EvaluationLoop  # noqa: F401
 from lightning.pytorch.loops.fit_loop import _FitLoop  # noqa: F401
-from lightning.pytorch.loops.optimization import _AutomaticOptimization, _ManualOptimization  # noqa: F401
 from lightning.pytorch.loops.prediction_loop import _PredictionLoop  # noqa: F401
-from lightning.pytorch.loops.training_epoch_loop import _TrainingEpochLoop  # noqa: F401

--- a/src/lightning/pytorch/loops/fit_loop.py
+++ b/src/lightning/pytorch/loops/fit_loop.py
@@ -68,9 +68,15 @@ class _FitLoop(_Loop):
             ...
 
     Args:
-        min_epochs: The minimum number of epochs
-        max_epochs: The maximum number of epochs, can be set -1 to turn this limit off
-
+        min_epochs: The minimum number of epochs, default 0
+        max_epochs: The maximum number of epochs, disabled by default (``None``).
+            If both ``max_epochs`` and ``max_steps`` are not specified,
+            :class:`~lightning.pytorch.trainer.trainer.Trainer` will default to ``max_epochs = 1000``.
+            To enable infinite training, set ``max_epochs = -1``.
+        min_steps: Force training for at least these number of steps. Disabled by default (``None``)
+        max_steps: Stop training after this number of steps. Disabled by default (-1). If ``max_steps = -1``
+            and ``max_epochs = None``, :class:`~lightning.pytorch.trainer.trainer.Trainer` will default to
+            ``max_epochs = 1000``. To enable infinite training, set ``max_epochs`` to ``-1``
     """
 
     def __init__(
@@ -78,6 +84,8 @@ class _FitLoop(_Loop):
         trainer: "pl.Trainer",
         min_epochs: Optional[int] = 0,
         max_epochs: Optional[int] = None,
+        min_steps: Optional[int] = None,
+        max_steps: int = -1,
     ) -> None:
         super().__init__(trainer)
         if isinstance(max_epochs, int) and max_epochs < -1:
@@ -88,7 +96,7 @@ class _FitLoop(_Loop):
 
         self.max_epochs = max_epochs
         self.min_epochs = min_epochs
-        self.epoch_loop = _TrainingEpochLoop(trainer)
+        self.epoch_loop = _TrainingEpochLoop(trainer, min_steps, max_steps)
         self.epoch_progress = _Progress()
         self.max_batches: Union[int, float] = float("inf")
 

--- a/src/lightning/pytorch/strategies/deepspeed.py
+++ b/src/lightning/pytorch/strategies/deepspeed.py
@@ -457,7 +457,7 @@ class DeepSpeedStrategy(DDPStrategy):
 
     def _init_optimizers(self) -> Tuple[Optimizer, Optional[LRSchedulerConfig]]:
         assert self.lightning_module is not None
-        optimizers, lr_schedulers = _init_optimizers_and_lr_schedulers(self.lightning_module)
+        optimizers, lr_schedulers, _ = _init_optimizers_and_lr_schedulers(self.lightning_module)
         if len(optimizers) > 1 or len(lr_schedulers) > 1:
             raise MisconfigurationException(
                 "DeepSpeed currently only supports single optimizer, single optional scheduler."

--- a/src/lightning/pytorch/strategies/strategy.py
+++ b/src/lightning/pytorch/strategies/strategy.py
@@ -111,7 +111,8 @@ class Strategy(ABC):
         # having only the last of all optimizers count towards the global step counter, so that if all optimizers are called during
         for opt in self._lightning_optimizers:
             opt._should_increment = False
-        self._lightning_optimizers[-1]._should_increment = True
+        if len(self._lightning_optimizers) >= 1:
+            self._lightning_optimizers[-1]._should_increment = True
     
     def _set_optimizers_with_should_increments(self, optimizers: List[Optimizer], should_increment: List[bool]) -> None:
         """Relevant only for manual optimization loop, in which case the user can manually set for each optimizer

--- a/src/lightning/pytorch/strategies/strategy.py
+++ b/src/lightning/pytorch/strategies/strategy.py
@@ -107,6 +107,18 @@ class Strategy(ABC):
     def optimizers(self, optimizers: List[Optimizer]) -> None:
         self._optimizers = optimizers
         self._lightning_optimizers = [LightningOptimizer._to_lightning_optimizer(opt, self) for opt in optimizers]
+        # The below is only relevant for the manual optimization loop, when for each optimizer it needs back to DO NOT SUBMIT
+        # having only the last of all optimizers count towards the global step counter, so that if all optimizers are called during
+        for opt in self._lightning_optimizers:
+            opt._should_increment = False
+        self._lightning_optimizers[-1]._should_increment = True
+    
+    def _set_optimizers_with_should_increments(self, optimizers: List[Optimizer], should_increment: List[bool]) -> None:
+        """Relevant only for manual optimization loop, in which case the user can manually set for each optimizer
+        whether it counts towards incrementing the global step counter.
+        """
+        self._optimizers = optimizers
+        self._lightning_optimizers = [LightningOptimizer._to_lightning_optimizer(opt, self, incr) for opt, incr in zip(optimizers, should_increment)]
 
     def connect(self, model: "pl.LightningModule") -> None:
         """Called by the Trainer to connect the strategy with the model."""
@@ -136,7 +148,12 @@ class Strategy(ABC):
 
         """
         assert self.lightning_module is not None
-        self.optimizers, self.lr_scheduler_configs = _init_optimizers_and_lr_schedulers(self.lightning_module)
+        optimizers, self.lr_scheduler_configs, should_increment = _init_optimizers_and_lr_schedulers(self.lightning_module)
+        if not should_increment:
+            self.optimizers = optimizers
+        else:
+            self._set_optimizers_with_should_increments(optimizers, should_increment)
+
 
     def setup(self, trainer: "pl.Trainer") -> None:
         """Sets up the accelerator, plugins and initializes the optimizers (if needed).

--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -44,7 +44,7 @@ from lightning.pytorch.loggers import Logger
 from lightning.pytorch.loggers.csv_logs import CSVLogger
 from lightning.pytorch.loggers.tensorboard import TensorBoardLogger
 from lightning.pytorch.loggers.utilities import _log_hyperparams
-from lightning.pytorch.loops import _PredictionLoop, _TrainingEpochLoop
+from lightning.pytorch.loops import _PredictionLoop
 from lightning.pytorch.loops.evaluation_loop import _EvaluationLoop
 from lightning.pytorch.loops.fit_loop import _FitLoop
 from lightning.pytorch.loops.utilities import _parse_loop_limits, _reset_progress
@@ -168,11 +168,11 @@ class Trainer:
                 of train, val and test to find any bugs (ie: a sort of unit test).
                 Default: ``False``.
 
-            max_epochs: Stop training once this number of epochs is reached. Disabled by default (None).
+            max_epochs: Stop training once this number of epochs is reached. Disabled by default (``None``).
                 If both max_epochs and max_steps are not specified, defaults to ``max_epochs = 1000``.
                 To enable infinite training, set ``max_epochs = -1``.
 
-            min_epochs: Force training for at least these many epochs. Disabled by default (None).
+            min_epochs: Force training for at least these many epochs. Disabled by default (``None``).
 
             max_steps: Stop training after this number of steps. Disabled by default (-1). If ``max_steps = -1``
                 and ``max_epochs = None``, will default to ``max_epochs = 1000``. To enable infinite training, set
@@ -416,8 +416,7 @@ class Trainer:
         self._signal_connector = _SignalConnector(self)
 
         # init loops
-        self.fit_loop = _FitLoop(self, min_epochs=min_epochs, max_epochs=max_epochs)
-        self.fit_loop.epoch_loop = _TrainingEpochLoop(self, min_steps=min_steps, max_steps=max_steps)
+        self.fit_loop = _FitLoop(self, min_epochs=min_epochs, max_epochs=max_epochs, min_steps=min_steps, max_steps=max_steps)
         self.validate_loop = _EvaluationLoop(
             self, TrainerFn.VALIDATING, RunningStage.VALIDATING, inference_mode=inference_mode
         )

--- a/src/lightning/pytorch/utilities/types.py
+++ b/src/lightning/pytorch/utilities/types.py
@@ -112,6 +112,7 @@ class LRSchedulerConfigType(TypedDict, total=False):
 class OptimizerLRSchedulerConfig(TypedDict):
     optimizer: Optimizer
     lr_scheduler: NotRequired[Union[LRSchedulerTypeUnion, LRSchedulerConfigType]]
+    should_increment: NotRequired[Union[bool, Sequence[bool]]]
 
 
 OptimizerLRScheduler = Optional[

--- a/tests/tests_pytorch/loops/optimization/test_manual_loop.py
+++ b/tests/tests_pytorch/loops/optimization/test_manual_loop.py
@@ -11,12 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Any
+
 import pytest
 import torch
+
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel
 from lightning.pytorch.loops.optimization.manual import ManualResult
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
+from lightning.pytorch.utilities.types import STEP_OUTPUT
 
 
 def test_manual_result():
@@ -42,3 +46,67 @@ def test_warning_invalid_trainstep_output(tmpdir):
 
     with pytest.raises(MisconfigurationException, match="return a Tensor or have no return"):
         trainer.fit(model)
+
+
+class MultiOptimizerModel(BoringModel):
+    def __init__(self) -> None:
+        # This initializes `BoringModel`'s parent, but skips `BoringModel`
+        # itself (as we don't need its `layer`)
+        super(BoringModel, self).__init__()
+        self.layer_1 = torch.nn.Linear(32, 4)
+        self.layer_2 = torch.nn.Linear(4, 2)
+        self.layer_3 = torch.nn.Linear(2, 1)
+        self.automatic_optimization=False
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layer_3(torch.relu(self.layer_2(torch.relu(self.layer_1(x)))))
+
+    def training_step(self, batch: Any, batch_idx: int) -> STEP_OUTPUT:
+        # self.optimizers().zero_grad()
+        for i, opt in enumerate(self.optimizers()):
+            opt.zero_grad()
+            # if i+1 < len(self.optimizers()):
+            #     opt._on_before_step = lambda : self.trainer.profiler.start("optimizer_step")
+            #     opt._on_after_step = lambda : self.trainer.profiler.stop("optimizer_step")
+        
+        loss = self.step(batch)
+        self.manual_backward(loss)
+        
+        # self.optimizers().step()
+        for opt in self.optimizers():
+            opt.step()
+        return {"loss": loss}
+    
+    # DO NOT SUBMIT add a note in PR about not seeing the point of resetting
+    # the opt._on_be/af back to do_nothing_closure
+
+    # def on_train_batch_end(self, outputs: STEP_OUTPUT, batch: Any, batch_idx: int) -> None:
+    #     for sch in self.lr_schedulers():
+    #         sch.step()
+
+    def configure_optimizers(self):
+        opt1 = torch.optim.SGD(self.layer_1.parameters(), lr=0.1)
+        opt2 = torch.optim.SGD(self.layer_2.parameters(), lr=0.2)
+        opt3 = torch.optim.SGD(self.layer_3.parameters(), lr=0.3)
+        # lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+        # increments_step
+        # test single dict with multi schedulers
+        return (
+            {'optimizer': [opt1, opt2], 'should_increment': [True, False]},
+            {'optimizer': [opt3], 'should_increment': False}
+        )
+
+# DO NOT SUBMIT: Parameterize to test default=no extra, explicit=is extra steps
+def test_multiple_optimizers(tmpdir):
+    # Tests the global number of steps interaction with multiple optimizers,
+    # as well as that multiple optimizers are still all run.
+    model = MultiOptimizerModel()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        limit_train_batches=2,
+        limit_val_batches=1,
+    )
+    trainer.fit(model)
+    print(trainer.global_step)
+    assert trainer.global_step == 4

--- a/tests/tests_pytorch/trainer/optimization/test_optimizers.py
+++ b/tests/tests_pytorch/trainer/optimization/test_optimizers.py
@@ -179,7 +179,7 @@ def test_optimizer_return_options(tmpdir):
 
     # single optimizer
     model.configure_optimizers = lambda: opt_a
-    opt, lr_sched = _init_optimizers_and_lr_schedulers(model)
+    opt, lr_sched, _ = _init_optimizers_and_lr_schedulers(model)
     assert len(opt) == 1
     assert len(lr_sched) == 0
 


### PR DESCRIPTION
# PR UNFINISHED BUT MAJOR SETUP READY FOR REVIEW TO DISCUSS HOW TO CONTINUE
(before updating docs & tests in vain in case community/maintainers settle on a different approach)


## What does this PR do?

### Background

Pre this PR, in a setup using multiple optimizers (and thus a manual optimization loop) each optimizer contributes to the global step counter.

For many people this is unexpected (see #\17958), as (my conjecture) the default expectation [1] is that each call to `training_step` counts as 1 increment to `trainer.global_step`

This unexpected behaviour can easily go unnoticed, and leads issues:
- `global_step` based logic (e.g. logging, manual lr schedulers, etc.) is unexpected/wrong (in the eye of the user who does not expect this behaviour)
- Personal case: I used two optimizers for two halves of my model, calling `step` on both in each `training_step`, which somehow indirectly caused my gradients to become 0: My model stopped training without me initially realizing why. The quick fix mentioned in #\17958 immediately resolved this again..

### Proposed behaviour
- In line with this expectation, the default mode could be (without the user having to do anything), according to Pytorch Lightning's _One less thing to remember_, only the last optimizer (order as provided by the user) incrementing the counter. (perfect for less complicated use cases, e.g. having multiple optimizers for parts of the model and for each optimizer its `step` being called in each `training_step`)
- For more complicated setting with e.g. GAN's users can specify themselves how they want the `global_step` to behave (by updating the documentation accordingly)

### Actual PR implications
The current PR does NOT implement expectation [1] per se. Instead, its a simpler update in that direction that yet allows for likely sufficient versatility (If there is a single incrementing optimizer, number of calls to `training_step` can still be misaligned if said optimizer is not called each step or multiple times per step)
- it implements the logic for a user to specify which optimizers should count towards the `global_step` counter
- it takes the default (user does not specify anything) as only the last optimizer incrementing (in line with above *Proposed behaviour*)

### Alternative solutions:
- `trainer.global_step` can be separated from optimizers and just a counter for the number of function calls. Clean on the surface, this sounds more invasive under the hood (expecting there was a good reason to make it according to `opt.steps()` calls and not `training_step` function calls)
- Same PR but different 'default' e.g. prevent change of behaviour going forward (see below in breaking) and instead having the above proposed 'default' instead as an option

Fixes #\17958

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->
Indirectly: this changes the `global_step` counter and thus changes behaviour. Anybody who *does not* expect the former behaviour will have their counter fixed and making sense to them, anybody who *does* expect the former behaviour has to update their `configure_optimizers` to have that behaviour persist.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [wip] Did you make sure to **update the documentation** with your changes? (if necessary)
- [wip] Did you write any **new necessary tests**? (not for typos and docs)
- [wip] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ]Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->