### PR TITLE
Fix PTL2.2 saving multiple *-last.ckpt checkpoints in resumed training

### DIFF
--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -779,7 +779,7 @@ class ModelCheckpoint(Checkpoint):
         A checkpoint won't be deleted if any of the cases apply:
         - The previous checkpoint is the same as the current checkpoint (means the old was already overwritten by new)
         - The previous checkpoint is not in the current checkpoint directory and the filesystem is local
-        - The previous checkpoint is the checkpoint the Trainer resumed from and the filesystem is local
+        - The previous checkpoint is the checkpoint the Trainer resumed from and the filesystem is local and not -last.ckpt
 
         """
         if previous == current:
@@ -789,7 +789,11 @@ class ModelCheckpoint(Checkpoint):
         previous = Path(previous).absolute()
         resume_path = Path(trainer.ckpt_path).absolute() if trainer.ckpt_path is not None else None
         if resume_path is not None and previous == resume_path:
-            return False
+            if str(current).endswith("-last.ckpt") and resume_path.name.endswith("-last.ckpt"):
+                # delete the previous `-last.ckpt` checkpoint when current saved checkpoint is also `-last.ckpt`, if they're in the same directory
+                pass
+            else:
+                return False
         assert self.dirpath is not None
         dirpath = Path(self.dirpath).absolute()
         return dirpath in previous.parents

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -779,7 +779,7 @@ class ModelCheckpoint(Checkpoint):
         A checkpoint won't be deleted if any of the cases apply:
         - The previous checkpoint is the same as the current checkpoint (means the old was already overwritten by new)
         - The previous checkpoint is not in the current checkpoint directory and the filesystem is local
-        - The previous checkpoint is the checkpoint the Trainer resumed from and the filesystem is local 
+        - The previous checkpoint is the checkpoint the Trainer resumed from and the filesystem is local
           and not resume_path and current are both -last.ckpt
 
         """
@@ -791,7 +791,7 @@ class ModelCheckpoint(Checkpoint):
         resume_path = Path(trainer.ckpt_path).absolute() if trainer.ckpt_path is not None else None
         if resume_path is not None and previous == resume_path:
             if str(current).endswith("-last.ckpt") and resume_path.name.endswith("-last.ckpt"):
-                # delete the previous `-last.ckpt` checkpoint when current saved checkpoint 
+                # delete the previous `-last.ckpt` checkpoint when current saved checkpoint
                 # is also `-last.ckpt`, if they're in the same directory
                 pass
             else:

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -780,7 +780,7 @@ class ModelCheckpoint(Checkpoint):
         - The previous checkpoint is the same as the current checkpoint (means the old was already overwritten by new)
         - The previous checkpoint is not in the current checkpoint directory and the filesystem is local
         - The previous checkpoint is the checkpoint the Trainer resumed from and the filesystem is local
-          and not resume_path and current are both -last.ckpt
+          and not resume_path and current are both last checkpoints
 
         """
         if previous == current:
@@ -790,9 +790,9 @@ class ModelCheckpoint(Checkpoint):
         previous = Path(previous).absolute()
         resume_path = Path(trainer.ckpt_path).absolute() if trainer.ckpt_path is not None else None
         if resume_path is not None and previous == resume_path:
-            if str(current).endswith("-last.ckpt") and resume_path.name.endswith("-last.ckpt"):
-                # delete the previous `-last.ckpt` checkpoint when current saved checkpoint
-                # is also `-last.ckpt`, if they're in the same directory
+            if str(current).endswith("last.ckpt") and resume_path.name.endswith("last.ckpt"):
+                # delete the previous `last.ckpt` checkpoint when current saved checkpoint
+                # is also `*last.ckpt`, if they're in the same directory
                 pass
             else:
                 return False

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -779,7 +779,8 @@ class ModelCheckpoint(Checkpoint):
         A checkpoint won't be deleted if any of the cases apply:
         - The previous checkpoint is the same as the current checkpoint (means the old was already overwritten by new)
         - The previous checkpoint is not in the current checkpoint directory and the filesystem is local
-        - The previous checkpoint is the checkpoint the Trainer resumed from and the filesystem is local and not -last.ckpt
+        - The previous checkpoint is the checkpoint the Trainer resumed from and the filesystem is local 
+          and not resume_path and current are both -last.ckpt
 
         """
         if previous == current:
@@ -790,7 +791,8 @@ class ModelCheckpoint(Checkpoint):
         resume_path = Path(trainer.ckpt_path).absolute() if trainer.ckpt_path is not None else None
         if resume_path is not None and previous == resume_path:
             if str(current).endswith("-last.ckpt") and resume_path.name.endswith("-last.ckpt"):
-                # delete the previous `-last.ckpt` checkpoint when current saved checkpoint is also `-last.ckpt`, if they're in the same directory
+                # delete the previous `-last.ckpt` checkpoint when current saved checkpoint 
+                # is also `-last.ckpt`, if they're in the same directory
                 pass
             else:
                 return False


### PR DESCRIPTION
## What does this PR do?

Fix PTL2.2 saving multiple *-last.ckpt checkpoints in resumed training.

In current PTL2.2 model_checkpoint.py, it doesn't delete the previous `*-last.ckpt` checkpoint that the model was resumed on when saving a new `*-last.ckpt` checkpoint, which results in multiple checkpoints. This will cause errors of "multiple *-last.ckpt checkpoints" when trying to resume from a previous job (first time resume is fine since there's one -last.ckpt, second time resume will crash due to multiple -last.ckpt).

The fix is to check whether the checkpoint to be saved is a `-last.ckpt` checkpoint and the model is resumed from a `-last.ckpt` checkpoint. If it is, delete the previous -last.ckpt if they are under the same directory.



