### PR TITLE
Fixes incorrect strategy init with HPUAccelerator

### DIFF
--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -408,13 +408,16 @@ class _AcceleratorConnector:
         return LightningEnvironment()
 
     def _choose_strategy(self) -> Union[Strategy, str]:
-        if self._accelerator_flag == "hpu":
-            if not _habana_available_and_importable():
+        try:
+            from lightning_habana import HPUAccelerator
+        except ImportError as exc:
+            if self._accelerator_flag == "hpu" and not _habana_available_and_importable():
                 raise ImportError(
                     "You have asked for HPU but you miss install related integration."
                     " Please run `pip install lightning-habana` or see for further instructions"
                     " in https://github.com/Lightning-AI/lightning-Habana/."
-                )
+                ) from exc
+        if self._accelerator_flag == "hpu" or isinstance(self._accelerator_flag, HPUAccelerator):
             if self._parallel_devices and len(self._parallel_devices) > 1:
                 from lightning_habana import HPUParallelStrategy
 

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -422,8 +422,8 @@ class _AcceleratorConnector:
                 return SingleHPUStrategy(device=torch.device("hpu"))
         if self._accelerator_flag == "hpu" and not _habana_available_and_importable():
             raise ImportError(
-                "You have asked for HPU but you miss install related integration."
-                " Please run `pip install lightning-habana` or see for further instructions"
+                "You asked to run with HPU but you are missing a required dependency."
+                " Please run `pip install lightning-habana` or seek further instructions"
                 " in https://github.com/Lightning-AI/lightning-Habana/."
             )
 


### PR DESCRIPTION
## What does this PR do?
Fixes for incorrect strategy init with HPUAccelerator 
Accelerator_connector only picks correct "auto" strategy when accelerator is set as "hpu". setting it with class instance fails this check and it sets default strategy from SingleDeviceStrategy / DDPStrategy instead of SingleHPUStrategy / ParallelHPUStrategy.

Fixes #19614 

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19615.org.readthedocs.build/en/19615/

<!-- readthedocs-preview pytorch-lightning end -->