### PR TITLE
Skip failing tests due to dependencies

### DIFF
--- a/tests/tests_pytorch/models/test_hparams.py
+++ b/tests/tests_pytorch/models/test_hparams.py
@@ -15,6 +15,7 @@ import copy
 import functools
 import os
 import pickle
+import sys
 from argparse import Namespace
 from dataclasses import dataclass
 from enum import Enum
@@ -36,6 +37,9 @@ from lightning.pytorch.utilities.imports import _OMEGACONF_AVAILABLE
 from lightning_utilities.core.imports import RequirementCache
 from lightning_utilities.test.warning import no_warning_call
 from torch.utils.data import DataLoader
+
+_PYTHON_GREATER_EQUAL_3_9_0 = (sys.version_info.major, sys.version_info.minor) >= (3, 9)
+
 
 from tests_pytorch.helpers.runif import RunIf
 
@@ -697,6 +701,14 @@ def test_model_with_fsspec_as_parameter(tmpdir):
     trainer.test()
 
 
+@pytest.mark.xfail(
+    # AttributeError: 'OrphanPath' object has no attribute 'exists'
+    # Issue with `importlib_resources>=6.2.0`
+    raises=AttributeError,
+    condition=(not _PYTHON_GREATER_EQUAL_3_9_0),
+    reason="Issue with `importlib_resources`",
+    strict=False,
+)
 @pytest.mark.skipif(RequirementCache("hydra-core<1.1"), reason="Requires Hydra's Compose API")
 def test_model_save_hyper_parameters_interpolation_with_hydra(tmpdir):
     """This test relies on configuration saved under tests/models/conf/config.yaml."""

--- a/tests/tests_pytorch/models/test_hparams.py
+++ b/tests/tests_pytorch/models/test_hparams.py
@@ -38,14 +38,13 @@ from lightning_utilities.core.imports import RequirementCache
 from lightning_utilities.test.warning import no_warning_call
 from torch.utils.data import DataLoader
 
-_PYTHON_GREATER_EQUAL_3_9_0 = (sys.version_info.major, sys.version_info.minor) >= (3, 9)
-
-
 from tests_pytorch.helpers.runif import RunIf
 
 if _OMEGACONF_AVAILABLE:
     from omegaconf import Container, OmegaConf
     from omegaconf.dictconfig import DictConfig
+
+_PYTHON_GREATER_EQUAL_3_9_0 = (sys.version_info.major, sys.version_info.minor) >= (3, 9)
 
 
 class SaveHparamsModel(BoringModel):

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -1536,7 +1536,10 @@ def test_comet_logger_init_args():
 
 @pytest.mark.xfail(
     # Only on Windows: TypeError: 'NoneType' object is not subscriptable
-    raises=TypeError, condition=(sys.platform == "win32"), strict=False, reason="TypeError on Windows when parsing"
+    raises=TypeError,
+    condition=(sys.platform == "win32"),
+    strict=False,
+    reason="TypeError on Windows when parsing",
 )
 def test_neptune_logger_init_args():
     _test_logger_init_args(

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -1534,6 +1534,7 @@ def test_comet_logger_init_args():
     )
 
 
+@pytest.mark.xfail(raises=TypeError, condition=(sys.platform == "win32"), strict=False)
 def test_neptune_logger_init_args():
     _test_logger_init_args(
         "NeptuneLogger",

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -1534,7 +1534,10 @@ def test_comet_logger_init_args():
     )
 
 
-@pytest.mark.xfail(raises=TypeError, condition=(sys.platform == "win32"), strict=False)
+@pytest.mark.xfail(
+    # Only on Windows: TypeError: 'NoneType' object is not subscriptable
+    raises=TypeError, condition=(sys.platform == "win32"), strict=False, reason="TypeError on Windows when parsing"
+)
 def test_neptune_logger_init_args():
     _test_logger_init_args(
         "NeptuneLogger",


### PR DESCRIPTION
## What does this PR do?

To unblock merging PRs.

## Issue 1

First seen here:
https://github.com/Lightning-AI/pytorch-lightning/actions/runs/8202388781/job/22563675151?pr=19524
I don't know what's up.


## Issue 2

On Python 3.8, failing test `test_model_save_hyper_parameters_interpolation_with_hydra`. Hydra depends on `importlib_resources` which recently released a new version and caused the error below on Python 3.8.
```
____________________________________________________ test_model_save_hyper_parameters_interpolation_with_hydra _____________________________________________________

tmpdir = local('/private/var/folders/q9/0cmn_hsd4ys18k3l6ks4gg_m0000gn/T/pytest-of-adrian/pytest-381/test_model_save_hyper_paramete0')

    @pytest.mark.skipif(RequirementCache("hydra-core<1.1"), reason="Requires Hydra's Compose API")
    def test_model_save_hyper_parameters_interpolation_with_hydra(tmpdir):
        """This test relies on configuration saved under tests/models/conf/config.yaml."""
        from hydra import compose, initialize
    
        class TestHydraModel(BoringModel):
            def __init__(self, args_0, args_1, args_2, kwarg_1=None):
                self.save_hyperparameters()
                assert self.hparams.args_0.log == "Something"
                assert self.hparams.args_1["cfg"].log == "Something"
                assert self.hparams.args_2[0].log == "Something"
                assert self.hparams.kwarg_1["cfg"][0].log == "Something"
                super().__init__()
    
        with initialize(config_path="conf"):
>           args_0 = compose(config_name="config")

tests/tests_pytorch/models/test_hparams.py:727: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../miniconda3/envs/lightning38/lib/python3.8/site-packages/hydra/compose.py:38: in compose
    cfg = gh.hydra.compose_config(
../../miniconda3/envs/lightning38/lib/python3.8/site-packages/hydra/_internal/hydra.py:594: in compose_config
    cfg = self.config_loader.load_configuration(
../../miniconda3/envs/lightning38/lib/python3.8/site-packages/hydra/_internal/config_loader_impl.py:142: in load_configuration
    return self._load_configuration_impl(
../../miniconda3/envs/lightning38/lib/python3.8/site-packages/hydra/_internal/config_loader_impl.py:244: in _load_configuration_impl
    parsed_overrides, caching_repo = self._parse_overrides_and_create_caching_repo(
../../miniconda3/envs/lightning38/lib/python3.8/site-packages/hydra/_internal/config_loader_impl.py:230: in _parse_overrides_and_create_caching_repo
    self._process_config_searchpath(config_name, parsed_overrides, caching_repo)
../../miniconda3/envs/lightning38/lib/python3.8/site-packages/hydra/_internal/config_loader_impl.py:159: in _process_config_searchpath
    loaded = repo.load_config(config_path=config_name)
../../miniconda3/envs/lightning38/lib/python3.8/site-packages/hydra/_internal/config_repository.py:348: in load_config
    ret = self.delegate.load_config(config_path=config_path)
../../miniconda3/envs/lightning38/lib/python3.8/site-packages/hydra/_internal/config_repository.py:86: in load_config
    source = self._find_object_source(
../../miniconda3/envs/lightning38/lib/python3.8/site-packages/hydra/_internal/config_repository.py:130: in _find_object_source
    if source.is_config(config_path):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = provider=hydra, path=pkg://hydra.conf, config_path = 'config.yaml'

    def is_config(self, config_path: str) -> bool:
        config_path = self._normalize_file_name(config_path)
        try:
            files = resources.files(self.path)
        except (ValueError, ModuleNotFoundError, TypeError):
            return False
        res = files.joinpath(config_path)
>       ret = res.exists() and res.is_file()
E       AttributeError: 'OrphanPath' object has no attribute 'exists'

../../miniconda3/envs/lightning38/lib/python3.8/site-packages/hydra/_internal/core_plugins/importlib_resources_config_source.py:87: AttributeError
===================================================================== short test summary info ======================================================================
FAILED tests/tests_pytorch/models/test_hparams.py::test_model_save_hyper_parameters_interpolation_with_hydra - AttributeError: 'OrphanPath' object has no attribute 'exists'

```




cc @borda