### PR TITLE
Fix `torch.compile` patching when applied as decorator

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -47,7 +47,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
--
+- Fixed an issue causing a TypeError when using `torch.compile` as a decorator ([#19627](https://github.com/Lightning-AI/pytorch-lightning/pull/19627))
 
 -
 

--- a/src/lightning/fabric/wrappers.py
+++ b/src/lightning/fabric/wrappers.py
@@ -403,7 +403,7 @@ def _capture_compile_kwargs(compile_fn: Callable) -> Callable:
     @wraps(compile_fn)
     def _capture(*args: Any, **kwargs: Any) -> Any:
         if not args:
-            # torch.compile is not being applied as a decorator
+            # torch.compile is being applied as a decorator
             return compile_fn(*args, **kwargs)
 
         model = args[0]

--- a/src/lightning/fabric/wrappers.py
+++ b/src/lightning/fabric/wrappers.py
@@ -407,9 +407,12 @@ def _capture_compile_kwargs(compile_fn: Callable) -> Callable:
             return compile_fn(*args, **kwargs)
 
         model = args[0]
+        if not isinstance(model, nn.Module):
+            # compiling something else
+            return compile_fn(*args, **kwargs)
+
         compiled_model = compile_fn(model, **kwargs)
-        if isinstance(model, nn.Module):
-            compiled_model._compile_kwargs = deepcopy(kwargs)
+        compiled_model._compile_kwargs = deepcopy(kwargs)
         return compiled_model
 
     return _capture

--- a/src/lightning/fabric/wrappers.py
+++ b/src/lightning/fabric/wrappers.py
@@ -401,7 +401,12 @@ def _capture_compile_kwargs(compile_fn: Callable) -> Callable:
     # PyTorch will resolve this in the future: https://github.com/pytorch/pytorch/issues/116575
 
     @wraps(compile_fn)
-    def _capture(model: Any, **kwargs: Any) -> Any:
+    def _capture(*args: Any, **kwargs: Any) -> Any:
+        if not args:
+            # torch.compile is not being applied as a decorator
+            return compile_fn(*args, **kwargs)
+
+        model = args[0]
         compiled_model = compile_fn(model, **kwargs)
         if isinstance(model, nn.Module):
             compiled_model._compile_kwargs = deepcopy(kwargs)

--- a/src/lightning/fabric/wrappers.py
+++ b/src/lightning/fabric/wrappers.py
@@ -402,15 +402,11 @@ def _capture_compile_kwargs(compile_fn: Callable) -> Callable:
 
     @wraps(compile_fn)
     def _capture(*args: Any, **kwargs: Any) -> Any:
-        if not args:
-            # torch.compile is being applied as a decorator
+        if not args or not isinstance(args[0], nn.Module):
+            # either torch.compile is being applied as a decorator or we're compiling something else
             return compile_fn(*args, **kwargs)
 
         model = args[0]
-        if not isinstance(model, nn.Module):
-            # compiling something else
-            return compile_fn(*args, **kwargs)
-
         compiled_model = compile_fn(model, **kwargs)
         compiled_model._compile_kwargs = deepcopy(kwargs)
         return compiled_model

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -45,7 +45,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed a KeyError when saving a FSDP sharded checkpoint and setting `save_weights_only=True` ([#19524](https://github.com/Lightning-AI/pytorch-lightning/pull/19524))
 
 
--
+- Fixed an issue causing a TypeError when using `torch.compile` as a decorator ([#19627](https://github.com/Lightning-AI/pytorch-lightning/pull/19627))
 
 -
 

--- a/tests/tests_fabric/test_wrappers.py
+++ b/tests/tests_fabric/test_wrappers.py
@@ -601,6 +601,9 @@ def test_step_method_redirection():
 def test_unwrap_compiled():
     model = torch.nn.Linear(1, 1)
 
+    # We wrap `torch.compile` on import of lightning in `wrappers.py`
+    assert torch.compile.__wrapped__
+
     with mock.patch("lightning.fabric.wrappers", "_TORCH_GREATER_EQUAL_2_0", False):
         unwrapped, compile_kwargs = _unwrap_compiled(model)
     assert unwrapped is model
@@ -615,3 +618,8 @@ def test_unwrap_compiled():
     del compiled._compile_kwargs
     with pytest.raises(RuntimeError, match="Failed to determine the arguments that were used to compile the module"):
         _unwrap_compiled(compiled)
+
+    # can still be applied as decorator
+    @torch.compile()
+    def cos(x):
+        return torch.cos(x)

--- a/tests/tests_fabric/test_wrappers.py
+++ b/tests/tests_fabric/test_wrappers.py
@@ -623,3 +623,7 @@ def test_unwrap_compiled():
     @torch.compile()
     def cos(x):
         return torch.cos(x)
+
+    @torch.compile
+    def sin(x):
+        return torch.sin(x)


### PR DESCRIPTION
## What does this PR do?

From #19598

@carmocca suspected trouble, and there came trouble.


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19627.org.readthedocs.build/en/19627/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli