### PR TITLE
docs: update links to `neptune` web

### DIFF
--- a/src/lightning/pytorch/loggers/neptune.py
+++ b/src/lightning/pytorch/loggers/neptune.py
@@ -63,7 +63,7 @@ def _catch_inactive(func: Callable) -> Callable:
 
 
 class NeptuneLogger(Logger):
-    r"""Log using `Neptune <https://neptune.ai>`_.
+    r"""Log using `Neptune <https://docs.neptune.ai/integrations/lightning/>`_.
 
     Install it with pip:
 
@@ -198,14 +198,14 @@ class NeptuneLogger(Logger):
 
     Args:
         api_key: Optional.
-            Neptune API token, found on https://neptune.ai upon registration.
+            Neptune API token, found on https://www.neptune.ai upon registration.
             You should save your token to the `NEPTUNE_API_TOKEN`
             environment variable and leave the api_key argument out of your code.
             Instructions: `Setting your API token <https://docs.neptune.ai/setup/setting_api_token/>`_.
         project: Optional.
             Name of a project in the form "workspace-name/project-name", for example "tom/mask-rcnn".
             If ``None``, the value of `NEPTUNE_PROJECT` environment variable is used.
-            You need to create the project on https://neptune.ai first.
+            You need to create the project on https://www.neptune.ai first.
         name: Optional. Editable name of the run.
             The run name is displayed in the Neptune web app.
         run: Optional. Default is ``None``. A Neptune ``Run`` object.


### PR DESCRIPTION
## What does this PR do?

Still seeing that this link is still timeouting on or broken 

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19630.org.readthedocs.build/en/19630/

<!-- readthedocs-preview pytorch-lightning end -->