### PR TITLE
Feat(plugins): adding `KeepMachinesAfterStop` flag propagation

### DIFF
--- a/requirements/app/app.txt
+++ b/requirements/app/app.txt
@@ -1,4 +1,4 @@
-lightning-cloud == 0.5.64  # Must be pinned to ensure compatibility
+lightning-cloud == 0.5.65  # Must be pinned to ensure compatibility
 packaging
 typing-extensions >=4.4.0, <4.10.0
 deepdiff >=5.7.0, <6.6.0

--- a/src/lightning/app/plugin/plugin.py
+++ b/src/lightning/app/plugin/plugin.py
@@ -46,6 +46,7 @@ class LightningPlugin:
         self.cloudspace_id = ""
         self.cluster_id = ""
         self.source_app = ""
+        self.keep_machines_after_stop = False
 
     def run(self, *args: str, **kwargs: str) -> Externalv1LightningappInstance:
         """Override with the logic to execute on the cloudspace."""
@@ -95,6 +96,7 @@ class LightningPlugin:
             name=name,
             cluster_id=self.cluster_id,
             source_app=self.source_app,
+            keep_machines_after_stop=self.keep_machines_after_stop,
         )
 
     def _setup(
@@ -103,11 +105,13 @@ class LightningPlugin:
         cloudspace_id: str,
         cluster_id: str,
         source_app: str,
+        keep_machines_after_stop: bool,
     ) -> None:
         self.source_app = source_app
         self.project_id = project_id
         self.cloudspace_id = cloudspace_id
         self.cluster_id = cluster_id
+        self.keep_machines_after_stop = keep_machines_after_stop
 
 
 class _Run(BaseModel):
@@ -118,6 +122,7 @@ class _Run(BaseModel):
     cluster_id: str
     plugin_arguments: Dict[str, str]
     source_app: str
+    keep_machines_after_stop: bool
 
 
 def _run_plugin(run: _Run) -> Dict[str, Any]:
@@ -191,6 +196,7 @@ def _run_plugin(run: _Run) -> Dict[str, Any]:
                 cloudspace_id=run.cloudspace_id,
                 cluster_id=run.cluster_id,
                 source_app=run.source_app,
+                keep_machines_after_stop=run.keep_machines_after_stop,
             )
             app_instance = plugin.run(**run.plugin_arguments)
             return _to_clean_dict(app_instance, True)

--- a/src/lightning/app/runners/cloud.py
+++ b/src/lightning/app/runners/cloud.py
@@ -208,7 +208,7 @@ class CloudRuntime(Runtime):
             name: The name for the run.
             cluster_id: The ID of the cluster to run on.
             source_app: Name of the source app that triggered the run.
-            keep_machines_after_stop: If true, machines will be left running after the run is finished (and can be reused after)
+            keep_machines_after_stop: If true, machines will be left running after the run is finished and reused after
 
         Raises:
             ApiException: If there was an issue in the backend.

--- a/src/lightning/app/runners/cloud.py
+++ b/src/lightning/app/runners/cloud.py
@@ -197,6 +197,7 @@ class CloudRuntime(Runtime):
         name: str,
         cluster_id: str,
         source_app: Optional[str] = None,
+        keep_machines_after_stop: Optional[bool] = None,
     ) -> Externalv1LightningappInstance:
         """Slim dispatch for creating runs from a cloudspace. This dispatch avoids resolution of some properties such
         as the project and cluster IDs that are instead passed directly.
@@ -206,6 +207,8 @@ class CloudRuntime(Runtime):
             cloudspace_id: The ID of the cloudspace.
             name: The name for the run.
             cluster_id: The ID of the cluster to run on.
+            source_app: Name of the source app that triggered the run.
+            keep_machines_after_stop: If true, machines will be left running after the run is finished (and can be reused after)
 
         Raises:
             ApiException: If there was an issue in the backend.
@@ -278,6 +281,7 @@ class CloudRuntime(Runtime):
             queue_server_type,
             env_vars,
             source_app=source_app,
+            keep_machines_after_stop=keep_machines_after_stop,
         )
 
     def dispatch(
@@ -1016,6 +1020,7 @@ class CloudRuntime(Runtime):
         env_vars: Optional[List[V1EnvVar]] = None,
         auth: Optional[V1LightningAuth] = None,
         source_app: Optional[str] = None,
+        keep_machines_after_stop: Optional[bool] = None,
     ) -> Externalv1LightningappInstance:
         """Create a new instance of the given run with the given specification."""
         return self.backend.client.cloud_space_service_create_lightning_run_instance(
@@ -1030,6 +1035,7 @@ class CloudRuntime(Runtime):
                 env=env_vars,
                 auth=auth,
                 source_app=source_app,
+                keep_machines_after_stop=keep_machines_after_stop,
             ),
         )
 

--- a/tests/tests_app/plugin/test_plugin.py
+++ b/tests/tests_app/plugin/test_plugin.py
@@ -85,6 +85,7 @@ plugin = TestPlugin()
                 cluster_id="any",
                 plugin_arguments={},
                 source_app="any",
+                keep_machines_after_stop=False,
             ),
             "Error downloading plugin source:",
             None,
@@ -99,6 +100,7 @@ plugin = TestPlugin()
                 cluster_id="any",
                 plugin_arguments={},
                 source_app="any",
+                keep_machines_after_stop=False,
             ),
             "Error extracting plugin source:",
             None,
@@ -113,6 +115,7 @@ plugin = TestPlugin()
                 cluster_id="any",
                 plugin_arguments={},
                 source_app="any",
+                keep_machines_after_stop=False,
             ),
             "Error loading plugin:",
             "plugin.py",
@@ -127,6 +130,7 @@ plugin = TestPlugin()
                 cluster_id="any",
                 plugin_arguments={},
                 source_app="any",
+                keep_machines_after_stop=False,
             ),
             "Error running plugin:",
             "plugin.py",
@@ -175,6 +179,7 @@ def test_run_job(mock_requests, mock_cloud_runtime, mock_cloud_backend, mock_plu
         cluster_id="test_cluster_id",
         plugin_arguments={"name": "test_name", "entrypoint": "test_entrypoint"},
         source_app="test_source_app",
+        keep_machines_after_stop=True,
     )
 
     mock_app = mock.MagicMock()
@@ -207,6 +212,7 @@ def test_run_job(mock_requests, mock_cloud_runtime, mock_cloud_backend, mock_plu
         name="test_name",
         cluster_id=body.cluster_id,
         source_app=body.source_app,
+        keep_machines_after_stop=body.keep_machines_after_stop,
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Continuing the sequence of improving running asynchronous jobs experience. A user will be able to set the flag on UI if they want to leave machines "on" after a job is finished (for their reusing). In this case, a subsequent job run setup will be way faster.

The PR adds `KeepMachinesAfterStop` flag propagation in plugin run arguments.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19660.org.readthedocs.build/en/19660/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda