### PR TITLE
test: move the pretrained model to the same device as current model before assertion

### DIFF
--- a/tests/tests_pytorch/models/test_restore.py
+++ b/tests/tests_pytorch/models/test_restore.py
@@ -446,6 +446,7 @@ def test_load_model_from_checkpoint(tmp_path, model_template):
         "limit_test_batches": 2,
         "callbacks": [ModelCheckpoint(dirpath=tmp_path, monitor="val_loss", save_top_k=-1)],
         "default_root_dir": tmp_path,
+        "accelerator": "cpu",
     }
 
     # fit model
@@ -465,7 +466,6 @@ def test_load_model_from_checkpoint(tmp_path, model_template):
 
     # Ensure that model can be correctly restored from checkpoint
     pretrained_model = model_template.load_from_checkpoint(last_checkpoint)
-    pretrained_model.to(model.device)  # Move pretrained_model to the same device as model
 
     # test that hparams loaded correctly
     for k, v in model.hparams.items():

--- a/tests/tests_pytorch/models/test_restore.py
+++ b/tests/tests_pytorch/models/test_restore.py
@@ -465,6 +465,7 @@ def test_load_model_from_checkpoint(tmp_path, model_template):
 
     # Ensure that model can be correctly restored from checkpoint
     pretrained_model = model_template.load_from_checkpoint(last_checkpoint)
+    pretrained_model.to(model.device)  # Move pretrained_model to the same device as model
 
     # test that hparams loaded correctly
     for k, v in model.hparams.items():


### PR DESCRIPTION
## What does this PR do?
The tests for `tests/tests_pytorch/models/test_restore.py::test_load_model_from_checkpoint` Were failing for me on macOS locally and I found out that there is a runtime error due to a comparison of two Tensors from different devices. 
Just moving the pretrained model to the same device as the current model we are comparing with seems to fix the issue.

I thought it was a quick fix no need to open a github issue.
Thanks
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #\<issue_number>

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19668.org.readthedocs.build/en/19668/

<!-- readthedocs-preview pytorch-lightning end -->