### PR TITLE
Fix overlapping tags in Fabric docs on small screens

### DIFF
--- a/docs/source-fabric/examples/index.rst
+++ b/docs/source-fabric/examples/index.rst
@@ -12,7 +12,7 @@ Examples
     :description: Train an image classifier on the MNIST dataset
     :button_link: https://github.com/Lightning-AI/lightning/blob/master/examples/fabric/image_classifier
     :col_css: col-md-4
-    :height: 150
+    :height: 200
     :tag: basic
 
 .. displayitem::
@@ -20,7 +20,7 @@ Examples
     :description: A simple language model that learns to predict the next word in a sentence
     :button_link: https://github.com/Lightning-AI/lightning/blob/master/examples/fabric/language_model
     :col_css: col-md-4
-    :height: 150
+    :height: 200
     :tag: basic
 
 .. displayitem::
@@ -28,7 +28,7 @@ Examples
     :description: Train a GAN that generates realistic human faces
     :button_link: https://github.com/Lightning-AI/lightning/blob/master/examples/fabric/dcgan
     :col_css: col-md-4
-    :height: 150
+    :height: 200
     :tag: intermediate
 
 .. displayitem::
@@ -36,7 +36,7 @@ Examples
     :description: Distributed training with the MAML algorithm on the Omniglot and MiniImagenet datasets
     :button_link: https://github.com/Lightning-AI/lightning/blob/master/examples/fabric/meta_learning
     :col_css: col-md-4
-    :height: 150
+    :height: 200
     :tag: intermediate
 
 .. displayitem::
@@ -44,7 +44,7 @@ Examples
     :description: Pretrain a large language model (LLM)
     :button_link: https://github.com/Lightning-AI/litgpt/blob/main/tutorials/pretrain_tinyllama.md
     :col_css: col-md-4
-    :height: 150
+    :height: 200
     :tag: advanced
 
 .. displayitem::
@@ -52,7 +52,7 @@ Examples
     :description: Implementation of the Proximal Policy Optimization (PPO) algorithm with multi-GPU support
     :button_link: https://github.com/Lightning-AI/lightning/blob/master/examples/fabric/reinforcement_learning
     :col_css: col-md-4
-    :height: 150
+    :height: 200
     :tag: intermediate
 
 .. displayitem::
@@ -60,14 +60,14 @@ Examples
     :description: Cross validation helps you estimate the generalization error of a model and select the best one.
     :button_link: https://github.com/Lightning-AI/lightning/tree/master/examples/fabric/kfold_cv
     :col_css: col-md-4
-    :height: 150
+    :height: 200
     :tag: intermediate
 
 .. displayitem::
     :header: Active Learning
     :description: Coming soon
     :col_css: col-md-4
-    :height: 150
+    :height: 200
     :tag: intermediate
 
 


### PR DESCRIPTION
## What does this PR do?

Fix the UI issue on https://lightning.ai/docs/fabric/stable/examples/. Tags are overlapping on text.

Fixes #19669

<details>
 <summary>before submit</summary>
- Was this **discussed/agreed** via a GitHub issue? yes
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section? Yes I did
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together? Yes I did
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes? Yes I did
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>

  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun? yes I did

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19692.org.readthedocs.build/en/19692/

<!-- readthedocs-preview pytorch-lightning end -->