### PR TITLE
Only warn about unsupported bwd sync if enabled

### DIFF
--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -674,7 +674,7 @@ class Fabric:
             )
         if isinstance(self._strategy, (SingleDeviceStrategy, XLAStrategy)):
             return nullcontext()
-        if self._strategy._backward_sync_control is None:
+        if enabled and self._strategy._backward_sync_control is None:
             rank_zero_warn(
                 f"The `{self._strategy.__class__.__name__}` does not support skipping the gradient synchronization."
                 f" Remove `.no_backward_sync()` from your code or choose a different strategy.",

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -674,12 +674,13 @@ class Fabric:
             )
         if isinstance(self._strategy, (SingleDeviceStrategy, XLAStrategy)):
             return nullcontext()
-        if enabled and self._strategy._backward_sync_control is None:
-            rank_zero_warn(
-                f"The `{self._strategy.__class__.__name__}` does not support skipping the gradient synchronization."
-                f" Remove `.no_backward_sync()` from your code or choose a different strategy.",
-                category=PossibleUserWarning,
-            )
+        if self._strategy._backward_sync_control is None:
+            if enabled:
+                rank_zero_warn(
+                    f"The `{self._strategy.__class__.__name__}` does not support skipping the gradient synchronization."
+                    f" Remove `.no_backward_sync()` from your code or choose a different strategy.",
+                    category=PossibleUserWarning,
+                )
             return nullcontext()
 
         forward_module, _ = _unwrap_compiled(module._forward_module)


### PR DESCRIPTION
## What does this PR do?

If your fabric script supports multiple strategies and it integrates the `no_backward_sync` context manager, fabric shouldn't show this warning if the strategy doesn't support it but it's not enabled


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19709.org.readthedocs.build/en/19709/

<!-- readthedocs-preview pytorch-lightning end -->