### PR TITLE
Support pathlib.Path file paths when saving ONNX models

### DIFF
--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -1395,7 +1395,7 @@ class LightningModule(
         input_sample = self._on_before_batch_transfer(input_sample)
         input_sample = self._apply_batch_transfer_handler(input_sample)
 
-        torch.onnx.export(self, input_sample, file_path, **kwargs)
+        torch.onnx.export(self, input_sample, str(file_path), **kwargs)
         self.train(mode)
 
     @torch.no_grad()

--- a/tests/tests_pytorch/models/test_onnx.py
+++ b/tests/tests_pytorch/models/test_onnx.py
@@ -33,25 +33,14 @@ from tests_pytorch.utilities.test_model_summary import UnorderedModel
 def test_model_saves_with_input_sample(tmp_path):
     """Test that ONNX model saves with input sample and size is greater than 3 MB."""
     model = BoringModel()
-    trainer = Trainer(fast_dev_run=True)
-    trainer.fit(model)
-
-    file_path = os.path.join(tmp_path, "model.onnx")
     input_sample = torch.randn((1, 32))
+
+    file_path = os.path.join(tmp_path, "os.path.onnx")
     model.to_onnx(file_path, input_sample)
     assert os.path.isfile(file_path)
     assert os.path.getsize(file_path) > 4e2
 
-
-@RunIf(onnx=True)
-def test_model_saves_with_pathlib_file_path(tmp_path):
-    """Test that ONNX model saves with pathlib.Path file_path and size is greater than 3 MB."""
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True)
-    trainer.fit(model)
-
-    file_path = Path(tmp_path) / "model.onnx"
-    input_sample = torch.randn((1, 32))
+    file_path = Path(tmp_path) / "pathlib.onnx"
     model.to_onnx(file_path, input_sample)
     assert os.path.isfile(file_path)
     assert os.path.getsize(file_path) > 4e2

--- a/tests/tests_pytorch/models/test_onnx.py
+++ b/tests/tests_pytorch/models/test_onnx.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import operator
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
@@ -36,6 +37,20 @@ def test_model_saves_with_input_sample(tmp_path):
     trainer.fit(model)
 
     file_path = os.path.join(tmp_path, "model.onnx")
+    input_sample = torch.randn((1, 32))
+    model.to_onnx(file_path, input_sample)
+    assert os.path.isfile(file_path)
+    assert os.path.getsize(file_path) > 4e2
+
+
+@RunIf(onnx=True)
+def test_model_saves_with_pathlib_file_path(tmp_path):
+    """Test that ONNX model saves with pathlib.Path file_path and size is greater than 3 MB."""
+    model = BoringModel()
+    trainer = Trainer(fast_dev_run=True)
+    trainer.fit(model)
+
+    file_path = Path(tmp_path) / "model.onnx"
     input_sample = torch.randn((1, 32))
     model.to_onnx(file_path, input_sample)
     assert os.path.isfile(file_path)


### PR DESCRIPTION
## What does this PR do?

Update `LightningModule.to_onnx` to support `pathlib.Path` file paths (as previously type-hinted)

Fixes #19726

- [X] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- ~Did you make sure to **update the documentation** with your changes? (if necessary)~
- [X] Did you write any **new necessary tests**? (not for typos and docs)
- [X] Did you verify new and **existing tests pass** locally with your changes?
- ~Did you list all the **breaking changes** introduced by this pull request?~
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [X] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [X] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19727.org.readthedocs.build/en/19727/

<!-- readthedocs-preview pytorch-lightning end -->