### PR TITLE
Skip test with compile error on torch=2.2.2 on Windows

### DIFF
--- a/tests/tests_pytorch/utilities/test_compile.py
+++ b/tests/tests_pytorch/utilities/test_compile.py
@@ -19,6 +19,7 @@ import torch
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel
 from lightning.pytorch.utilities.compile import from_compiled, to_uncompiled
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_2
 from lightning_utilities.core import module_available
 
 from tests_pytorch.conftest import mock_cuda_count
@@ -114,6 +115,9 @@ def test_compile_uncompile():
 
 # https://github.com/pytorch/pytorch/issues/95708
 @pytest.mark.skipif(sys.platform == "darwin", reason="fatal error: 'omp.h' file not found")
+@pytest.mark.xfail(
+    sys.platform == "win32" and _TORCH_GREATER_EQUAL_2_2, strict=False, reason="RuntimeError: Failed to import"
+)
 @RunIf(dynamo=True)
 def test_trainer_compiled_model_that_logs(tmp_path):
     class MyModel(BoringModel):

--- a/tests/tests_pytorch/utilities/test_compile.py
+++ b/tests/tests_pytorch/utilities/test_compile.py
@@ -144,6 +144,9 @@ def test_trainer_compiled_model_that_logs(tmp_path):
 
 # https://github.com/pytorch/pytorch/issues/95708
 @pytest.mark.skipif(sys.platform == "darwin", reason="fatal error: 'omp.h' file not found")
+@pytest.mark.xfail(
+    sys.platform == "win32" and _TORCH_GREATER_EQUAL_2_2, strict=False, reason="RuntimeError: Failed to import"
+)
 @RunIf(dynamo=True)
 def test_trainer_compiled_model_test(tmp_path):
     model = BoringModel()

--- a/tests/tests_pytorch/utilities/test_compile.py
+++ b/tests/tests_pytorch/utilities/test_compile.py
@@ -16,10 +16,10 @@ from unittest import mock
 
 import pytest
 import torch
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_2
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel
 from lightning.pytorch.utilities.compile import from_compiled, to_uncompiled
-from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_2
 from lightning_utilities.core import module_available
 
 from tests_pytorch.conftest import mock_cuda_count


### PR DESCRIPTION
## What does this PR do?

The following tests started failing when CI updated to the recent release of PyTorch 2.2.2:
```
______________________ test_trainer_compiled_model_test _______________________

tmp_path = WindowsPath('C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/test_trainer_compiled_model_te0')

    @pytest.mark.skipif(sys.platform == "darwin", reason="fatal error: 'omp.h' file not found")
    @RunIf(dynamo=True)
    def test_trainer_compiled_model_test(tmp_path):
        model = BoringModel()
        compiled_model = torch.compile(model)
    
        trainer = Trainer(
            default_root_dir=tmp_path,
            fast_dev_run=True,
            enable_checkpointing=False,
            enable_model_summary=False,
            enable_progress_bar=False,
            accelerator="cpu",
        )
>       trainer.test(compiled_model)

utilities\test_compile.py:156: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\pytorch\trainer\trainer.py:754: in test
    return call._call_and_handle_interrupt(
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\pytorch\trainer\call.py:44: in _call_and_handle_interrupt
    return trainer_fn(*args, **kwargs)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\pytorch\trainer\trainer.py:794: in _test_impl
    results = self._run(model, ckpt_path=ckpt_path)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\pytorch\trainer\trainer.py:987: in _run
    results = self._run_stage()
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\pytorch\trainer\trainer.py:1026: in _run_stage
    return self._evaluation_loop.run()
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\pytorch\loops\utilities.py:182: in _decorator
    return loop_run(self, *args, **kwargs)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\pytorch\loops\evaluation_loop.py:135: in run
    self._evaluation_step(batch, batch_idx, dataloader_idx, dataloader_iter)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\pytorch\loops\evaluation_loop.py:396: in _evaluation_step
    output = call._call_strategy_hook(trainer, hook_name, *step_args)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\pytorch\trainer\call.py:311: in _call_strategy_hook
    output = fn(*args, **kwargs)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\pytorch\strategies\strategy.py:425: in test_step
    return self.lightning_module.test_step(*args, **kwargs)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\eval_frame.py:489: in _fn
    return fn(*args, **kwargs)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\eval_frame.py:655: in catch_errors
    return callback(frame, cache_entry, hooks, frame_state)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\convert_frame.py:727: in _convert_frame
    result = inner_convert(frame, cache_entry, hooks, frame_state)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\convert_frame.py:383: in _convert_frame_assert
    compiled_product = _compile(
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\convert_frame.py:646: in _compile
    guarded_code = compile_inner(code, one_graph, hooks, transform)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\utils.py:244: in time_wrapper
    r = func(*args, **kwargs)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\convert_frame.py:562: in compile_inner
    out_code = transform_code_object(code, transform)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\bytecode_transformation.py:1033: in transform_code_object
    transformations(instructions, code_options)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\convert_frame.py:151: in _fn
    return fn(*args, **kwargs)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\convert_frame.py:527: in transform
    tracer.run()
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\symbolic_convert.py:2128: in run
    super().run()
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\symbolic_convert.py:818: in run
    and self.step()
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\symbolic_convert.py:781: in step
    getattr(self, inst.opname)(inst)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\symbolic_convert.py:2243: in RETURN_VALUE
    self.output.compile_subgraph(
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\output_graph.py:945: in compile_subgraph
    self.compile_and_call_fx_graph(tx, pass2.graph_output_vars(), root)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\contextlib.py:79: in inner
    return func(*args, **kwds)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\output_graph.py:1087: in compile_and_call_fx_graph
    compiled_fn = self.call_user_compiler(gm)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\utils.py:244: in time_wrapper
    r = func(*args, **kwargs)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_dynamo\output_graph.py:1159: in call_user_compiler

    @classmethod
    def load_by_key_path(
        cls,
        key: str,
        path: str,
        linemap: Optional[List[Tuple[int, str]]] = None,
        attrs: Optional[Dict[str, Any]] = None,
    ) -> ModuleType:
        if linemap is None:
            linemap = []
        if key not in cls.cache:
            with open(path) as f:
                try:
                    code = compile(f.read(), path, "exec")
                except Exception as e:
>                   raise RuntimeError(
                        f"Failed to import {path}\n{type(e).__name__}: {e}"
                    ) from None
E                   torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
E                   RuntimeError: Failed to import C:\Users\RUNNER~1\AppData\Local\Temp\torchinductor_runneradmin\3e\c3echiribpf5lk3o3wovc4ap55h4jvdbyvra356dynpzti6bfrvh.py
E                   SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 13-14: truncated \UXXXXXXXX escape (c3echiribpf5lk3o3wovc4ap55h4jvdbyvra356dynpzti6bfrvh.py, line 52)
E                   
E                   Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information
E                   
E                   
E                   You can suppress this exception and fall back to eager by setting:
E                       import torch._dynamo
E                       torch._dynamo.config.suppress_errors = True

C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\torch\_inductor\codecache.py:1886: BackendCompilerFailed
```


This is currently blocking us from merging other PRs.

cc @carmocca @borda