### PR TITLE
Fix initialized weights resetting in `Fabric.setup()` when using FSDP

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -51,7 +51,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed issue where some model methods couldn't be monkeypatched after being Fabric wrapped ([#19705](https://github.com/Lightning-AI/pytorch-lightning/pull/19705))
 
--
+- Fixed an issue causing weights to be reset in `Fabric.setup()` when using FSDP ([#19755](https://github.com/Lightning-AI/pytorch-lightning/pull/19755))
+
 
 
 ## [2.2.1] - 2024-03-04

--- a/src/lightning/fabric/utilities/device_dtype_mixin.py
+++ b/src/lightning/fabric/utilities/device_dtype_mixin.py
@@ -109,14 +109,13 @@ class _DeviceDtypeModuleMixin(Module):
 def _update_properties(
     root: torch.nn.Module, device: Optional[torch.device] = None, dtype: Optional[Union[str, torch.dtype]] = None
 ) -> None:
-    def apply_fn(module: Union[_DeviceDtypeModuleMixin, Module]) -> None:
+
+    for module in root.modules():
         if not isinstance(module, _DeviceDtypeModuleMixin):
-            return
+            continue
         # cannot use `module.to()` because we don't actually want to move the model in case there are multiple
         # devices types (such as partial meta parameters)
         if device is not None:
             module._device = device
         if dtype is not None:
             module._dtype = dtype
-
-    root.apply(apply_fn)

--- a/src/lightning/fabric/utilities/device_dtype_mixin.py
+++ b/src/lightning/fabric/utilities/device_dtype_mixin.py
@@ -109,7 +109,6 @@ class _DeviceDtypeModuleMixin(Module):
 def _update_properties(
     root: torch.nn.Module, device: Optional[torch.device] = None, dtype: Optional[Union[str, torch.dtype]] = None
 ) -> None:
-
     for module in root.modules():
         if not isinstance(module, _DeviceDtypeModuleMixin):
             continue

--- a/tests/tests_fabric/strategies/test_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_fsdp_integration.py
@@ -674,14 +674,14 @@ def test_save_sharded_and_consolidate_and_load(tmp_path):
 def test_no_call_to_apply(monkeypatch):
     """Regression test to ensure we're not calling `FSDP.apply()` indirectly (see #19755)."""
     monkeypatch.setattr(torch.distributed.fsdp.FullyShardedDataParallel, "apply", Mock())
-    
+
     fabric = Fabric(
         accelerator="cuda",
         strategy=FSDPStrategy(auto_wrap_policy=always_wrap_policy),
         devices=2,
     )
     fabric.launch()
-    
+
     for setup_method in ("setup", "setup_module"):
         model = BoringModel()
         setup = getattr(fabric, setup_method)

--- a/tests/tests_fabric/strategies/test_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_fsdp_integration.py
@@ -668,3 +668,19 @@ def test_save_sharded_and_consolidate_and_load(tmp_path):
     model, optimizer = fabric.setup(model, optimizer)
     state = {"model": model, "optimizer": optimizer, "steps": 1}
     fabric.load(checkpoint_path_full, state)
+
+
+def test_no_call_to_apply(monkeypatch):
+    """Regression test to ensure we're not calling `FSDP.apply()` indirectly (see #19755)."""
+    monkeypatch.setattr(torch.distributed.fsdp.FullyShardedDataParallel, "apply", Mock())
+    
+    fabric = Fabric(
+        accelerator="cuda",
+        strategy=FSDPStrategy(auto_wrap_policy=always_wrap_policy),
+        devices=2,
+    )
+    fabric.launch()
+    
+    model = BoringModel()
+    model = fabric.setup(model)
+    model._forward_module.apply.assert_not_called()

--- a/tests/tests_fabric/strategies/test_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_fsdp_integration.py
@@ -670,6 +670,7 @@ def test_save_sharded_and_consolidate_and_load(tmp_path):
     fabric.load(checkpoint_path_full, state)
 
 
+@RunIf(min_cuda_gpus=2, standalone=True)
 def test_no_call_to_apply(monkeypatch):
     """Regression test to ensure we're not calling `FSDP.apply()` indirectly (see #19755)."""
     monkeypatch.setattr(torch.distributed.fsdp.FullyShardedDataParallel, "apply", Mock())
@@ -681,6 +682,8 @@ def test_no_call_to_apply(monkeypatch):
     )
     fabric.launch()
     
-    model = BoringModel()
-    model = fabric.setup(model)
-    model._forward_module.apply.assert_not_called()
+    for setup_method in ("setup", "setup_module"):
+        model = BoringModel()
+        setup = getattr(fabric, setup_method)
+        model = setup(model)
+        model._forward_module.apply.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Fixes a subtle issue with weight initialization in FSDP triggered by the change #19152. The real cause is that FSDP overrides the `apply` method of `nn.Module`:
https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/fully_sharded_data_parallel.py/#L567-L605

We call it indirectly here:
https://github.com/Lightning-AI/pytorch-lightning/blob/76b691d80c6c5203c66365272ce246ac86e418f0/src/lightning/fabric/fabric.py#L260-L262
and then `root.apply` here:
https://github.com/Lightning-AI/pytorch-lightning/blob/76b691d80c6c5203c66365272ce246ac86e418f0/src/lightning/fabric/utilities/device_dtype_mixin.py#L122

which by itself is innocent because all we want to do is apply a function to each submodule.
Since all we want to do is update an attribute recursively, we don't need the parameters to be unshareded anyway. So this PR simply iterates over the modules instead of calling `apply`. Consequently, this should also make `fabric.setup()` faster because no longer does each submodule be unsharded.

The added test fails on master.
The bug is critical enough that we will need to prioritize a release after this is merged.

Needs #19756 to unblock failing tests.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19755.org.readthedocs.build/en/19755/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @tchaton @carmocca @justusschock @awaelchli