### PR TITLE
Skip CLI argparse errors on Python 3.11

### DIFF
--- a/tests/tests_pytorch/loggers/test_wandb.py
+++ b/tests/tests_pytorch/loggers/test_wandb.py
@@ -24,6 +24,7 @@ from lightning.pytorch.demos.boring_classes import BoringModel
 from lightning.pytorch.loggers import WandbLogger
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from lightning_utilities.test.warning import no_warning_call
+from tests_pytorch.test_cli import _xfail_python_3_11_9
 
 
 def test_wandb_project_name(wandb_mock):
@@ -548,6 +549,7 @@ def test_wandb_logger_download_artifact(wandb_mock, tmp_path):
     wandb_mock.Api().artifact.assert_called_once_with("test_artifact", type="model")
 
 
+@_xfail_python_3_11_9
 @pytest.mark.parametrize(("log_model", "expected"), [("True", True), ("False", False), ("all", "all")])
 def test_wandb_logger_cli_integration(log_model, expected, wandb_mock, monkeypatch, tmp_path):
     """Test that the WandbLogger can be used with the LightningCLI."""

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -18,6 +18,7 @@ import operator
 import os
 import sys
 from contextlib import ExitStack, contextmanager, redirect_stdout
+from packaging.version import Version
 from io import StringIO
 from pathlib import Path
 from typing import Callable, List, Optional, Union
@@ -62,6 +63,13 @@ else:
 
     def lazy_instance(*args, **kwargs):
         return None
+
+
+_xfail_python_3_11_9 = pytest.mark.xfail(
+    Version(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}") < Version("3.11.9"),
+    strict=False,
+    reason="argparse error in Python 3.11.9: not enough values to unpack"
+)
 
 
 @contextmanager
@@ -347,6 +355,7 @@ def test_save_to_log_dir_false_error():
         )
 
 
+@_xfail_python_3_11_9
 def test_lightning_cli_logger_save_config(cleandir):
     class LoggerSaveConfigCallback(SaveConfigCallback):
         def __init__(self, *args, **kwargs) -> None:
@@ -736,6 +745,7 @@ def test_lightning_cli_optimizer_and_lr_scheduler_subclasses(cleandir):
     assert cli.trainer.lr_scheduler_configs[0].scheduler.step_size == 50
 
 
+@_xfail_python_3_11_9
 @pytest.mark.parametrize("use_generic_base_class", [False, True])
 def test_lightning_cli_optimizers_and_lr_scheduler_with_link_to(use_generic_base_class):
     class MyLightningCLI(LightningCLI):
@@ -782,7 +792,7 @@ def test_lightning_cli_optimizers_and_lr_scheduler_with_link_to(use_generic_base
     assert isinstance(cli.model.scheduler, torch.optim.lr_scheduler.ExponentialLR)
 
 
-@pytest.mark.skipif(compare_version("jsonargparse", operator.lt, "4.21.3"), reason="vulnerability with failing imports")
+@_xfail_python_3_11_9
 def test_lightning_cli_optimizers_and_lr_scheduler_with_callable_type():
     class TestModel(BoringModel):
         def __init__(
@@ -1031,6 +1041,7 @@ class TestModel(BoringModel):
         self.bar = bar
 
 
+@_xfail_python_3_11_9
 def test_lightning_cli_model_short_arguments():
     with mock.patch("sys.argv", ["any.py", "fit", "--model=BoringModel"]), mock.patch(
         "lightning.pytorch.Trainer._fit_impl"
@@ -1055,6 +1066,7 @@ class MyDataModule(BoringDataModule):
         self.bar = bar
 
 
+@_xfail_python_3_11_9
 def test_lightning_cli_datamodule_short_arguments():
     # with set model
     with mock.patch("sys.argv", ["any.py", "fit", "--data=BoringDataModule"]), mock.patch(
@@ -1100,6 +1112,7 @@ def test_lightning_cli_datamodule_short_arguments():
         assert cli.parser.groups["data"].group_class is BoringDataModule
 
 
+@_xfail_python_3_11_9
 @pytest.mark.parametrize("use_class_path_callbacks", [False, True])
 def test_callbacks_append(use_class_path_callbacks):
     """This test validates registries are used when simplified command line are being used."""
@@ -1143,6 +1156,7 @@ def test_callbacks_append(use_class_path_callbacks):
     assert all(t in callback_types for t in expected)
 
 
+@_xfail_python_3_11_9
 def test_optimizers_and_lr_schedulers_reload(cleandir):
     base = ["any.py", "--trainer.max_epochs=1"]
     input = base + [
@@ -1174,6 +1188,7 @@ def test_optimizers_and_lr_schedulers_reload(cleandir):
         LightningCLI(BoringModel, run=False)
 
 
+@_xfail_python_3_11_9
 def test_optimizers_and_lr_schedulers_add_arguments_to_parser_implemented_reload(cleandir):
     class TestLightningCLI(LightningCLI):
         def __init__(self, *args):
@@ -1427,6 +1442,7 @@ def test_cli_help_message():
     assert "Implements Adam" in shorthand_help.getvalue()
 
 
+@_xfail_python_3_11_9
 def test_cli_reducelronplateau():
     with mock.patch(
         "sys.argv", ["any.py", "--optimizer=Adam", "--lr_scheduler=ReduceLROnPlateau", "--lr_scheduler.monitor=foo"]
@@ -1437,6 +1453,7 @@ def test_cli_reducelronplateau():
     assert config["lr_scheduler"]["scheduler"].monitor == "foo"
 
 
+@_xfail_python_3_11_9
 def test_cli_configureoptimizers_can_be_overridden():
     class MyCLI(LightningCLI):
         def __init__(self):
@@ -1481,6 +1498,7 @@ def test_cli_parameter_with_lazy_instance_default():
         assert cli.model.activation is not model.activation
 
 
+@_xfail_python_3_11_9
 def test_ddpstrategy_instantiation_and_find_unused_parameters(mps_count_0):
     strategy_default = lazy_instance(DDPStrategy, find_unused_parameters=True)
     with mock.patch("sys.argv", ["any.py", "--trainer.strategy.process_group_backend=group"]):
@@ -1496,6 +1514,7 @@ def test_ddpstrategy_instantiation_and_find_unused_parameters(mps_count_0):
     assert strategy_default is not cli.config_init.trainer.strategy
 
 
+@_xfail_python_3_11_9
 def test_cli_logger_shorthand():
     with mock.patch("sys.argv", ["any.py"]):
         cli = LightningCLI(TestModel, run=False, trainer_defaults={"logger": False})
@@ -1526,6 +1545,7 @@ def _test_logger_init_args(logger_name, init, unresolved=None):
         assert data["dict_kwargs"] == unresolved
 
 
+@_xfail_python_3_11_9
 def test_comet_logger_init_args():
     _test_logger_init_args(
         "CometLogger",
@@ -1534,6 +1554,7 @@ def test_comet_logger_init_args():
     )
 
 
+@_xfail_python_3_11_9
 @pytest.mark.xfail(
     # Only on Windows: TypeError: 'NoneType' object is not subscriptable
     raises=TypeError,
@@ -1549,6 +1570,7 @@ def test_neptune_logger_init_args():
     )
 
 
+@_xfail_python_3_11_9
 def test_tensorboard_logger_init_args():
     _test_logger_init_args(
         "TensorBoardLogger",
@@ -1560,6 +1582,7 @@ def test_tensorboard_logger_init_args():
     )
 
 
+@_xfail_python_3_11_9
 def test_wandb_logger_init_args():
     _test_logger_init_args(
         "WandbLogger",
@@ -1644,6 +1667,7 @@ def test_unresolvable_import_paths():
     assert "a_func: torch.nn.Softmax" in out.getvalue()
 
 
+@_xfail_python_3_11_9
 def test_pytorch_profiler_init_args():
     from lightning.pytorch.profilers import Profiler, PyTorchProfiler
 


### PR DESCRIPTION
## What does this PR do?

Python 3.11.9 was released recently and is picked up by our CI. It doesn't play well with jsonargparse in our tests, probably because jsonargparse is calling a protected method that had changes in this version:

https://github.com/Lightning-AI/pytorch-lightning/actions/runs/8633090509/job/23665307586?pr=19755

```
_________________ test_wandb_logger_cli_integration[True-True] _________________

log_model = 'True', expected = True, wandb_mock = <module 'wandb'>
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x15a365d50>
tmp_path = PosixPath('/private/var/folders/n2/pt_35rc53tdgkld9531s2tfh0000gn/T/pytest-of-runner/pytest-0/test_wandb_logger_cli_integrat2')

    @pytest.mark.parametrize(("log_model", "expected"), [("True", True), ("False", False), ("all", "all")])
    def test_wandb_logger_cli_integration(log_model, expected, wandb_mock, monkeypatch, tmp_path):
        """Test that the WandbLogger can be used with the LightningCLI."""
        monkeypatch.chdir(tmp_path)
    
        class InspectParsedCLI(LightningCLI):
            def before_instantiate_classes(self):
                assert self.config.trainer.logger.init_args.log_model == expected
    
        # Create a config file with the log_model parameter set. This seems necessary to be able
        # to set the init_args parameter of the logger on the CLI later on.
        input_config = {
            "trainer": {
                "logger": {
                    "class_path": "pytorch_lightning.loggers.wandb.WandbLogger",
                    "init_args": {"log_model": log_model},
                },
            }
        }
        config_path = "config.yaml"
        with open(config_path, "w") as f:
            f.write(yaml.dump(input_config))
    
        # Test case 1: Set the log_model parameter only via the config file.
        with mock.patch("sys.argv", ["any.py", "--config", config_path]):
            InspectParsedCLI(BoringModel, run=False, save_config_callback=None)
    
        # Test case 2: Overwrite the log_model parameter via the command line.
        wandb_cli_arg = f"--trainer.logger.init_args.log_model={log_model}"
    
        with mock.patch("sys.argv", ["any.py", "--config", config_path, wandb_cli_arg]):
>           InspectParsedCLI(BoringModel, run=False, save_config_callback=None)

/Users/runner/work/pytorch-lightning/pytorch-lightning/tests/tests_pytorch/loggers/test_wandb.py:582: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pytorch_lightning/cli.py:383: in __init__
    self.parse_arguments(self.parser, args)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pytorch_lightning/cli.py:534: in parse_arguments
    self.config = parser.parse_args(args)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/jsonargparse/_deprecated.py:124: in patched_parse
    cfg = parse_method(*args, _skip_check=_skip_check, **kwargs)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/jsonargparse/_core.py:390: in parse_args
    cfg, unk = self.parse_known_args(args=args, namespace=cfg)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/jsonargparse/_core.py:261: in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/argparse.py:2128: in _parse_known_args
    start_index = consume_optional(start_index)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

start_index = 2

    def consume_optional(start_index):
    
        # get the optional identified at this index
        option_tuple = option_string_indices[start_index]
>       action, option_string, sep, explicit_arg = option_tuple
E       ValueError: not enough values to unpack (expected 4, got 3)

/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/argparse.py:1990: ValueError
```
