### PR TITLE
Specify branch name in release-pkg workflow

### DIFF
--- a/.github/workflows/release-pkg.yml
+++ b/.github/workflows/release-pkg.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           repository: gridai/base-images
           token: ${{ secrets.PAT_GHOST }}
+          ref: "main"
       - name: Update lightning version
         run: |
           import json, os, re


### PR DESCRIPTION
## What does this PR do?

The release is currently blocked because the action can't determine the main branch of the repository:
https://github.com/Lightning-AI/pytorch-lightning/actions/runs/8647537840/job/23717684220

I'm trying now to explicitly specify the main branch.


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19765.org.readthedocs.build/en/19765/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca