### PR TITLE
Use `step` interval in `estimated_stepping_batches` docs example

### DIFF
--- a/docs/source-pytorch/common/trainer.rst
+++ b/docs/source-pytorch/common/trainer.rst
@@ -1233,6 +1233,7 @@ dataloader if hadn't been set up already.
             "optimizer": optimizer,
             "lr_scheduler": {"scheduler": scheduler, "interval": "step"},
         }
+
 state
 *****
 


### PR DESCRIPTION
Copy-pasting the current example would produce unexpected results as the default interval is `epoch`.



<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19774.org.readthedocs.build/en/19774/

<!-- readthedocs-preview pytorch-lightning end -->