### PR TITLE
Fix TensorBoardLogger test on Windows

### DIFF
--- a/requirements/fabric/base.txt
+++ b/requirements/fabric/base.txt
@@ -3,7 +3,7 @@
 
 numpy >=1.17.2, <1.27.0
 torch >=2.0.0, <2.4.0
-fsspec[http] >=2022.5.0, <2023.11.0
+fsspec[http] >=2022.5.0, <2024.4.0
 packaging >=20.0, <=23.1
 typing-extensions >=4.4.0, <4.10.0
 lightning-utilities >=0.8.0, <0.12.0

--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -5,7 +5,7 @@ numpy >=1.17.2, <1.27.0
 torch >=2.0.0, <2.4.0
 tqdm >=4.57.0, <4.67.0
 PyYAML >=5.4, <6.1.0
-fsspec[http] >=2022.5.0, <2023.11.0
+fsspec[http] >=2022.5.0, <2024.4.0
 torchmetrics >=0.7.0, <1.3.0  # needed for using fixed compare_version
 packaging >=20.0, <=23.1
 typing-extensions >=4.4.0, <4.10.0

--- a/tests/tests_pytorch/loggers/test_tensorboard.py
+++ b/tests/tests_pytorch/loggers/test_tensorboard.py
@@ -109,7 +109,6 @@ def test_tensorboard_no_name(tmp_path, name):
     assert os.listdir(tmp_path / "version_0")
 
 
-@mock.patch.dict(os.environ, {}, clear=True)
 def test_tensorboard_log_sub_dir(tmp_path):
     class TestLogger(TensorBoardLogger):
         # for reproducibility
@@ -141,14 +140,15 @@ def test_tensorboard_log_sub_dir(tmp_path):
     trainer = Trainer(**trainer_args, logger=logger)
     assert trainer.logger.log_dir == os.path.join(explicit_save_dir, "name", "version", "sub_dir")
 
-    # test env var (`$`) handling
-    test_env_dir = "some_directory"
-    os.environ["TEST_ENV_DIR"] = test_env_dir
-    save_dir = "$TEST_ENV_DIR/tmp"
-    explicit_save_dir = f"{test_env_dir}/tmp"
-    logger = TestLogger(save_dir, sub_dir="sub_dir")
-    trainer = Trainer(**trainer_args, logger=logger)
-    assert trainer.logger.log_dir == os.path.join(explicit_save_dir, "name", "version", "sub_dir")
+    with mock.patch.dict(os.environ, {}):
+        # test env var (`$`) handling
+        test_env_dir = "some_directory"
+        os.environ["TEST_ENV_DIR"] = test_env_dir
+        save_dir = "$TEST_ENV_DIR/tmp"
+        explicit_save_dir = f"{test_env_dir}/tmp"
+        logger = TestLogger(save_dir, sub_dir="sub_dir")
+        trainer = Trainer(**trainer_args, logger=logger)
+        assert trainer.logger.log_dir == os.path.join(explicit_save_dir, "name", "version", "sub_dir")
 
 
 @pytest.mark.parametrize("step_idx", [10, None])


### PR DESCRIPTION
## What does this PR do?

On Windows, this test fails with Recursion error on master with fsspec unpinned to the latest:

```
________________________ test_tensorboard_log_sub_dir _________________________

tmp_path = WindowsPath('C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/test_tensorboard_log_sub_dir0')

    @mock.patch.dict(os.environ, {}, clear=True)
    def test_tensorboard_log_sub_dir(tmp_path):
        class TestLogger(TensorBoardLogger):
            # for reproducibility
            @property
            def version(self):
                return "version"
    
            @property
            def name(self):
                return "name"
    
        trainer_args = {"default_root_dir": tmp_path, "max_steps": 1}
    
        # no sub_dir specified
        save_dir = tmp_path / "logs"
        logger = TestLogger(save_dir)
        trainer = Trainer(**trainer_args, logger=logger)
        assert trainer.logger.log_dir == os.path.join(save_dir, "name", "version")
    
        # sub_dir specified
        logger = TestLogger(save_dir, sub_dir="sub_dir")
        trainer = Trainer(**trainer_args, logger=logger)
        assert trainer.logger.log_dir == os.path.join(save_dir, "name", "version", "sub_dir")
    
        # test home dir (`~`) handling
        save_dir = "~/tmp"
        explicit_save_dir = os.path.expanduser(save_dir)
>       logger = TestLogger(save_dir, sub_dir="sub_dir")

loggers\test_tensorboard.py:140: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\pytorch\loggers\tensorboard.py:99: in __init__
    super().__init__(
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\fabric\loggers\tensorboard.py:108: in __init__
    self._fs = get_filesystem(root_dir)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\lightning\fabric\utilities\cloud_io.py:61: in get_filesystem
    fs, _ = url_to_fs(str(path), **kwargs)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\fsspec\core.py:383: in url_to_fs
    chain = _un_chain(url, kwargs)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\fsspec\core.py:338: in _un_chain
    bit = cls._strip_protocol(bit)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\fsspec\implementations\local.py:247: in _strip_protocol
    return make_path_posix(path, remove_trailing_slash)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\fsspec\implementations\local.py:290: in make_path_posix
    return make_path_posix(osp.expanduser(path), remove_trailing_slash)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\fsspec\implementations\local.py:290: in make_path_posix
    return make_path_posix(osp.expanduser(path), remove_trailing_slash)
E   RecursionError: maximum recursion depth exceeded while calling a Python object
!!! Recursion detected (same locals & position)
```


Because fsspec needs some env variable to determine home, but we are mocking out `os.environ` there. This PR fixes the test to only mock the region we need.

cc @borda @carmocca @justusschock @awaelchli