### PR TITLE
[App] Extend retry to 4xx except 400, 401, 403, 404

### DIFF
--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -356,8 +356,6 @@ intersphinx_mapping = {
     "torchmetrics": ("https://lightning.ai/docs/torchmetrics/stable/", None),
     "lightning_habana": ("https://lightning-ai.github.io/lightning-Habana/", None),
     "tensorboardX": ("https://tensorboardx.readthedocs.io/en/stable/", None),
-    # needed for referencing App from lightning scope
-    "lightning.app": ("https://lightning.ai/docs/app/stable/", None),
     # needed for referencing Fabric from lightning scope
     "lightning.fabric": ("https://lightning.ai/docs/fabric/stable/", None),
     # TODO: these are missing objects.inv

--- a/src/lightning/app/utilities/network.py
+++ b/src/lightning/app/utilities/network.py
@@ -96,10 +96,14 @@ def create_retry_strategy():
         # are going to be alive for a very long time (~ 4 days) but retries every 120 seconds
         total=_CONNECTION_RETRY_TOTAL,
         backoff_factor=_CONNECTION_RETRY_BACKOFF_FACTOR,
+        # Any 4xx and 5xx statuses except
+        # 400 Bad Request
+        # 401 Unauthorized
+        # 403 Forbidden
+        # 404 Not Found
         status_forcelist={
-            408,  # Request Timeout
-            429,  # Too Many Requests
-            *range(500, 600),  # Any 5xx Server Error status
+            402,
+            *range(405, 600),
         },
         allowed_methods={
             "POST",  # Default methods are idempotent, add POST here

--- a/tests/tests_app/utilities/test_network.py
+++ b/tests/tests_app/utilities/test_network.py
@@ -49,7 +49,8 @@ def test_find_free_network_port_cloudspace(_, patch_constants):
 def test_http_client_retry_post(getconn_mock):
     getconn_mock.return_value.getresponse.side_effect = [
         mock.Mock(status=500, msg=HTTPMessage()),
-        mock.Mock(status=429, msg=HTTPMessage()),
+        mock.Mock(status=599, msg=HTTPMessage()),
+        mock.Mock(status=405, msg=HTTPMessage()),
         mock.Mock(status=200, msg=HTTPMessage()),
     ]
 
@@ -61,6 +62,7 @@ def test_http_client_retry_post(getconn_mock):
         mock.call("POST", "/test", body=None, headers=mock.ANY),
         mock.call("POST", "/test", body=None, headers=mock.ANY),
         mock.call("POST", "/test", body=None, headers=mock.ANY),
+        mock.call("POST", "/test", body=None, headers=mock.ANY),
     ]
 
 
@@ -68,7 +70,8 @@ def test_http_client_retry_post(getconn_mock):
 def test_http_client_retry_get(getconn_mock):
     getconn_mock.return_value.getresponse.side_effect = [
         mock.Mock(status=500, msg=HTTPMessage()),
-        mock.Mock(status=429, msg=HTTPMessage()),
+        mock.Mock(status=599, msg=HTTPMessage()),
+        mock.Mock(status=405, msg=HTTPMessage()),
         mock.Mock(status=200, msg=HTTPMessage()),
     ]
 
@@ -77,6 +80,7 @@ def test_http_client_retry_get(getconn_mock):
     r.raise_for_status()
 
     assert getconn_mock.return_value.request.mock_calls == [
+        mock.call("GET", "/test", body=None, headers=mock.ANY),
         mock.call("GET", "/test", body=None, headers=mock.ANY),
         mock.call("GET", "/test", body=None, headers=mock.ANY),
         mock.call("GET", "/test", body=None, headers=mock.ANY),


### PR DESCRIPTION
## What does this PR do?

This is a follow up to #19837, where we extend the retry logic to more status codes, namely everything 4xx and 5xx except 400, 401, 403, and 404.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19842.org.readthedocs.build/en/19842/

<!-- readthedocs-preview pytorch-lightning end -->