### PR TITLE
(1/n) Support 2D Parallelism

### DIFF
--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -356,8 +356,6 @@ intersphinx_mapping = {
     "torchmetrics": ("https://lightning.ai/docs/torchmetrics/stable/", None),
     "lightning_habana": ("https://lightning-ai.github.io/lightning-Habana/", None),
     "tensorboardX": ("https://tensorboardx.readthedocs.io/en/stable/", None),
-    # needed for referencing App from lightning scope
-    "lightning.app": ("https://lightning.ai/docs/app/stable/", None),
     # needed for referencing Fabric from lightning scope
     "lightning.fabric": ("https://lightning.ai/docs/fabric/stable/", None),
     # TODO: these are missing objects.inv

--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -635,4 +635,6 @@ linkcheck_ignore = [
     "https://www.intel.com/content/www/us/en/products/docs/processors/what-is-a-gpu.html",
     "https://www.microsoft.com/en-us/research/blog/zero-infinity-and-deepspeed-unlocking-unprecedented-model-scale-for-deep-learning-training/",  # noqa: E501
     "https://stackoverflow.com/questions/66640705/how-can-i-install-grpcio-on-an-apple-m1-silicon-laptop",
+    "https://openai.com/blog/.*",
+    "https://tinyurl.com/.*",  # has a human verification check on redirect
 ]

--- a/examples/fabric/tensor_parallel/README.md
+++ b/examples/fabric/tensor_parallel/README.md
@@ -1,0 +1,45 @@
+## Tensor Parallel and 2D Parallel
+
+This example shows how to apply tensor-parallelism to your model (here Llama 2 7B) with the `ModelParallelStrategy`, and how it can be combined with FSDP (2D parallelism).
+PyTorch 2.3+ and a machine with at least 4 GPUs and 24 GB memory each are required to run this example.
+
+```bash
+pip install 'torch>=2.3'
+```
+
+Navigate to this example folder and run the training script:
+
+```bash
+cd examples/fabric/tensor_parallel
+python train.py
+```
+
+You should see an output like this:
+
+```
+Initializing distributed: GLOBAL_RANK: 0, MEMBER: 1/4
+Initializing distributed: GLOBAL_RANK: 3, MEMBER: 4/4
+Initializing distributed: GLOBAL_RANK: 2, MEMBER: 3/4
+Initializing distributed: GLOBAL_RANK: 1, MEMBER: 2/4
+----------------------------------------------------------------------------------------------------
+distributed_backend=nccl
+All distributed processes registered. Starting with 4 processes
+----------------------------------------------------------------------------------------------------
+
+Number of model parameters: 6.7 B
+Starting training ...
+Iteration 0 complete
+Iteration 1 complete
+Iteration 2 complete
+Iteration 3 complete
+Iteration 4 complete
+Iteration 5 complete
+Iteration 6 complete
+Iteration 7 complete
+Saving a (distributed) checkpoint ...
+Training successfully completed!
+Peak memory usage: 17.95 GB
+```
+
+> \[!NOTE\]
+> The `ModelParallelStrategy` is experimental and subject to change. Report issues on [GitHub](https://github.com/Lightning-AI/pytorch-lightning/issues).

--- a/examples/fabric/tensor_parallel/data.py
+++ b/examples/fabric/tensor_parallel/data.py
@@ -1,0 +1,19 @@
+import torch
+from torch.utils.data import Dataset
+
+
+class RandomTokenDataset(Dataset):
+    def __init__(self, vocab_size: int, seq_length: int):
+        self.vocab_size = vocab_size
+        self.seq_length = seq_length
+        self.tokens = torch.randint(
+            self.vocab_size,
+            size=(len(self), self.seq_length + 1),
+            generator=torch.Generator().manual_seed(42),
+        )
+
+    def __len__(self) -> int:
+        return 128
+
+    def __getitem__(self, item: int):
+        return self.tokens[item]

--- a/examples/fabric/tensor_parallel/data.py
+++ b/examples/fabric/tensor_parallel/data.py
@@ -9,6 +9,8 @@ class RandomTokenDataset(Dataset):
         self.tokens = torch.randint(
             self.vocab_size,
             size=(len(self), self.seq_length + 1),
+            # Set a seed to make this toy dataset the same on each rank
+            # Fabric will add a `DistributedSampler` to shard the data correctly
             generator=torch.Generator().manual_seed(42),
         )
 

--- a/examples/fabric/tensor_parallel/model.py
+++ b/examples/fabric/tensor_parallel/model.py
@@ -1,0 +1,532 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.distributed._composable.fsdp import MixedPrecisionPolicy
+from torch.distributed._composable.fsdp.fully_shard import fully_shard
+from torch.distributed._tensor import Replicate, Shard
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    PrepareModuleInput,
+    RowwiseParallel,
+    SequenceParallel,
+    parallelize_module,
+)
+
+
+@dataclass
+class ModelArgs:
+    dim: int = 4096
+    n_layers: int = 32
+    n_heads: int = 32
+    n_kv_heads: Optional[int] = None
+    vocab_size: int = -1  # defined later by tokenizer
+    multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
+    ffn_dim_multiplier: Optional[float] = None
+    norm_eps: float = 1e-5
+
+    max_batch_size: int = 32
+    max_seq_len: int = 32768
+    # If `True`, then each transformer block init uses its layer ID, and if
+    # `False`, each uses the total number of transformer blocks
+    depth_init: bool = True
+
+
+def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0):
+    """Precompute the frequency tensor for complex exponentials (cis) with given dimensions.
+
+    This function calculates a frequency tensor with complex exponentials using the given dimension 'dim'
+    and the end index 'end'. The 'theta' parameter scales the frequencies.
+    The returned tensor contains complex values in complex64 data type.
+
+    Args:
+        dim (int): Dimension of the frequency tensor.
+        end (int): End index for precomputing frequencies.
+        theta (float, optional): Scaling factor for frequency computation. Defaults to 10000.0.
+
+    Returns:
+        torch.Tensor: Precomputed frequency tensor with complex exponentials.
+
+    """
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    t = torch.arange(end, device=freqs.device)  # type: ignore
+    freqs = torch.outer(t, freqs).float()  # type: ignore
+    return torch.polar(torch.ones_like(freqs), freqs)  # complex64
+
+
+def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor):
+    """Reshape frequency tensor for broadcasting it with another tensor.
+
+    This function reshapes the frequency tensor to have the same shape as the target tensor 'x'
+    for the purpose of broadcasting the frequency tensor during element-wise operations.
+
+    Args:
+        freqs_cis (torch.Tensor): Frequency tensor to be reshaped.
+        x (torch.Tensor): Target tensor for broadcasting compatibility.
+
+    Returns:
+        torch.Tensor: Reshaped frequency tensor.
+
+    """
+    ndim = x.ndim
+    assert 0 <= 1 < ndim
+    assert freqs_cis.shape == (x.shape[1], x.shape[-1])
+    shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
+    return freqs_cis.view(*shape)
+
+
+def apply_rotary_emb(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    freqs_cis: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply rotary embeddings to input tensors using the given frequency tensor.
+
+    This function applies rotary embeddings to the given query 'xq' and key 'xk' tensors using the provided
+    frequency tensor 'freqs_cis'. The input tensors are reshaped as complex numbers, and the frequency tensor
+    is reshaped for broadcasting compatibility. The resulting tensors contain rotary embeddings and are
+    returned as real tensors.
+
+    Args:
+        xq (torch.Tensor): Query tensor to apply rotary embeddings.
+        xk (torch.Tensor): Key tensor to apply rotary embeddings.
+        freqs_cis (torch.Tensor): Precomputed frequency tensor for complex exponentials.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: Tuple of modified query tensor and key tensor with rotary embeddings.
+
+    """
+    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+    freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
+    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
+    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
+    return xq_out.type_as(xq), xk_out.type_as(xk)
+
+
+def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
+    bs, slen, n_kv_heads, head_dim = x.shape
+    if n_rep == 1:
+        return x
+    return (
+        x[:, :, :, None, :]
+        .expand(bs, slen, n_kv_heads, n_rep, head_dim)
+        .reshape(bs, slen, n_kv_heads * n_rep, head_dim)
+    )
+
+
+class RMSNorm(nn.Module):
+    """Initialize the RMSNorm normalization layer.
+
+    Args:
+        dim (int): The dimension of the input tensor.
+        eps (float, optional): A small value added to the denominator for numerical stability. Default is 1e-6.
+
+    Attributes:
+        eps (float): A small value added to the denominator for numerical stability.
+        weight (nn.Parameter): Learnable scaling parameter.
+
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x: torch.Tensor):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x: torch.Tensor):
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight
+
+    def reset_parameters(self):
+        torch.nn.init.ones_(self.weight)  # type: ignore
+
+
+class Attention(nn.Module):
+    """Multi-head attention module.
+
+    Args:
+        model_args (ModelArgs): Model configuration arguments.
+
+    Attributes:
+        n_kv_heads (int): Number of key and value heads.
+        n_heads (int): Number of query heads.
+        n_local_kv_heads (int): Number of local key and value heads.
+        n_rep (int): Number of repetitions for local heads.
+        head_dim (int): Dimension size of each attention head.
+        wq (Linear): Linear transformation for queries.
+        wk (Linear): Linear transformation for keys.
+        wv (Linear): Linear transformation for values.
+        wo (Linear): Linear transformation for output.
+
+    """
+
+    def __init__(self, model_args: ModelArgs):
+        super().__init__()
+        self.n_heads = model_args.n_heads
+        self.n_kv_heads = model_args.n_heads if model_args.n_kv_heads is None else model_args.n_kv_heads
+        self.n_rep = self.n_heads // self.n_kv_heads
+        self.head_dim = model_args.dim // model_args.n_heads
+
+        self.wq = nn.Linear(model_args.dim, model_args.n_heads * self.head_dim, bias=False)
+        self.wk = nn.Linear(model_args.dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.wv = nn.Linear(model_args.dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.wo = nn.Linear(model_args.n_heads * self.head_dim, model_args.dim, bias=False)
+
+    def init_weights(self, init_std: float):
+        for linear in (self.wq, self.wk, self.wv):
+            nn.init.trunc_normal_(linear.weight, mean=0.0, std=0.02)
+        nn.init.trunc_normal_(self.wo.weight, mean=0.0, std=init_std)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        freqs_cis: torch.Tensor,
+    ):
+        """Forward pass of the attention module.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+            freqs_cis (torch.Tensor): Precomputed frequency tensor.
+
+        Returns:
+            torch.Tensor: Output tensor after attention.
+
+        """
+        bsz, seqlen, _ = x.shape
+        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+
+        xq = xq.view(bsz, seqlen, self.n_heads, self.head_dim)
+        xk = xk.view(bsz, seqlen, self.n_kv_heads, self.head_dim)
+        xv = xv.view(bsz, seqlen, self.n_kv_heads, self.head_dim)
+
+        xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
+
+        keys = repeat_kv(xk, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
+        values = repeat_kv(xv, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
+
+        xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+        xk = keys.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+        xv = values.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+
+        # we use casual mask for training
+        output = F.scaled_dot_product_attention(xq, xk, xv, is_causal=True)
+        output = output.transpose(1, 2).contiguous()  # (bs, seqlen, n_local_heads, head_dim)
+        output = output.view(bsz, seqlen, -1)
+        return self.wo(output)
+
+
+class FeedForward(nn.Module):
+    """FeedForward module.
+
+    Args:
+        dim (int): Input dimension.
+        hidden_dim (int): Hidden dimension of the feedforward layer.
+        multiple_of (int): Value to ensure hidden dimension is a multiple of this value.
+        ffn_dim_multiplier (Optional[float]): Custom multiplier for hidden dimension. Defaults to None.
+
+    Attributes:
+        w1 (Linear): Linear transformation for the first layer.
+        w2 (Linear): Linear transformation for the second layer.
+        w3 (Linear): Linear transformation for the third layer.
+
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        hidden_dim: int,
+        multiple_of: int,
+        ffn_dim_multiplier: Optional[float],
+    ):
+        super().__init__()
+        hidden_dim = int(2 * hidden_dim / 3)
+        # custom dim factor multiplier
+        if ffn_dim_multiplier is not None:
+            hidden_dim = int(ffn_dim_multiplier * hidden_dim)
+        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
+
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
+        self.w3 = nn.Linear(dim, hidden_dim, bias=False)
+
+    def forward(self, x):
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+    def init_weights(self, init_std: float):
+        nn.init.trunc_normal_(self.w1.weight, mean=0.0, std=0.02)
+        for linear in (self.w2, self.w3):
+            nn.init.trunc_normal_(linear.weight, mean=0.0, std=init_std)
+
+
+class TransformerBlock(nn.Module):
+    """TransformerBlock Module.
+
+    Args:
+        layer_id (int): Identifier for the layer.
+        model_args (ModelArgs): Model configuration arguments.
+
+    Attributes:
+        n_heads (int): Number of attention heads.
+        dim (int): Dimension size of the model.
+        head_dim (int): Dimension size of each attention head.
+        attention (Attention): Attention module.
+        feed_forward (FeedForward): FeedForward module.
+        layer_id (int): Identifier for the layer.
+        attention_norm (RMSNorm): Layer normalization for attention output.
+        ffn_norm (RMSNorm): Layer normalization for feedforward output.
+
+    """
+
+    def __init__(self, layer_id: int, model_args: ModelArgs):
+        super().__init__()
+        self.n_heads = model_args.n_heads
+        self.dim = model_args.dim
+        self.attention = Attention(model_args)
+        self.feed_forward = FeedForward(
+            dim=model_args.dim,
+            hidden_dim=4 * model_args.dim,
+            multiple_of=model_args.multiple_of,
+            ffn_dim_multiplier=model_args.ffn_dim_multiplier,
+        )
+        self.layer_id = layer_id
+        self.num_layers = model_args.n_layers
+
+        self.attention_norm = RMSNorm(dim=model_args.dim, eps=model_args.norm_eps)
+        self.ffn_norm = RMSNorm(dim=model_args.dim, eps=model_args.norm_eps)
+
+        if model_args.depth_init:
+            self.weight_init_std = 0.02 / (2 * (self.layer_id + 1)) ** 0.5
+        else:
+            self.weight_init_std = 0.02 / (2 * self.num_layers) ** 0.5
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        freqs_cis: torch.Tensor,
+    ):
+        """Perform a forward pass through the TransformerBlock.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+            freqs_cis (torch.Tensor): Precomputed cosine and sine frequencies.
+
+        Returns:
+            torch.Tensor: Output tensor after applying attention and feedforward layers.
+
+        """
+        h = x + self.attention(self.attention_norm(x), freqs_cis)
+        return h + self.feed_forward(self.ffn_norm(h))
+
+    def init_weights(self):
+        for norm in (self.attention_norm, self.ffn_norm):
+            norm.reset_parameters()
+        self.attention.init_weights(self.weight_init_std)
+        self.feed_forward.init_weights(self.weight_init_std)
+
+
+class Transformer(nn.Module):
+    """Transformer Module.
+
+    Args:
+        model_args (ModelArgs): Model configuration arguments.
+
+    Attributes:
+        model_args (ModelArgs): Model configuration arguments.
+        vocab_size (int): Vocabulary size.
+        n_layers (int): Number of layers in the model.
+        tok_embeddings (ParallelEmbedding): Token embeddings.
+        layers (torch.nn.ModuleList): List of Transformer blocks.
+        norm (RMSNorm): Layer normalization for the model output.
+        output (ColumnParallelLinear): Linear layer for final output.
+        freqs_cis (torch.Tensor): Precomputed cosine and sine frequencies.
+
+    """
+
+    def __init__(self, model_args: ModelArgs):
+        super().__init__()
+        self.model_args = model_args
+        self.vocab_size = model_args.vocab_size
+        self.n_layers = model_args.n_layers
+        self.model_dim = model_args.dim
+
+        self.tok_embeddings = nn.Embedding(model_args.vocab_size, model_args.dim)
+        self.register_buffer(
+            "freqs_cis",
+            precompute_freqs_cis(
+                model_args.dim // model_args.n_heads,
+                # Need to compute until at least the max token limit for generation
+                # (use 2x max sequence length to be safe)
+                model_args.max_seq_len * 2,
+            ),
+        )
+        self.layers = torch.nn.ModuleList()
+        for layer_id in range(model_args.n_layers):
+            self.layers.append(TransformerBlock(layer_id, model_args))
+
+        self.norm = RMSNorm(dim=model_args.dim, eps=model_args.norm_eps)
+        self.output = nn.Linear(model_args.dim, model_args.vocab_size, bias=False)
+
+    def reset_parameters(self):
+        with torch.device(self.freqs_cis.device):
+            self.freqs_cis = precompute_freqs_cis(
+                self.model_args.dim // self.model_args.n_heads,
+                # Need to compute until at least the max token limit for generation
+                # (use 2x max sequence length to be safe)
+                self.model_args.max_seq_len * 2,
+            )
+
+    def init_weights(self):
+        """[Note: On ``init_weights`` vs.
+
+        ``reset_parameters``]
+        Modules may define ``reset_parameters`` to initialize parameter values.
+        ``reset_parameters`` is meant to only initialize directly owned
+        parameters/buffers, not those of their child modules, and it can be
+        used to give the initial values for these tensors.
+        Separately, users may want custom initialization for their modules,
+        different from that in ``reset_parameters``. For this, we define
+        ``init_weights``. We only call it in the constructor of this
+        ``Transformer`` root module to avoid reinitializing tensors.
+
+        """
+        nn.init.normal_(self.tok_embeddings.weight)
+        for layer in self.layers:
+            layer.init_weights()
+        self.norm.reset_parameters()
+        final_out_std = self.model_args.dim**-0.5
+        cutoff_factor = 3
+        nn.init.trunc_normal_(
+            self.output.weight,
+            mean=0.0,
+            std=final_out_std,
+            a=-cutoff_factor * final_out_std,
+            b=cutoff_factor * final_out_std,
+        )
+
+    def forward(self, tokens: torch.Tensor):
+        """Perform a forward pass through the Transformer model.
+
+        Args:
+            tokens (torch.Tensor): Input token indices.
+
+        Returns:
+            torch.Tensor: Output logits after applying the Transformer model.
+
+        """
+        _bsz, seqlen = tokens.shape
+        h = self.tok_embeddings(tokens)
+        self.freqs_cis = self.freqs_cis.to(h.device)
+        freqs_cis = self.freqs_cis[0:seqlen]
+
+        for layer in self.layers:
+            h = layer(h, freqs_cis)
+        h = self.norm(h)
+        return self.output(h).float()
+
+    @classmethod
+    def from_model_args(cls, model_args: ModelArgs) -> "Transformer":
+        """Initialize a Transformer model from a ModelArgs object.
+
+        Args:
+            model_args (ModelArgs): Model configuration arguments.
+
+        Returns:
+            Transformer: Transformer model.
+
+        """
+        return cls(model_args)
+
+
+# Taken and modified from torchtitan
+# https://github.com/pytorch/torchtitan/blob/main/torchtitan/parallelisms/parallelize_llama.py
+def parallelize(model: Transformer, device_mesh: DeviceMesh) -> Transformer:
+    """Apply parallelisms and activation checkpointing to the model.
+
+    NOTE: The passed-in model preferably should be on meta device. Otherwise,
+    the model must fit on GPU or CPU memory.
+
+    """
+
+    dp_mesh = device_mesh["data_parallel"]
+    tp_mesh = device_mesh["tensor_parallel"]
+
+    if tp_mesh.size() > 1:
+        # 1. Parallelize the first embedding and the last linear proj layer
+        # 2. Parallelize the root norm layer over the sequence dim
+        # 3. Shard the first transformer block's inputs
+        # Parallelize the first embedding and the last linear out projection
+        plan = {
+            "tok_embeddings": RowwiseParallel(
+                input_layouts=Replicate(),
+            ),
+            "output": ColwiseParallel(input_layouts=Shard(1), output_layouts=Replicate()),
+            "norm": SequenceParallel(),
+            "layers.0": PrepareModuleInput(
+                input_layouts=(Replicate(), None),
+                desired_input_layouts=(Shard(1), None),
+                use_local_output=True,
+            ),
+        }
+        model = parallelize_module(model, tp_mesh, plan)
+
+        # Parallelize each transformer block
+        for transformer_block in model.layers:
+            plan = {
+                "attention": PrepareModuleInput(
+                    input_layouts=(Shard(1), None),
+                    desired_input_layouts=(Replicate(), None),
+                ),
+                "attention.wq": ColwiseParallel(),
+                "attention.wk": ColwiseParallel(),
+                "attention.wv": ColwiseParallel(),
+                "attention.wo": RowwiseParallel(output_layouts=Shard(1)),
+                "attention_norm": SequenceParallel(),
+                "feed_forward": PrepareModuleInput(
+                    input_layouts=(Shard(1),),
+                    desired_input_layouts=(Replicate(),),
+                ),
+                "feed_forward.w1": ColwiseParallel(),
+                "feed_forward.w2": RowwiseParallel(output_layouts=Shard(1)),
+                "feed_forward.w3": ColwiseParallel(),
+                "ffn_norm": SequenceParallel(),
+            }
+
+            # Adjust attention module to use the local number of heads
+            attn_layer = transformer_block.attention
+            attn_layer.n_heads = attn_layer.n_heads // tp_mesh.size()
+            attn_layer.n_kv_heads = attn_layer.n_kv_heads // tp_mesh.size()
+
+            # Apply the plan for the current transformer block
+            parallelize_module(transformer_block, tp_mesh, plan)
+
+    if dp_mesh.size() > 1:
+        assert dp_mesh.ndim == 1  # Hybrid-sharding not supported
+
+        mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.float32)
+        fsdp_config = {"mesh": dp_mesh, "mp_policy": mp_policy}
+        for layer_id, transformer_block in enumerate(model.layers):
+            # Apply activation checkpointing
+            transformer_block = checkpoint_wrapper(transformer_block)
+            # As an optimization, do not reshard after forward for the last
+            # transformer block since FSDP would prefetch it immediately
+            reshard_after_forward = layer_id < len(model.layers) - 1
+            fully_shard(
+                transformer_block,
+                **fsdp_config,
+                reshard_after_forward=reshard_after_forward,
+            )
+            model.layers[layer_id] = transformer_block
+        model = fully_shard(model, **fsdp_config)
+
+    return model

--- a/examples/fabric/tensor_parallel/model.py
+++ b/examples/fabric/tensor_parallel/model.py
@@ -7,18 +7,6 @@ from typing import Optional, Tuple
 import torch
 import torch.nn.functional as F
 from torch import nn
-from torch.distributed._composable.fsdp import MixedPrecisionPolicy
-from torch.distributed._composable.fsdp.fully_shard import fully_shard
-from torch.distributed._tensor import Replicate, Shard
-from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
-from torch.distributed.device_mesh import DeviceMesh
-from torch.distributed.tensor.parallel import (
-    ColwiseParallel,
-    PrepareModuleInput,
-    RowwiseParallel,
-    SequenceParallel,
-    parallelize_module,
-)
 
 
 @dataclass
@@ -446,87 +434,3 @@ class Transformer(nn.Module):
 
         """
         return cls(model_args)
-
-
-# Taken and modified from torchtitan
-# https://github.com/pytorch/torchtitan/blob/main/torchtitan/parallelisms/parallelize_llama.py
-def parallelize(model: Transformer, device_mesh: DeviceMesh) -> Transformer:
-    """Apply parallelisms and activation checkpointing to the model.
-
-    NOTE: The passed-in model preferably should be on meta device. Otherwise,
-    the model must fit on GPU or CPU memory.
-
-    """
-
-    dp_mesh = device_mesh["data_parallel"]
-    tp_mesh = device_mesh["tensor_parallel"]
-
-    if tp_mesh.size() > 1:
-        # 1. Parallelize the first embedding and the last linear proj layer
-        # 2. Parallelize the root norm layer over the sequence dim
-        # 3. Shard the first transformer block's inputs
-        # Parallelize the first embedding and the last linear out projection
-        plan = {
-            "tok_embeddings": RowwiseParallel(
-                input_layouts=Replicate(),
-            ),
-            "output": ColwiseParallel(input_layouts=Shard(1), output_layouts=Replicate()),
-            "norm": SequenceParallel(),
-            "layers.0": PrepareModuleInput(
-                input_layouts=(Replicate(), None),
-                desired_input_layouts=(Shard(1), None),
-                use_local_output=True,
-            ),
-        }
-        model = parallelize_module(model, tp_mesh, plan)
-
-        # Parallelize each transformer block
-        for transformer_block in model.layers:
-            plan = {
-                "attention": PrepareModuleInput(
-                    input_layouts=(Shard(1), None),
-                    desired_input_layouts=(Replicate(), None),
-                ),
-                "attention.wq": ColwiseParallel(),
-                "attention.wk": ColwiseParallel(),
-                "attention.wv": ColwiseParallel(),
-                "attention.wo": RowwiseParallel(output_layouts=Shard(1)),
-                "attention_norm": SequenceParallel(),
-                "feed_forward": PrepareModuleInput(
-                    input_layouts=(Shard(1),),
-                    desired_input_layouts=(Replicate(),),
-                ),
-                "feed_forward.w1": ColwiseParallel(),
-                "feed_forward.w2": RowwiseParallel(output_layouts=Shard(1)),
-                "feed_forward.w3": ColwiseParallel(),
-                "ffn_norm": SequenceParallel(),
-            }
-
-            # Adjust attention module to use the local number of heads
-            attn_layer = transformer_block.attention
-            attn_layer.n_heads = attn_layer.n_heads // tp_mesh.size()
-            attn_layer.n_kv_heads = attn_layer.n_kv_heads // tp_mesh.size()
-
-            # Apply the plan for the current transformer block
-            parallelize_module(transformer_block, tp_mesh, plan)
-
-    if dp_mesh.size() > 1:
-        assert dp_mesh.ndim == 1  # Hybrid-sharding not supported
-
-        mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.float32)
-        fsdp_config = {"mesh": dp_mesh, "mp_policy": mp_policy}
-        for layer_id, transformer_block in enumerate(model.layers):
-            # Apply activation checkpointing
-            transformer_block = checkpoint_wrapper(transformer_block)
-            # As an optimization, do not reshard after forward for the last
-            # transformer block since FSDP would prefetch it immediately
-            reshard_after_forward = layer_id < len(model.layers) - 1
-            fully_shard(
-                transformer_block,
-                **fsdp_config,
-                reshard_after_forward=reshard_after_forward,
-            )
-            model.layers[layer_id] = transformer_block
-        model = fully_shard(model, **fsdp_config)
-
-    return model

--- a/examples/fabric/tensor_parallel/parallelism.py
+++ b/examples/fabric/tensor_parallel/parallelism.py
@@ -79,7 +79,10 @@ def parallelize(model: Transformer, device_mesh: DeviceMesh) -> Transformer:
     if dp_mesh.size() > 1:
         assert dp_mesh.ndim == 1  # Hybrid-sharding not supported
 
+        # NOTE: Currently, the user is required to manually handle precision settings such as the `mp_policy` here
+        # because the model parallel strategy does not respect all settings of `Fabric(precision=...)` at the moment.
         mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.float32)
+
         fsdp_config = {"mesh": dp_mesh, "mp_policy": mp_policy}
         for layer_id, transformer_block in enumerate(model.layers):
             # Apply activation checkpointing

--- a/examples/fabric/tensor_parallel/parallelism.py
+++ b/examples/fabric/tensor_parallel/parallelism.py
@@ -1,5 +1,5 @@
 import torch
-
+from model import Transformer
 from torch.distributed._composable.fsdp import MixedPrecisionPolicy
 from torch.distributed._composable.fsdp.fully_shard import fully_shard
 from torch.distributed._tensor import Replicate, Shard
@@ -12,8 +12,6 @@ from torch.distributed.tensor.parallel import (
     SequenceParallel,
     parallelize_module,
 )
-
-from model import Transformer
 
 
 # Taken and modified from torchtitan

--- a/examples/fabric/tensor_parallel/parallelism.py
+++ b/examples/fabric/tensor_parallel/parallelism.py
@@ -1,0 +1,100 @@
+import torch
+
+from torch.distributed._composable.fsdp import MixedPrecisionPolicy
+from torch.distributed._composable.fsdp.fully_shard import fully_shard
+from torch.distributed._tensor import Replicate, Shard
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    PrepareModuleInput,
+    RowwiseParallel,
+    SequenceParallel,
+    parallelize_module,
+)
+
+from model import Transformer
+
+
+# Taken and modified from torchtitan
+# https://github.com/pytorch/torchtitan/blob/main/torchtitan/parallelisms/parallelize_llama.py
+def parallelize(model: Transformer, device_mesh: DeviceMesh) -> Transformer:
+    """Apply parallelisms and activation checkpointing to the model.
+
+    NOTE: The passed-in model preferably should be on meta device. Otherwise,
+    the model must fit on GPU or CPU memory.
+
+    """
+
+    dp_mesh = device_mesh["data_parallel"]
+    tp_mesh = device_mesh["tensor_parallel"]
+
+    if tp_mesh.size() > 1:
+        # 1. Parallelize the first embedding and the last linear proj layer
+        # 2. Parallelize the root norm layer over the sequence dim
+        # 3. Shard the first transformer block's inputs
+        # Parallelize the first embedding and the last linear out projection
+        plan = {
+            "tok_embeddings": RowwiseParallel(
+                input_layouts=Replicate(),
+            ),
+            "output": ColwiseParallel(input_layouts=Shard(1), output_layouts=Replicate()),
+            "norm": SequenceParallel(),
+            "layers.0": PrepareModuleInput(
+                input_layouts=(Replicate(), None),
+                desired_input_layouts=(Shard(1), None),
+                use_local_output=True,
+            ),
+        }
+        model = parallelize_module(model, tp_mesh, plan)
+
+        # Parallelize each transformer block
+        for transformer_block in model.layers:
+            plan = {
+                "attention": PrepareModuleInput(
+                    input_layouts=(Shard(1), None),
+                    desired_input_layouts=(Replicate(), None),
+                ),
+                "attention.wq": ColwiseParallel(),
+                "attention.wk": ColwiseParallel(),
+                "attention.wv": ColwiseParallel(),
+                "attention.wo": RowwiseParallel(output_layouts=Shard(1)),
+                "attention_norm": SequenceParallel(),
+                "feed_forward": PrepareModuleInput(
+                    input_layouts=(Shard(1),),
+                    desired_input_layouts=(Replicate(),),
+                ),
+                "feed_forward.w1": ColwiseParallel(),
+                "feed_forward.w2": RowwiseParallel(output_layouts=Shard(1)),
+                "feed_forward.w3": ColwiseParallel(),
+                "ffn_norm": SequenceParallel(),
+            }
+
+            # Adjust attention module to use the local number of heads
+            attn_layer = transformer_block.attention
+            attn_layer.n_heads = attn_layer.n_heads // tp_mesh.size()
+            attn_layer.n_kv_heads = attn_layer.n_kv_heads // tp_mesh.size()
+
+            # Apply the plan for the current transformer block
+            parallelize_module(transformer_block, tp_mesh, plan)
+
+    if dp_mesh.size() > 1:
+        assert dp_mesh.ndim == 1  # Hybrid-sharding not supported
+
+        mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.float32)
+        fsdp_config = {"mesh": dp_mesh, "mp_policy": mp_policy}
+        for layer_id, transformer_block in enumerate(model.layers):
+            # Apply activation checkpointing
+            transformer_block = checkpoint_wrapper(transformer_block)
+            # As an optimization, do not reshard after forward for the last
+            # transformer block since FSDP would prefetch it immediately
+            reshard_after_forward = layer_id < len(model.layers) - 1
+            fully_shard(
+                transformer_block,
+                **fsdp_config,
+                reshard_after_forward=reshard_after_forward,
+            )
+            model.layers[layer_id] = transformer_block
+        model = fully_shard(model, **fsdp_config)
+
+    return model

--- a/examples/fabric/tensor_parallel/train.py
+++ b/examples/fabric/tensor_parallel/train.py
@@ -1,0 +1,77 @@
+import lightning as L
+import torch
+import torch.nn.functional as F
+from data import RandomTokenDataset
+from lightning.fabric.strategies import ModelParallelStrategy
+from model import ModelArgs, Transformer, parallelize
+from torch.distributed.tensor.parallel import loss_parallel
+from torch.utils.data import DataLoader
+
+
+def train():
+    strategy = ModelParallelStrategy(
+        # User-defined function that applies the desired parallelizations specific to the model
+        # (TP, FSDP2, activation checkpointing, ...)
+        parallelize_fn=parallelize,
+        # Define the size of the 2D parallelism
+        # Set to "auto" to apply TP intra-node and DP inter-node
+        data_parallel_size=2,
+        tensor_parallel_size=2,
+    )
+
+    fabric = L.Fabric(accelerator="cuda", devices=4, strategy=strategy)
+    fabric.launch()
+
+    # Initialize the model
+    model_args = ModelArgs(vocab_size=32000)
+    with fabric.init_module(empty_init=True):
+        model = Transformer(model_args)
+
+    fabric.print(f"Number of model parameters: {sum(p.numel() for p in model.parameters()) / 1e9:.1f} B")
+
+    # Define the optimizer
+    optimizer = torch.optim.AdamW(model.parameters(), lr=3e-3, foreach=True)
+
+    # Set up model and optimizer
+    model, optimizer = fabric.setup(model, optimizer)
+
+    model.init_weights()
+
+    # Define dataset/dataloader
+    dataset = RandomTokenDataset(vocab_size=model_args.vocab_size, seq_length=128)
+    dataloader = DataLoader(dataset, batch_size=8)
+
+    # Fabric configures the sampler automatically for you such that
+    # all batches in a tensor-parallel group are identical
+    dataloader = fabric.setup_dataloaders(dataloader)
+
+    # Simplified training loop
+    fabric.print("Starting training ...")
+
+    for i, batch in enumerate(dataloader):
+        inputs = batch[:, :-1]
+        labels = batch[:, 1:]
+
+        output = model(inputs)
+
+        with loss_parallel():
+            loss = F.cross_entropy(output.reshape(-1, output.size(-1)), labels.reshape(-1))
+
+        fabric.backward(loss)
+        optimizer.step()
+        optimizer.zero_grad()
+        fabric.print(f"Iteration {i} complete")
+
+    # See `fabric consolidate --help` if you need to convert the checkpoint to a single file
+    fabric.print("Saving a (distributed) checkpoint ...")
+    state = {"model": model, "optimizer": optimizer, "iteration": i}
+    fabric.save("checkpoint.pt", state)
+
+    fabric.print("Training successfully completed!")
+    fabric.print(f"Peak memory usage: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB")
+
+
+if __name__ == "__main__":
+    assert torch.cuda.device_count() >= 4, "This example requires at least 4 GPUs with 24 GB of memory each."
+    torch.set_float32_matmul_precision("high")
+    train()

--- a/examples/fabric/tensor_parallel/train.py
+++ b/examples/fabric/tensor_parallel/train.py
@@ -1,13 +1,12 @@
 import lightning as L
 import torch
 import torch.nn.functional as F
-from torch.distributed.tensor.parallel import loss_parallel
-from torch.utils.data import DataLoader
-from lightning.fabric.strategies import ModelParallelStrategy
-
 from data import RandomTokenDataset
+from lightning.fabric.strategies import ModelParallelStrategy
 from model import ModelArgs, Transformer
 from parallelism import parallelize
+from torch.distributed.tensor.parallel import loss_parallel
+from torch.utils.data import DataLoader
 
 
 def train():

--- a/examples/fabric/tensor_parallel/train.py
+++ b/examples/fabric/tensor_parallel/train.py
@@ -1,11 +1,13 @@
 import lightning as L
 import torch
 import torch.nn.functional as F
-from data import RandomTokenDataset
-from lightning.fabric.strategies import ModelParallelStrategy
-from model import ModelArgs, Transformer, parallelize
 from torch.distributed.tensor.parallel import loss_parallel
 from torch.utils.data import DataLoader
+from lightning.fabric.strategies import ModelParallelStrategy
+
+from data import RandomTokenDataset
+from model import ModelArgs, Transformer
+from parallelism import parallelize
 
 
 def train():

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -53,7 +53,7 @@ from lightning.fabric.strategies import (
     Strategy,
     XLAStrategy,
 )
-from lightning.fabric.strategies.fsdp import _has_meta_device_parameters_or_buffers
+from lightning.fabric.utilities.init import _has_meta_device_parameters_or_buffers
 from lightning.fabric.strategies.launchers import _MultiProcessingLauncher, _XLALauncher
 from lightning.fabric.strategies.strategy import TBroadcast, _Sharded
 from lightning.fabric.utilities import move_data_to_device

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -53,7 +53,6 @@ from lightning.fabric.strategies import (
     Strategy,
     XLAStrategy,
 )
-from lightning.fabric.utilities.init import _has_meta_device_parameters_or_buffers
 from lightning.fabric.strategies.launchers import _MultiProcessingLauncher, _XLALauncher
 from lightning.fabric.strategies.strategy import TBroadcast, _Sharded
 from lightning.fabric.utilities import move_data_to_device
@@ -66,6 +65,7 @@ from lightning.fabric.utilities.data import (
 )
 from lightning.fabric.utilities.device_dtype_mixin import _update_properties
 from lightning.fabric.utilities.distributed import DistributedSamplerWrapper, _InfiniteBarrier
+from lightning.fabric.utilities.init import _has_meta_device_parameters_or_buffers
 from lightning.fabric.utilities.rank_zero import rank_zero_deprecation, rank_zero_warn
 from lightning.fabric.utilities.registry import _load_external_callbacks
 from lightning.fabric.utilities.seed import seed_everything

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -53,7 +53,7 @@ from lightning.fabric.strategies import (
     Strategy,
     XLAStrategy,
 )
-from lightning.fabric.strategies.fsdp import _has_meta_device_parameters
+from lightning.fabric.strategies.fsdp import _has_meta_device_parameters_or_buffers
 from lightning.fabric.strategies.launchers import _MultiProcessingLauncher, _XLALauncher
 from lightning.fabric.strategies.strategy import TBroadcast, _Sharded
 from lightning.fabric.utilities import move_data_to_device
@@ -1016,7 +1016,7 @@ class Fabric:
             raise ValueError("An optimizer should be passed only once to the `setup` method.")
 
         if isinstance(self._strategy, FSDPStrategy) and any(
-            _has_meta_device_parameters(optimizer) for optimizer in optimizers
+            _has_meta_device_parameters_or_buffers(optimizer) for optimizer in optimizers
         ):
             raise RuntimeError(
                 "The optimizer has references to the model's meta-device parameters. Materializing them is"
@@ -1044,7 +1044,7 @@ class Fabric:
         if any(isinstance(opt, _FabricOptimizer) for opt in optimizers):
             raise ValueError("An optimizer should be passed only once to the `setup_optimizers` method.")
 
-        if any(_has_meta_device_parameters(optimizer) for optimizer in optimizers):
+        if any(_has_meta_device_parameters_or_buffers(optimizer) for optimizer in optimizers):
             raise RuntimeError(
                 "The optimizer has references to the model's meta-device parameters. Materializing them is"
                 " is currently not supported. Create the optimizer after setting up the model, then call"

--- a/src/lightning/fabric/strategies/__init__.py
+++ b/src/lightning/fabric/strategies/__init__.py
@@ -17,6 +17,7 @@ from lightning.fabric.strategies.ddp import DDPStrategy  # noqa: F401
 from lightning.fabric.strategies.deepspeed import DeepSpeedStrategy  # noqa: F401
 from lightning.fabric.strategies.dp import DataParallelStrategy  # noqa: F401
 from lightning.fabric.strategies.fsdp import FSDPStrategy  # noqa: F401
+from lightning.fabric.strategies.model_parallel import ModelParallelStrategy  # noqa: F401
 from lightning.fabric.strategies.parallel import ParallelStrategy  # noqa: F401
 from lightning.fabric.strategies.registry import _StrategyRegistry
 from lightning.fabric.strategies.single_device import SingleDeviceStrategy  # noqa: F401

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import itertools
 import shutil
 from contextlib import ExitStack, nullcontext
 from datetime import timedelta
@@ -37,7 +36,7 @@ import torch
 from lightning_utilities.core.imports import RequirementCache
 from lightning_utilities.core.rank_zero import rank_zero_only as utils_rank_zero_only
 from torch import Tensor
-from torch.nn import Module, Parameter
+from torch.nn import Module
 from torch.optim import Optimizer
 from typing_extensions import TypeGuard, override
 

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -68,7 +68,7 @@ from lightning.fabric.utilities.imports import (
     _TORCH_GREATER_EQUAL_2_2,
     _TORCH_GREATER_EQUAL_2_3,
 )
-from lightning.fabric.utilities.init import _EmptyInit
+from lightning.fabric.utilities.init import _EmptyInit, _has_meta_device_parameters_or_buffers
 from lightning.fabric.utilities.load import _METADATA_FILENAME, _lazy_load, _materialize_tensors, _move_state_into
 from lightning.fabric.utilities.rank_zero import rank_zero_deprecation, rank_zero_only, rank_zero_warn
 from lightning.fabric.utilities.seed import reset_seed
@@ -869,16 +869,6 @@ def _load_raw_module_state(state_dict: Dict[str, Any], module: Module, world_siz
     else:
         with _get_full_state_dict_context(module, world_size=world_size, rank0_only=False):
             module.load_state_dict(state_dict, strict=strict)
-
-
-def _has_meta_device_parameters_or_buffers(obj: Union[Module, Optimizer], recurse: bool = True) -> bool:
-    if isinstance(obj, Optimizer):
-        return any(
-            t.is_meta for param_group in obj.param_groups for t in param_group["params"] if isinstance(t, Parameter)
-        )
-    if isinstance(obj, Module):
-        return any(t.is_meta for t in itertools.chain(obj.parameters(recurse=recurse), obj.buffers(recurse=recurse)))
-    raise TypeError(f"Expected `torch.nn.Module` or `torch.optim.Optimizer`, got: {type(obj).__name__}")
 
 
 def _move_torchmetrics_to_device(module: torch.nn.Module, device: torch.device) -> None:

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -1,0 +1,331 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import itertools
+from contextlib import ExitStack
+from datetime import timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, ContextManager, Dict, Literal, Optional, TypeVar, Union
+
+import torch
+from lightning_utilities.core.rank_zero import rank_zero_only as utils_rank_zero_only
+from torch import Tensor
+from torch.nn import Module
+from torch.optim import Optimizer
+from typing_extensions import override
+
+from lightning.fabric.plugins import CheckpointIO
+from lightning.fabric.plugins.collectives.torch_collective import default_pg_timeout
+from lightning.fabric.strategies.fsdp import (
+    _distributed_checkpoint_load,
+    _distributed_checkpoint_save,
+    _has_meta_device_parameters_or_buffers,
+)
+from lightning.fabric.strategies.launchers.subprocess_script import _SubprocessScriptLauncher
+from lightning.fabric.strategies.parallel import ParallelStrategy
+from lightning.fabric.strategies.strategy import TBroadcast, _BackwardSyncControl
+from lightning.fabric.utilities.distributed import (
+    ReduceOp,
+    _distributed_is_initialized,
+    _get_default_process_group_backend_for_device,
+    _init_dist_connection,
+    _sync_ddp_if_available,
+)
+from lightning.fabric.utilities.distributed import group as _group
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_3
+from lightning.fabric.utilities.rank_zero import rank_zero_only, rank_zero_warn
+from lightning.fabric.utilities.seed import reset_seed
+from lightning.fabric.utilities.types import _PATH
+
+if TYPE_CHECKING:
+    from torch.distributed.device_mesh import DeviceMesh
+
+TModel = TypeVar("TModel", bound=Module)
+
+
+class ModelParallelStrategy(ParallelStrategy):
+    """Enables user-defined parallelism applied to a model.
+
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
+
+    Currently supports up to 2D parallelism, for example Fully Sharded Data-Parallel combined with
+    Tensor Parallelism. Requires PyTorch 2.3 or newer.
+
+    Arguments:
+        parallelize_fn: A function that applies parallelisms to a module. The strategy will provide the
+            model and device mesh as input.
+        data_parallel_size: The number of devices within a data-parallel group. Defaults to ``"auto"``, which
+            sets this size to the number of nodes in the cluster.
+        tensor_parallel_size: The number of devices within a tensor-parallel group. Defaults to ``"auto"``, which
+            sets this size to the number of GPUs in a single node.
+
+    """
+
+    def __init__(
+        self,
+        parallelize_fn: Callable[[TModel, "DeviceMesh"], TModel],
+        data_parallel_size: Union[Literal["auto"], int] = "auto",
+        tensor_parallel_size: Union[Literal["auto"], int] = "auto",
+        process_group_backend: Optional[str] = None,
+        timeout: Optional[timedelta] = default_pg_timeout,
+    ) -> None:
+        super().__init__()
+        if not _TORCH_GREATER_EQUAL_2_3:
+            raise ImportError(f"{self.__class__.__name__} requires PyTorch 2.3 or higher.")
+        self._parallelize_fn = parallelize_fn
+        self._data_parallel_size = data_parallel_size
+        self._tensor_parallel_size = tensor_parallel_size
+        self._num_nodes = 1
+        self._process_group_backend: Optional[str] = process_group_backend
+        self._timeout: Optional[timedelta] = timeout
+        self._backward_sync_control = _ParallelBackwardSyncControl()
+
+        self._device_mesh: Optional["DeviceMesh"] = None
+
+    @property
+    def device_mesh(self) -> "DeviceMesh":
+        if self._device_mesh is None:
+            raise RuntimeError("Accessing the device mesh before processes have initialized is not allowed.")
+        return self._device_mesh
+
+    @property
+    @override
+    def checkpoint_io(self) -> CheckpointIO:
+        raise NotImplementedError(f"The `{type(self).__name__}` does not use the `CheckpointIO` plugin interface.")
+
+    @checkpoint_io.setter
+    @override
+    def checkpoint_io(self, io: CheckpointIO) -> None:
+        raise NotImplementedError(f"The `{type(self).__name__}` does not support setting a `CheckpointIO` plugin.")
+
+    @property
+    @override
+    def root_device(self) -> torch.device:
+        assert self.parallel_devices is not None
+        return self.parallel_devices[self.local_rank]
+
+    @property
+    def num_nodes(self) -> int:
+        return self._num_nodes
+
+    @num_nodes.setter
+    def num_nodes(self, num_nodes: int) -> None:
+        self._num_nodes = num_nodes
+
+    @property
+    def num_processes(self) -> int:
+        return len(self.parallel_devices) if self.parallel_devices is not None else 0
+
+    @property
+    @override
+    def distributed_sampler_kwargs(self) -> Dict[str, Any]:
+        assert self.device_mesh is not None
+        data_parallel_mesh = self.device_mesh["data_parallel"]
+        return {"num_replicas": data_parallel_mesh.size(), "rank": data_parallel_mesh.get_local_rank()}
+
+    @property
+    def process_group_backend(self) -> Optional[str]:
+        return self._process_group_backend
+
+    @override
+    def _configure_launcher(self) -> None:
+        assert self.cluster_environment is not None
+        if not self.cluster_environment.creates_processes_externally:
+            self._launcher = _SubprocessScriptLauncher(self.cluster_environment, self.num_processes, self.num_nodes)
+
+    @override
+    def setup_environment(self) -> None:
+        super().setup_environment()
+        self._setup_distributed()
+        self._setup_device_mesh()
+
+    @override
+    def setup_module(self, module: Module) -> Module:
+        module = self._parallelize_fn(module, self.device_mesh)
+        if not isinstance(module, Module):
+            raise TypeError(
+                f"The `parallelize_fn` must return a `nn.Module` instance, but got: {type(module).__name__}"
+            )
+        _materialize_module(module, self.root_device)
+        return module
+
+    @override
+    def module_to_device(self, module: Module) -> None:
+        pass
+
+    @override
+    def module_init_context(self, empty_init: Optional[bool] = None) -> ContextManager:
+        precision_init_ctx = self.precision.module_init_context()
+        stack = ExitStack()
+        if empty_init:
+            # Materializaton happens in `setup_module`
+            # TODO: Introduce `Fabric.materialize(module)` to give user control over materialization
+            stack.enter_context(torch.device("meta"))
+        stack.enter_context(precision_init_ctx)
+        return stack
+
+    @override
+    def all_reduce(
+        self, tensor: Tensor, group: Optional[Any] = None, reduce_op: Optional[Union[ReduceOp, str]] = "mean"
+    ) -> Tensor:
+        if isinstance(tensor, Tensor):
+            return _sync_ddp_if_available(tensor, group, reduce_op=reduce_op)
+        return tensor
+
+    @override
+    def barrier(self, *args: Any, **kwargs: Any) -> None:
+        if not _distributed_is_initialized():
+            return
+        if torch.distributed.get_backend() == "nccl":
+            torch.distributed.barrier(device_ids=[self.root_device.index])
+        else:
+            torch.distributed.barrier()
+
+    @override
+    def broadcast(self, obj: TBroadcast, src: int = 0) -> TBroadcast:
+        if not _distributed_is_initialized():
+            return obj
+
+        obj = [obj]
+        torch.distributed.broadcast_object_list(obj, src, group=_group.WORLD)
+        return obj[0]
+
+    @override
+    def save_checkpoint(
+        self,
+        path: _PATH,
+        state: Dict[str, Union[Module, Optimizer, Any]],
+        storage_options: Optional[Any] = None,
+        filter: Optional[Dict[str, Callable[[str, Any], bool]]] = None,
+    ) -> None:
+        """Save model, optimizer, and other state to a checkpoint on disk."""
+        if storage_options is not None:
+            raise TypeError(
+                f"`{self.__class__.__name__}.save_checkpoint(..., storage_options=...)` is not supported because"
+                f" `{self.__class__.__name__}` does not use the `CheckpointIO`."
+            )
+        if filter is not None:
+            raise NotImplementedError(f"{self.__class__.__name__} does not yet support the `filter` argument.")
+
+        # broadcast the path from rank 0 to ensure all the states are saved in a common path
+        path = Path(self.broadcast(path))
+        _distributed_checkpoint_save(state, path)
+
+    @override
+    def load_checkpoint(
+        self,
+        path: _PATH,
+        state: Optional[Union[Module, Optimizer, Dict[str, Union[Module, Optimizer, Any]]]] = None,
+        strict: bool = True,
+    ) -> Dict[str, Any]:
+        if isinstance(state, (Module, Optimizer)):
+            raise NotImplementedError(
+                "Loading a module or optimizer object from a checkpoint directly is not yet supported."
+            )
+        if strict is False:
+            raise NotImplementedError(f"Non-strict loading is not yet supported in {self.__class__.__name__}.")
+
+        # broadcast the path from rank 0 to ensure all the states are loaded from a common path
+        path = Path(self.broadcast(path))
+        _distributed_checkpoint_load(state, path)  # type: ignore[arg-type]
+        return {}
+
+    def _setup_distributed(self) -> None:
+        reset_seed()
+        self._set_world_ranks()
+        self._process_group_backend = self._get_process_group_backend()
+        assert self.cluster_environment is not None
+        _init_dist_connection(self.cluster_environment, self._process_group_backend, timeout=self._timeout)
+
+    def _setup_device_mesh(self) -> None:
+        from torch.distributed.device_mesh import init_device_mesh
+
+        if self._data_parallel_size == "auto":
+            self._data_parallel_size = self.num_nodes
+        if self._tensor_parallel_size == "auto":
+            self._tensor_parallel_size = self.num_processes
+        if self._data_parallel_size * self._tensor_parallel_size != self.world_size:
+            raise RuntimeError(
+                f"The sizes `data_parallel_size={self._data_parallel_size}` and"
+                f" `tensor_parallel_size={self._tensor_parallel_size}` multiplied should equal the world size"
+                f" ({self.world_size})."
+            )
+        self._device_mesh = init_device_mesh(
+            device_type=self.root_device.type,
+            mesh_shape=(self._data_parallel_size, self._tensor_parallel_size),
+            mesh_dim_names=("data_parallel", "tensor_parallel"),
+        )
+
+    def _get_process_group_backend(self) -> str:
+        return self._process_group_backend or _get_default_process_group_backend_for_device(self.root_device)
+
+    def _set_world_ranks(self) -> None:
+        if self.cluster_environment is not None:
+            self.cluster_environment.set_global_rank(self.node_rank * self.num_processes + self.local_rank)
+            self.cluster_environment.set_world_size(self.num_nodes * self.num_processes)
+        # `LightningEnvironment.set_global_rank` will do this too, but we cannot rely on that implementation detail
+        # additionally, for some implementations, the setter is a no-op, so it's safer to access the getter
+        rank_zero_only.rank = utils_rank_zero_only.rank = self.global_rank
+
+
+def _materialize_module(module: Module, device: torch.device) -> None:
+    # Reference: https://github.com/pytorch/torchtitan/blob/main/docs/fsdp.md#meta-device-initialization
+    # TODO: Introduce `Fabric.materialize(module)` to give user control when materialization should happen
+    # TODO: Make `torchmetrics.Metric` compatible with the `to_empty()` + `reset_parameters()` semantics
+    if not _has_meta_device_parameters_or_buffers(module):
+        return
+
+    module.to_empty(device=device)  # has to be called on the root module
+
+    uninitialized_modules = set()
+    for submodule in module.modules():
+        if all(False for _ in itertools.chain(submodule.parameters(recurse=False), submodule.buffers(recurse=False))):
+            # module has no parameters or buffers
+            continue
+        if callable(reset_method := getattr(submodule, "reset_parameters", None)):
+            reset_method()
+        else:
+            uninitialized_modules.add(type(submodule).__name__)
+
+    if uninitialized_modules:
+        rank_zero_warn(
+            "Parameter initialization incomplete. The following modules have parameters or buffers with uninitialized"
+            " memory because they don't define a `reset_parameters()` method for re-initialization:"
+            f" {', '.join(uninitialized_modules)}"
+        )
+
+
+class _ParallelBackwardSyncControl(_BackwardSyncControl):
+    @override
+    def no_backward_sync(self, module: Module, enabled: bool) -> ContextManager:
+        """Blocks gradient synchronization inside the FSDP2 modules."""
+        return _FSDPNoSync(module=module, enabled=enabled)
+
+
+class _FSDPNoSync(ContextManager):
+    def __init__(self, module: Module, enabled: bool) -> None:
+        self._module = module
+        self._enabled = enabled
+
+    def _set_requires_grad_sync(self, requires_grad_sync: bool) -> None:
+        from torch.distributed._composable.fsdp import FSDP
+
+        for mod in self._module.modules():
+            if isinstance(mod, FSDP):
+                mod.set_requires_gradient_sync(requires_grad_sync, recurse=False)
+
+    def __enter__(self) -> None:
+        self._set_requires_grad_sync(not self._enabled)
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self._set_requires_grad_sync(self._enabled)

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import itertools
 from contextlib import ExitStack
 from datetime import timedelta
 from pathlib import Path
@@ -24,7 +23,6 @@ from torch.nn import Module
 from torch.optim import Optimizer
 from typing_extensions import override
 
-from lightning.fabric.utilities.init import _materialize_distributed_module
 from lightning.fabric.plugins import CheckpointIO
 from lightning.fabric.plugins.collectives.torch_collective import default_pg_timeout
 from lightning.fabric.strategies.fsdp import (
@@ -43,7 +41,8 @@ from lightning.fabric.utilities.distributed import (
 )
 from lightning.fabric.utilities.distributed import group as _group
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_3
-from lightning.fabric.utilities.rank_zero import rank_zero_only, rank_zero_warn
+from lightning.fabric.utilities.init import _materialize_distributed_module
+from lightning.fabric.utilities.rank_zero import rank_zero_only
 from lightning.fabric.utilities.seed import reset_seed
 from lightning.fabric.utilities.types import _PATH
 

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -151,7 +151,7 @@ class ModelParallelStrategy(ParallelStrategy):
         self._setup_device_mesh()
 
     @override
-    def setup_module(self, module: Module) -> Module:
+    def setup_module(self, module: TModel) -> TModel:
         from torch.distributed.fsdp import FullyShardedDataParallel
 
         if any(isinstance(mod, FullyShardedDataParallel) for mod in module.modules()):

--- a/src/lightning/fabric/utilities/init.py
+++ b/src/lightning/fabric/utilities/init.py
@@ -21,8 +21,8 @@ from torch.overrides import TorchFunctionMode
 from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_1
-from lightning.fabric.utilities.types import _DEVICE
 from lightning.fabric.utilities.rank_zero import rank_zero_warn
+from lightning.fabric.utilities.types import _DEVICE
 
 
 # From https://lernapparat.de/faster-model-init by Thomas Viehmann

--- a/src/lightning/fabric/utilities/init.py
+++ b/src/lightning/fabric/utilities/init.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import itertools
-from typing import Any, Callable, Dict, Optional, Sequence
+from typing import Any, Callable, Dict, Optional, Sequence, Union
 
 import torch
+from torch.nn import Module, Parameter
+from torch.optim import Optimizer
 from torch.overrides import TorchFunctionMode
 from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from lightning.fabric.utilities.types import _DEVICE
+from lightning.fabric.utilities.rank_zero import rank_zero_warn
 
 
 # From https://lernapparat.de/faster-model-init by Thomas Viehmann
@@ -56,7 +59,7 @@ class _EmptyInit(TorchFunctionMode):
         return func(*args, **kwargs)
 
 
-def _materialize(module: torch.nn.Module, device: _DEVICE) -> None:
+def _materialize(module: Module, device: _DEVICE) -> None:
     """Materialize a module."""
     if not _TORCH_GREATER_EQUAL_2_1:
         raise RuntimeError("recurse=False requires torch 2.1")
@@ -69,8 +72,45 @@ def _materialize(module: torch.nn.Module, device: _DEVICE) -> None:
     module.reset_parameters()
 
 
-def _materialize_meta_tensors(module: torch.nn.Module, device: _DEVICE) -> None:
+def _materialize_meta_tensors(module: Module, device: _DEVICE) -> None:
     """Materialize all tensors in a given module."""
     for module in module.modules():
-        if any(t.is_meta for t in itertools.chain(module.parameters(recurse=False), module.buffers(recurse=False))):
+        if _has_meta_device_parameters_or_buffers(module, recurse=False):
             _materialize(module, device)
+
+
+def _materialize_distributed_module(module: Module, device: torch.device) -> None:
+    # Reference: https://github.com/pytorch/torchtitan/blob/main/docs/fsdp.md#meta-device-initialization
+    # TODO: Introduce `Fabric.materialize(module)` to give user control when materialization should happen
+    # TODO: Make `torchmetrics.Metric` compatible with the `to_empty()` + `reset_parameters()` semantics
+    if not _has_meta_device_parameters_or_buffers(module):
+        return
+
+    module.to_empty(device=device)  # has to be called on the root module
+
+    uninitialized_modules = set()
+    for submodule in module.modules():
+        if all(False for _ in itertools.chain(submodule.parameters(recurse=False), submodule.buffers(recurse=False))):
+            # module has no parameters or buffers
+            continue
+        if callable(reset_method := getattr(submodule, "reset_parameters", None)):
+            reset_method()
+        else:
+            uninitialized_modules.add(type(submodule).__name__)
+
+    if uninitialized_modules:
+        rank_zero_warn(
+            "Parameter initialization incomplete. The following modules have parameters or buffers with uninitialized"
+            " memory because they don't define a `reset_parameters()` method for re-initialization:"
+            f" {', '.join(uninitialized_modules)}"
+        )
+
+
+def _has_meta_device_parameters_or_buffers(obj: Union[Module, Optimizer], recurse: bool = True) -> bool:
+    if isinstance(obj, Optimizer):
+        return any(
+            t.is_meta for param_group in obj.param_groups for t in param_group["params"] if isinstance(t, Parameter)
+        )
+    if isinstance(obj, Module):
+        return any(t.is_meta for t in itertools.chain(obj.parameters(recurse=recurse), obj.buffers(recurse=recurse)))
+    raise TypeError(f"Expected `torch.nn.Module` or `torch.optim.Optimizer`, got: {type(obj).__name__}")

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -37,7 +37,7 @@ from lightning.fabric.strategies.fsdp import (
     _distributed_checkpoint_save,
     _get_full_state_dict_context,
     _get_sharded_state_dict_context,
-    _has_meta_device_parameters,
+    _has_meta_device_parameters_or_buffers,
     _init_cpu_offload,
     _init_sharding_strategy,
     _is_full_checkpoint,
@@ -269,7 +269,7 @@ class FSDPStrategy(ParallelStrategy):
         from torch.distributed.fsdp import FullyShardedDataParallel
 
         if any(isinstance(mod, FullyShardedDataParallel) for mod in model.modules()):
-            if _has_meta_device_parameters(model):
+            if _has_meta_device_parameters_or_buffers(model):
                 rank_zero_warn(
                     "The model is already wrapped in `FSDP` but there are still parameters on the meta device."
                 )

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -37,7 +37,6 @@ from lightning.fabric.strategies.fsdp import (
     _distributed_checkpoint_save,
     _get_full_state_dict_context,
     _get_sharded_state_dict_context,
-    _has_meta_device_parameters_or_buffers,
     _init_cpu_offload,
     _init_sharding_strategy,
     _is_full_checkpoint,
@@ -55,7 +54,7 @@ from lightning.fabric.utilities.distributed import (
 )
 from lightning.fabric.utilities.distributed import group as _group
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_1
-from lightning.fabric.utilities.init import _EmptyInit
+from lightning.fabric.utilities.init import _EmptyInit, _has_meta_device_parameters_or_buffers
 from lightning.fabric.utilities.load import _lazy_load, _materialize_tensors
 from lightning.fabric.utilities.optimizer import _optimizers_to_device
 from lightning.fabric.utilities.seed import reset_seed

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -26,7 +26,7 @@ from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.strategies.fsdp import (
     _FSDPBackwardSyncControl,
     _get_full_state_dict_context,
-    _has_meta_device_parameters,
+    _has_meta_device_parameters_or_buffers,
     _is_sharded_checkpoint,
 )
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_1, _TORCH_GREATER_EQUAL_2_2
@@ -34,14 +34,14 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import CPUOffload, Fully
 from torch.optim import Adam
 
 
-def test_fsdp_custom_mixed_precision():
+def test_custom_mixed_precision():
     """Test that passing a custom mixed precision config works."""
     config = MixedPrecision()
     strategy = FSDPStrategy(mixed_precision=config)
     assert strategy.mixed_precision_config == config
 
 
-def test_fsdp_cpu_offload():
+def test_cpu_offload():
     """Test the different ways cpu offloading can be enabled."""
     # bool
     strategy = FSDPStrategy(cpu_offload=True)
@@ -53,7 +53,7 @@ def test_fsdp_cpu_offload():
     assert strategy.cpu_offload == config
 
 
-def test_fsdp_sharding_strategy():
+def test_sharding_strategy():
     """Test the different ways the sharding strategy can be set."""
     from torch.distributed.fsdp import ShardingStrategy
 
@@ -73,7 +73,7 @@ def test_fsdp_sharding_strategy():
 
 
 @pytest.mark.parametrize("sharding_strategy", ["HYBRID_SHARD", "_HYBRID_SHARD_ZERO2"])
-def test_fsdp_hybrid_shard_configuration(sharding_strategy):
+def test_hybrid_shard_configuration(sharding_strategy):
     """Test that the hybrid sharding strategies can only be used with automatic wrapping or a manually specified pg."""
     with pytest.raises(RuntimeError, match="The hybrid sharding strategy requires you to pass at least one of"):
         FSDPStrategy(sharding_strategy=sharding_strategy)
@@ -95,7 +95,7 @@ def test_fsdp_hybrid_shard_configuration(sharding_strategy):
         FSDPStrategy(sharding_strategy=sharding_strategy, process_group=process_group, device_mesh=device_mesh)
 
 
-def test_fsdp_checkpoint_io_unsupported():
+def test_checkpoint_io_unsupported():
     """Test that the FSDP strategy does not support the `CheckpointIO` plugin."""
     strategy = FSDPStrategy()
     with pytest.raises(NotImplementedError, match="does not use the `CheckpointIO` plugin"):
@@ -106,7 +106,7 @@ def test_fsdp_checkpoint_io_unsupported():
 
 
 @mock.patch("lightning.fabric.strategies.fsdp.FSDPStrategy.setup_module")
-def test_fsdp_setup_use_orig_params(_):
+def test_setup_use_orig_params(_):
     module = nn.Linear(2, 2)
     optimizer = Adam(module.parameters())
 
@@ -122,7 +122,7 @@ def test_fsdp_setup_use_orig_params(_):
     assert strategy._fsdp_kwargs["use_orig_params"]
 
 
-def test_fsdp_no_backward_sync():
+def test_no_backward_sync():
     """Test that the backward sync control calls `.no_sync()`, and only on a module wrapped in
     FullyShardedDataParallel."""
 
@@ -143,14 +143,14 @@ def test_fsdp_no_backward_sync():
     module.no_sync.assert_called_once()
 
 
-def test_fsdp_activation_checkpointing_support(monkeypatch):
+def test_activation_checkpointing_support(monkeypatch):
     """Test that we error out if activation checkpointing requires a newer PyTorch version."""
     monkeypatch.setattr(lightning.fabric.strategies.fsdp, "_TORCH_GREATER_EQUAL_2_1", False)
     with pytest.raises(ValueError, match="activation_checkpointing_policy` requires torch >= 2.1.0"):
         FSDPStrategy(activation_checkpointing_policy=Mock())
 
 
-def test_fsdp_activation_checkpointing():
+def test_activation_checkpointing():
     """Test that the FSDP strategy can apply activation checkpointing to the given layers."""
 
     class Block1(nn.Linear):
@@ -197,7 +197,7 @@ def test_fsdp_activation_checkpointing():
     apply_mock.assert_called_with(wrapped, checkpoint_wrapper_fn=ANY, **strategy._activation_checkpointing_kwargs)
 
 
-def test_fsdp_forbidden_precision_raises():
+def test_forbidden_precision_raises():
     with pytest.raises(TypeError, match="can only work with the `FSDPPrecision"):
         FSDPStrategy(precision=HalfPrecision())
 
@@ -206,7 +206,7 @@ def test_fsdp_forbidden_precision_raises():
         strategy.precision = HalfPrecision()
 
 
-def test_fsdp_grad_clipping_norm_error():
+def test_grad_clipping_norm_error():
     strategy = FSDPStrategy()
     with pytest.raises(
         TypeError,
@@ -215,7 +215,7 @@ def test_fsdp_grad_clipping_norm_error():
         strategy.clip_gradients_norm(Mock(), Mock(), Mock())
 
 
-def test_fsdp_save_checkpoint_storage_options(tmp_path):
+def test_save_checkpoint_storage_options(tmp_path):
     """Test that the FSDP strategy does not accept storage options for saving checkpoints."""
     strategy = FSDPStrategy()
     with pytest.raises(TypeError, match=escape("FSDPStrategy.save_checkpoint(..., storage_options=...)` is not")):
@@ -227,7 +227,7 @@ def test_fsdp_save_checkpoint_storage_options(tmp_path):
 @mock.patch("lightning.fabric.strategies.fsdp._get_sharded_state_dict_context")
 @mock.patch("lightning.fabric.strategies.fsdp.torch.save")
 @mock.patch("lightning.fabric.strategies.fsdp.shutil")
-def test_fsdp_save_checkpoint_path_exists(shutil_mock, torch_save_mock, __, ___, tmp_path):
+def test_save_checkpoint_path_exists(shutil_mock, torch_save_mock, __, ___, tmp_path):
     strategy = FSDPStrategy(state_dict_type="full")
 
     # state_dict_type='full', path exists, path is not a sharded checkpoint: error
@@ -285,7 +285,7 @@ def test_fsdp_save_checkpoint_path_exists(shutil_mock, torch_save_mock, __, ___,
 
 
 @mock.patch("lightning.fabric.strategies.fsdp.FSDPStrategy.broadcast", lambda _, x: x)
-def test_fsdp_save_checkpoint_one_fsdp_module_required(tmp_path):
+def test_save_checkpoint_one_fsdp_module_required(tmp_path):
     """Test that the FSDP strategy can only save one FSDP model per checkpoint."""
     strategy = FSDPStrategy()
 
@@ -304,7 +304,7 @@ def test_fsdp_save_checkpoint_one_fsdp_module_required(tmp_path):
         strategy.save_checkpoint(path=tmp_path, state={"model1": model1, "model2": model2})
 
 
-def test_fsdp_load_checkpoint_no_state(tmp_path):
+def test_load_checkpoint_no_state(tmp_path):
     """Test that the FSDP strategy can't load the full state without access to a model instance from the user."""
     strategy = FSDPStrategy()
     with pytest.raises(ValueError, match=escape("Got FSDPStrategy.load_checkpoint(..., state=None")):
@@ -315,7 +315,7 @@ def test_fsdp_load_checkpoint_no_state(tmp_path):
 
 @mock.patch("lightning.fabric.strategies.fsdp.FSDPStrategy.broadcast", lambda _, x: x)
 @mock.patch("lightning.fabric.strategies.fsdp._lazy_load", Mock())
-def test_fsdp_load_checkpoint_one_fsdp_module_required(tmp_path):
+def test_load_checkpoint_one_fsdp_module_required(tmp_path):
     """Test that the FSDP strategy can only load one FSDP model per checkpoint."""
     strategy = FSDPStrategy()
 
@@ -341,7 +341,7 @@ def test_fsdp_load_checkpoint_one_fsdp_module_required(tmp_path):
 
 
 @mock.patch("lightning.fabric.strategies.fsdp.FSDPStrategy.broadcast", lambda _, x: x)
-def test_fsdp_save_checkpoint_unknown_state_dict_type(tmp_path):
+def test_save_checkpoint_unknown_state_dict_type(tmp_path):
     strategy = FSDPStrategy(state_dict_type="invalid")
     model = Mock(spec=FullyShardedDataParallel)
     model.modules.return_value = [model]
@@ -349,7 +349,7 @@ def test_fsdp_save_checkpoint_unknown_state_dict_type(tmp_path):
         strategy.save_checkpoint(path=tmp_path, state={"model": model})
 
 
-def test_fsdp_load_unknown_checkpoint_type(tmp_path):
+def test_load_unknown_checkpoint_type(tmp_path):
     """Test that the strategy validates the contents at the checkpoint path."""
     strategy = FSDPStrategy()
     model = Mock(spec=FullyShardedDataParallel)
@@ -360,7 +360,7 @@ def test_fsdp_load_unknown_checkpoint_type(tmp_path):
         strategy.load_checkpoint(path=path, state={"model": model})
 
 
-def test_fsdp_load_raw_checkpoint_validate_single_file(tmp_path):
+def test_load_raw_checkpoint_validate_single_file(tmp_path):
     """Test that we validate the given checkpoint is a single file when loading a raw PyTorch state-dict checkpoint."""
     strategy = FSDPStrategy()
     model = Mock(spec=nn.Module)
@@ -370,7 +370,7 @@ def test_fsdp_load_raw_checkpoint_validate_single_file(tmp_path):
         strategy.load_checkpoint(path=path, state=model)
 
 
-def test_fsdp_load_raw_checkpoint_optimizer_unsupported(tmp_path):
+def test_load_raw_checkpoint_optimizer_unsupported(tmp_path):
     """Validate that the FSDP strategy does not yet support loading the raw PyTorch state-dict for an optimizer."""
     strategy = FSDPStrategy()
     optimizer = Mock(spec=torch.optim.Optimizer)
@@ -396,23 +396,31 @@ def test_set_timeout(init_process_group_mock):
     )
 
 
-def test_has_meta_device_parameters():
-    """Test that the `_has_meta_device_parameters` function can find meta-device parameters in models and
+def test_has_meta_device_parameters_or_buffers():
+    """Test that the `_has_meta_device_parameters_or_buffers` function can find meta-device parameters in models and
     optimizers."""
+
+    class BufferModule(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("buffer", torch.ones(2, device="meta"))
+
     # nn.Module
     module = nn.Linear(2, 2)
     meta_module = nn.Linear(2, 2, device="meta")
-    assert not _has_meta_device_parameters(module)
-    assert _has_meta_device_parameters(meta_module)
-    assert _has_meta_device_parameters(nn.Sequential(module, meta_module, nn.ReLU()))
+    buffer_meta_module = BufferModule()
+    assert not _has_meta_device_parameters_or_buffers(module)
+    assert _has_meta_device_parameters_or_buffers(meta_module)
+    assert _has_meta_device_parameters_or_buffers(nn.Sequential(module, meta_module, nn.ReLU()))
+    assert _has_meta_device_parameters_or_buffers(buffer_meta_module)
     # optim.Optimizer
     optimizer = torch.optim.SGD(module.parameters(), lr=0.1)
     meta_optimizer = torch.optim.SGD(meta_module.parameters(), lr=0.1)
-    assert not _has_meta_device_parameters(optimizer)
-    assert _has_meta_device_parameters(meta_optimizer)
+    assert not _has_meta_device_parameters_or_buffers(optimizer)
+    assert _has_meta_device_parameters_or_buffers(meta_optimizer)
     # unsupported objects
     with pytest.raises(TypeError, match="Expected `torch.nn.Module` or `torch.optim.Optimizer`"):
-        _has_meta_device_parameters(None)
+        _has_meta_device_parameters_or_buffers(None)
 
 
 @pytest.mark.parametrize("torch_ge_2_1", [True, False])

--- a/tests/tests_fabric/strategies/test_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_fsdp_integration.py
@@ -122,7 +122,7 @@ class _TrainerManualWrapping(_Trainer):
 @RunIf(min_cuda_gpus=2, standalone=True)
 @pytest.mark.parametrize("precision", ["16-mixed", pytest.param("bf16-mixed", marks=RunIf(bf16_cuda=True))])
 @pytest.mark.parametrize("manual_wrapping", [True, False])
-def test_fsdp_train_save_load(tmp_path, manual_wrapping, precision):
+def test_train_save_load(tmp_path, manual_wrapping, precision):
     """Test FSDP training, saving and loading with different wrapping and precision settings."""
     trainer_cls = _TrainerManualWrapping if manual_wrapping else _Trainer
     fabric = Fabric(
@@ -175,7 +175,7 @@ def test_fsdp_train_save_load(tmp_path, manual_wrapping, precision):
 
 
 @RunIf(min_cuda_gpus=2, standalone=True)
-def test_fsdp_save_full_state_dict(tmp_path):
+def test_save_full_state_dict(tmp_path):
     """Test that FSDP saves the full state into a single file with `state_dict_type="full"`."""
     fabric = Fabric(
         accelerator="cuda",
@@ -289,7 +289,7 @@ def test_fsdp_save_full_state_dict(tmp_path):
 
 
 @RunIf(min_cuda_gpus=2, standalone=True)
-def test_fsdp_load_full_state_dict_into_sharded_model(tmp_path):
+def test_load_full_state_dict_into_sharded_model(tmp_path):
     """Test that the strategy can load a full-state checkpoint into a FSDP sharded model."""
     from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
@@ -475,7 +475,7 @@ def test_module_init_context(precision, expected_dtype):
 
 
 @RunIf(min_cuda_gpus=2, standalone=True)
-def test_fsdp_save_filter(tmp_path):
+def test_save_filter(tmp_path):
     fabric = Fabric(accelerator="cuda", strategy=FSDPStrategy(state_dict_type="full"), devices=2)
     fabric.launch()
     model = nn.Linear(32, 2)
@@ -498,7 +498,7 @@ def test_fsdp_save_filter(tmp_path):
 
 
 @RunIf(min_cuda_gpus=1)
-def test_fsdp_manual_activation_checkpointing():
+def test_manual_activation_checkpointing():
     model = torch.nn.Sequential(torch.nn.Linear(1, 1), torch.nn.Linear(1, 1))
     strategy = FSDPStrategy(activation_checkpointing_policy={torch.nn.Linear})
     fabric = Fabric(devices=1, accelerator="cuda", strategy=strategy)

--- a/tests/tests_fabric/strategies/test_model_parallel.py
+++ b/tests/tests_fabric/strategies/test_model_parallel.py
@@ -1,0 +1,188 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import timedelta
+from re import escape
+from unittest import mock
+from unittest.mock import Mock
+
+import pytest
+import torch
+import torch.nn as nn
+from lightning.fabric.plugins.environments import LightningEnvironment
+from lightning.fabric.strategies import ModelParallelStrategy
+from lightning.fabric.strategies.model_parallel import _ParallelBackwardSyncControl
+from torch.optim import Adam
+
+from tests_fabric.helpers.runif import RunIf
+
+
+@mock.patch("lightning.fabric.strategies.model_parallel._TORCH_GREATER_EQUAL_2_3", False)
+def test_torch_greater_equal_2_3():
+    with pytest.raises(ImportError, match="ModelParallelStrategy requires PyTorch 2.3 or higher"):
+        ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+
+
+@RunIf(min_torch="2.3")
+def test_device_mesh_access():
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+    with pytest.raises(RuntimeError, match="Accessing the device mesh .* not allowed"):
+        _ = strategy.device_mesh
+
+
+@RunIf(min_torch="2.3")
+def test_checkpoint_io_unsupported():
+    """Test that the ModelParallel strategy does not support the `CheckpointIO` plugin."""
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+    with pytest.raises(NotImplementedError, match="does not use the `CheckpointIO` plugin"):
+        _ = strategy.checkpoint_io
+
+    with pytest.raises(NotImplementedError, match="does not support setting a `CheckpointIO` plugin"):
+        strategy.checkpoint_io = Mock()
+
+
+@RunIf(min_torch="2.3")
+def test_save_filter_unsupported(tmp_path):
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+    with pytest.raises(NotImplementedError, match="does not yet support the `filter` argument"):
+        strategy.save_checkpoint(tmp_path / "checkpoint.pth", state={}, filter=Mock())
+
+
+@RunIf(min_torch="2.3")
+def test_load_raw_unsupported(tmp_path):
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+    model = nn.Linear(2, 2)
+    optimizer = Adam(model.parameters())
+    with pytest.raises(NotImplementedError, match="object from a checkpoint directly is not yet supported"):
+        strategy.load_checkpoint(tmp_path / "checkpoint.pth", state=model)
+    with pytest.raises(NotImplementedError, match="object from a checkpoint directly is not yet supported"):
+        strategy.load_checkpoint(tmp_path / "checkpoint.pth", state=optimizer)
+
+
+@RunIf(min_torch="2.3")
+def test_load_non_strict_unsupported(tmp_path):
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+    with pytest.raises(NotImplementedError, match="Non-strict loading is not yet supported"):
+        strategy.load_checkpoint(tmp_path / "checkpoint.pth", state={}, strict=False)
+
+
+@RunIf(min_torch="2.3")
+def test_parallelize_fn_call():
+    model = nn.Linear(2, 2)
+    optimizer = Adam(model.parameters())
+
+    parallel_model_mock = Mock(spec=nn.Module, parameters=Mock(return_value=[]), buffers=Mock(return_value=[]))
+    parallelize_fn = Mock(return_value=parallel_model_mock)
+    strategy = ModelParallelStrategy(parallelize_fn=parallelize_fn)
+    strategy._device_mesh = Mock()
+    strategy.parallel_devices = [torch.device("cpu")]
+    model_setup, [optimizer_setup] = strategy.setup_module_and_optimizers(model, [optimizer])
+    assert model_setup is parallel_model_mock
+    assert optimizer_setup is optimizer
+    parallelize_fn.assert_called_with(model, strategy.device_mesh)
+
+    # Raises an error if parallelize_fn does not return a module
+    parallelize_fn = Mock(return_value=None)
+    strategy = ModelParallelStrategy(parallelize_fn=parallelize_fn)
+    strategy._device_mesh = Mock()
+    strategy.parallel_devices = [torch.device("cpu")]
+    with pytest.raises(TypeError, match="The `parallelize_fn` must return a `nn.Module` instance"):
+        strategy.setup_module_and_optimizers(model, [optimizer])
+
+
+@RunIf(min_torch="2.3")
+def test_no_backward_sync():
+    """Test that the backward sync control calls `.no_sync()`, and only on a module wrapped in
+    FullyShardedDataParallel."""
+    from torch.distributed._composable.fsdp import FSDP
+
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+    assert isinstance(strategy._backward_sync_control, _ParallelBackwardSyncControl)
+
+    fsdp_layer = Mock(spec=FSDP)
+    other_layer = nn.Linear(2, 2)
+    module = Mock()
+    module.modules = Mock(return_value=[fsdp_layer, other_layer])
+
+    with strategy._backward_sync_control.no_backward_sync(module, True):
+        fsdp_layer.set_requires_gradient_sync.assert_called_with(False, recurse=False)
+    fsdp_layer.set_requires_gradient_sync.assert_called_with(True, recurse=False)
+
+    with strategy._backward_sync_control.no_backward_sync(module, False):
+        fsdp_layer.set_requires_gradient_sync.assert_called_with(True, recurse=False)
+    fsdp_layer.set_requires_gradient_sync.assert_called_with(False, recurse=False)
+
+
+@RunIf(min_torch="2.3")
+def test_save_checkpoint_storage_options(tmp_path):
+    """Test that the FSDP strategy does not accept storage options for saving checkpoints."""
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+    with pytest.raises(
+        TypeError, match=escape("ModelParallelStrategy.save_checkpoint(..., storage_options=...)` is not")
+    ):
+        strategy.save_checkpoint(path=tmp_path, state=Mock(), storage_options=Mock())
+
+
+@RunIf(min_torch="2.3")
+@mock.patch("lightning.fabric.strategies.ModelParallelStrategy._setup_device_mesh")
+@mock.patch("torch.distributed.init_process_group")
+def test_set_timeout(init_process_group_mock, _):
+    """Test that the timeout gets passed to the ``torch.distributed.init_process_group`` function."""
+    test_timedelta = timedelta(seconds=30)
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m), timeout=test_timedelta)
+    strategy.parallel_devices = [torch.device("cpu")]
+    strategy.cluster_environment = LightningEnvironment()
+    strategy.accelerator = Mock()
+    strategy.setup_environment()
+    process_group_backend = strategy._get_process_group_backend()
+    global_rank = strategy.cluster_environment.global_rank()
+    world_size = strategy.cluster_environment.world_size()
+    init_process_group_mock.assert_called_with(
+        process_group_backend, rank=global_rank, world_size=world_size, timeout=test_timedelta
+    )
+
+
+@RunIf(min_torch="2.3")
+def test_meta_device_materialization():
+    """Test that the `setup_module()` method materializes meta-device tensors in the module."""
+
+    class NoResetParameters(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.ones(4, 4))
+
+    class CustomModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            # nn.Sequential as a parameterless module
+            self.layer1 = nn.Sequential(NoResetParameters(), NoResetParameters())
+            self.layer2 = nn.Linear(4, 4)
+            self.register_buffer("buffer", torch.rand(2))
+
+        def reset_parameters(self):
+            self.buffer.fill_(1.0)
+
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda x, _: x))
+    strategy._device_mesh = Mock()
+    strategy._parallel_devices = [torch.device("cpu")]
+
+    with torch.device("meta"):
+        model = CustomModel()
+    assert model.layer1[0].weight.is_meta
+    assert model.layer2.weight.is_meta
+    assert model.buffer.is_meta
+
+    with pytest.warns(UserWarning, match=r"`reset_parameters\(\)` method for re-initialization: NoResetParameters"):
+        model = strategy.setup_module(model)
+    assert all(not p.is_meta for p in model.parameters())
+    assert all(not b.is_meta for b in model.buffers())

--- a/tests/tests_fabric/strategies/test_model_parallel.py
+++ b/tests/tests_fabric/strategies/test_model_parallel.py
@@ -41,15 +41,18 @@ def test_device_mesh_access():
 
 
 @RunIf(min_torch="2.3")
-@pytest.mark.parametrize(("num_nodes", "devices", "invalid_dp_size", "invalid_tp_size"), [
-    (1, 4, 1, 1),
-    (1, 4, 2, 3),
-    (1, 4, 4, 2),
-    (2, 4, 1, 4),
-    (2, 4, 2, 1),
-])
+@pytest.mark.parametrize(
+    ("num_nodes", "devices", "invalid_dp_size", "invalid_tp_size"),
+    [
+        (1, 4, 1, 1),
+        (1, 4, 2, 3),
+        (1, 4, 4, 2),
+        (2, 4, 1, 4),
+        (2, 4, 2, 1),
+    ],
+)
 def test_validate_device_mesh_dimensions(num_nodes, devices, invalid_dp_size, invalid_tp_size):
-    """Test passing sizes that don't multiply to the world size raises an error"""
+    """Test passing sizes that don't multiply to the world size raises an error."""
     strategy = ModelParallelStrategy(
         parallelize_fn=(lambda m, _: m),
         data_parallel_size=invalid_dp_size,
@@ -58,8 +61,7 @@ def test_validate_device_mesh_dimensions(num_nodes, devices, invalid_dp_size, in
     strategy._setup_distributed = Mock()
     strategy._accelerator = Mock()
     strategy.cluster_environment = Mock(
-        world_size=Mock(return_value=(num_nodes * devices)),
-        local_rank=Mock(return_value=1)
+        world_size=Mock(return_value=(num_nodes * devices)), local_rank=Mock(return_value=1)
     )
     strategy.parallel_devices = [torch.device("cpu")] * devices
     strategy.num_nodes = num_nodes

--- a/tests/tests_fabric/strategies/test_model_parallel.py
+++ b/tests/tests_fabric/strategies/test_model_parallel.py
@@ -77,6 +77,17 @@ def test_load_non_strict_unsupported(tmp_path):
 
 
 @RunIf(min_torch="2.3")
+def test_fsdp_v1_modules_unsupported():
+    """Test that the strategy won't allow setting up a module wrapped with the legacy FSDP API."""
+    from torch.distributed.fsdp import FullyShardedDataParallel
+
+    module = Mock(modules=Mock(return_value=[Mock(spec=FullyShardedDataParallel)]))
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda x, _: x))
+    with pytest.raises(TypeError, match="only supports the new FSDP2 APIs in PyTorch >= 2.3"):
+        strategy.setup_module(module)
+
+
+@RunIf(min_torch="2.3")
 def test_parallelize_fn_call():
     model = nn.Linear(2, 2)
     optimizer = Adam(model.parameters())

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -1,0 +1,489 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from lightning.fabric import Fabric
+from lightning.fabric.strategies import ModelParallelStrategy
+from lightning.fabric.utilities.load import _load_distributed_checkpoint
+from torch.utils.data import DataLoader, DistributedSampler
+
+from tests_fabric.helpers.datasets import RandomDataset
+from tests_fabric.helpers.runif import RunIf
+
+
+@RunIf(min_torch="2.3", standalone=True, min_cuda_gpus=4)
+def test_setup_device_mesh():
+    from torch.distributed.device_mesh import DeviceMesh
+
+    for dp_size, tp_size in ((1, 4), (4, 1), (2, 2)):
+        strategy = ModelParallelStrategy(
+            parallelize_fn=(lambda m, _: m),
+            data_parallel_size=dp_size,
+            tensor_parallel_size=tp_size,
+        )
+        fabric = Fabric(accelerator="auto", devices=4, strategy=strategy)
+        fabric.launch()
+
+        device_mesh = fabric.strategy.device_mesh
+        assert isinstance(device_mesh, DeviceMesh)
+        assert device_mesh.device_type == fabric.device.type
+        assert device_mesh.mesh_dim_names == ("data_parallel", "tensor_parallel")
+        assert device_mesh.size(0) == dp_size
+        assert device_mesh.size(1) == tp_size
+        assert device_mesh.ndim == 2
+
+        fabric.barrier()
+
+    # Passing sizes that don't multiply to the world size raises an error
+    for invalid_dp_size, invalid_tp_size in ((1, 1), (2, 3), (4, 2)):
+        strategy = ModelParallelStrategy(
+            parallelize_fn=(lambda m, _: m),
+            data_parallel_size=invalid_dp_size,
+            tensor_parallel_size=invalid_tp_size,
+        )
+        fabric = Fabric(accelerator="auto", devices=4, strategy=strategy)
+        with pytest.raises(RuntimeError, match="multiplied should equal the world size"):
+            fabric.launch()
+
+        fabric.barrier()
+
+    # Passing "auto" will select internode and intranode dimensions automatically
+    strategy = ModelParallelStrategy(
+        parallelize_fn=(lambda m, _: m),
+        data_parallel_size="auto",
+        tensor_parallel_size="auto",
+    )
+    fabric = Fabric(accelerator="auto", devices=4, num_nodes=1, strategy=strategy)
+    fabric.launch()
+    assert fabric.strategy.device_mesh.mesh_dim_names == ("data_parallel", "tensor_parallel")
+    assert fabric.strategy.device_mesh.size(0) == 1
+    assert fabric.strategy.device_mesh.size(1) == 4
+
+
+class FeedForward(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w1 = nn.Linear(32, 64)
+        self.w2 = nn.Linear(32, 64)
+        self.w3 = nn.Linear(64, 32)
+
+    def forward(self, x):
+        return self.w3(F.silu(self.w1(x)) * self.w2(x))
+
+
+def _parallelize_feed_forward_tp(model, device_mesh):
+    from torch.distributed.tensor.parallel import ColwiseParallel, RowwiseParallel, parallelize_module
+
+    tp_mesh = device_mesh["tensor_parallel"]
+    tp_plan = {
+        "w1": ColwiseParallel(),
+        "w2": ColwiseParallel(),
+        "w3": RowwiseParallel(),
+    }
+    parallelize_module(model, tp_mesh, tp_plan)
+    return model
+
+
+def _parallelize_feed_forward_fsdp2(model, device_mesh):
+    from torch.distributed._composable.fsdp.fully_shard import fully_shard
+    from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
+
+    dp_mesh = device_mesh["data_parallel"]
+    assert dp_mesh.ndim == 1  # Hybrid-sharding not supported
+
+    # Fully-shard each layer
+    fully_shard(model.w1, mesh=dp_mesh)
+    fully_shard(model.w2, mesh=dp_mesh)
+    fully_shard(model.w3, mesh=dp_mesh)
+
+    # Activation checkpointing
+    model = checkpoint_wrapper(model)
+
+    return model
+
+
+def _parallelize_feed_forward_fsdp2_tp(model, device_mesh):
+    model = _parallelize_feed_forward_tp(model, device_mesh)
+    model = _parallelize_feed_forward_fsdp2(model, device_mesh)
+    return model
+
+
+@RunIf(min_torch="2.3", standalone=True, min_cuda_gpus=2)
+def test_tensor_parallel():
+    from torch.distributed._tensor import DTensor
+
+    strategy = ModelParallelStrategy(parallelize_fn=_parallelize_feed_forward_tp)
+    fabric = Fabric(accelerator="auto", devices=2, strategy=strategy)
+    fabric.launch()
+
+    fabric.seed_everything(0)
+
+    with fabric.init_module(empty_init=True):
+        model = FeedForward()
+
+    optimizer = torch.optim.AdamW(model.parameters())
+    model, optimizer = fabric.setup(model, optimizer)
+
+    assert all(isinstance(weight, DTensor) for weight in model.parameters())
+    assert model.w1.weight.device_mesh == fabric.strategy.device_mesh["tensor_parallel"]
+
+    dataset_size = 6
+    dataset = RandomDataset(32, dataset_size)
+    dataloader = DataLoader(dataset, batch_size=2)
+    dataloader = fabric.setup_dataloaders(dataloader)
+
+    # No data sharding, all GPUs get the same input inside a TP group
+    assert len(dataloader) == dataset_size // dataloader.batch_size
+    assert isinstance(dataloader.sampler, DistributedSampler)
+
+    for _, batch in enumerate(dataloader):
+        # All batches must be identical across TP group
+        batches = fabric.all_gather(batch)
+        assert all(torch.equal(batches[0], batches[i]) for i in range(1, len(batches)))
+
+        output = model(batch)
+        fabric.backward(output.sum())
+        optimizer.step()
+        optimizer.zero_grad()
+
+
+@RunIf(min_torch="2.3", standalone=True, min_cuda_gpus=4)
+def test_fsdp2_tensor_parallel():
+    from torch.distributed._tensor import DTensor
+
+    strategy = ModelParallelStrategy(
+        parallelize_fn=_parallelize_feed_forward_fsdp2_tp,
+        data_parallel_size=2,
+        tensor_parallel_size=2,
+    )
+    fabric = Fabric(accelerator="auto", devices=4, strategy=strategy)
+    fabric.launch()
+
+    fabric.seed_everything(0)
+
+    with fabric.init_module(empty_init=True):
+        model = FeedForward()
+
+    optimizer = torch.optim.AdamW(model.parameters())
+    model, optimizer = fabric.setup(model, optimizer)
+
+    assert all(isinstance(weight, DTensor) for weight in model.parameters())
+    assert model.w1.weight.device_mesh.ndim == 2
+    assert model.w1.weight.device_mesh.size(0) == 2
+    assert model.w1.weight.device_mesh.size(1) == 2
+    assert all(weight.device.type != "meta" for weight in model.parameters())
+
+    dataset_size = 8
+    dataset = RandomDataset(32, dataset_size)
+    dataloader = DataLoader(dataset, batch_size=2)
+    dataloader = fabric.setup_dataloaders(dataloader)
+
+    # No data sharding across TP dimension, sharding across data-parallel dimension only
+    dp_mesh = fabric.strategy.device_mesh["data_parallel"]
+    tp_mesh = fabric.strategy.device_mesh["tensor_parallel"]
+    assert len(dataloader) == dataset_size // dataloader.batch_size // dp_mesh.size()
+    assert isinstance(dataloader.sampler, DistributedSampler)
+
+    for _, batch in enumerate(dataloader):
+        batches = fabric.all_gather(batch)
+        # Batches across the TP dimension must be identical
+        batches_tp = batches[tp_mesh.mesh]
+        assert all(torch.equal(batches_tp[0], batches_tp[i]) for i in range(1, len(batches_tp)))
+        # Batches across the DP dimension must be different
+        batches_dp = batches[dp_mesh.mesh]
+        assert all(not torch.equal(batches_dp[0], batches_dp[i]) for i in range(1, len(batches_dp)))
+
+        output = model(batch)
+        fabric.backward(output.sum())
+        optimizer.step()
+        optimizer.zero_grad()
+
+
+@RunIf(min_torch="2.3", min_cuda_gpus=4, standalone=True)
+@pytest.mark.parametrize(
+    "precision",
+    [
+        pytest.param(
+            "16-mixed", marks=pytest.mark.xfail(reason="Precision plugin does not implement ShardedGradScaler yet")
+        ),
+        pytest.param("bf16-mixed", marks=RunIf(bf16_cuda=True)),
+    ],
+)
+def test_train_save_load(precision, tmp_path):
+    """Test 2D-parallel training, saving and loading precision settings."""
+    strategy = ModelParallelStrategy(
+        _parallelize_feed_forward_fsdp2_tp,
+        data_parallel_size=2,
+        tensor_parallel_size=2,
+    )
+    fabric = Fabric(accelerator="cuda", devices=4, strategy=strategy, precision=precision)
+    fabric.launch()
+
+    fabric.seed_everything(0)
+    with fabric.init_module(empty_init=True):
+        model = FeedForward()
+    model = fabric.setup(model)
+    optimizer = torch.optim.AdamW(model.parameters())
+    optimizer = fabric.setup_optimizers(optimizer)
+    output = model(torch.rand(2, 32, device=fabric.device))
+    fabric.backward(output.sum())
+    optimizer.step()
+    optimizer.zero_grad()
+
+    checkpoint_path = fabric.broadcast(str(tmp_path / "dist-checkpoint"))
+
+    params_before = [p.full_tensor().clone() for p in model.parameters()]
+    state = {"model": model, "optimizer": optimizer, "steps": 1}
+    fabric.save(checkpoint_path, state)
+    assert set(os.listdir(checkpoint_path)) == {
+        ".metadata",
+        "__0_0.distcp",
+        "__1_0.distcp",
+        "__2_0.distcp",
+        "__3_0.distcp",
+    }
+
+    # re-init all objects and resume
+    strategy = ModelParallelStrategy(
+        _parallelize_feed_forward_fsdp2_tp,
+        data_parallel_size=2,
+        tensor_parallel_size=2,
+    )
+    fabric = Fabric(accelerator="cuda", devices=4, strategy=strategy, precision=precision)
+    fabric.launch()
+
+    fabric.seed_everything(0)
+    with fabric.init_module(empty_init=True):
+        model = FeedForward()
+    model = fabric.setup(model)
+    optimizer = torch.optim.AdamW(model.parameters())
+    optimizer = fabric.setup_optimizers(optimizer)
+    output = model(torch.rand(2, 32, device=fabric.device))
+    fabric.backward(output.sum())
+    optimizer.step()
+    optimizer.zero_grad()
+
+    # check correctness with loaded state
+    state = {"model": model, "optimizer": optimizer, "steps": 0}
+    metadata = fabric.load(checkpoint_path, state)
+    for p0, p1 in zip(params_before, (p.full_tensor() for p in model.parameters())):
+        torch.testing.assert_close(p0, p1, atol=0, rtol=0, equal_nan=True)
+
+    # check user data in state reloaded
+    # TODO: This should be 1, torch.distributed.checkpoint only supports tensor data
+    assert state["steps"] == 0
+    assert not metadata
+
+    # TODO: Test strict and non-strict loading here once supported
+    # attempt to load a key not in the metadata checkpoint
+    # state = {"model": model, "coconut": 11}
+    # with pytest.raises(KeyError, match="The requested state contains a key 'coconut' that does not exist"):
+    #     fabric.load(checkpoint_path, state)
+
+    # # `strict=False` ignores the missing key
+    # state = {"model": trainer.model, "coconut": 11}
+    # fabric.load(checkpoint_path, state, strict=False)
+    # assert state["coconut"] == 11
+
+
+@RunIf(min_torch="2.3", min_cuda_gpus=2, skip_windows=True, standalone=True)
+@pytest.mark.parametrize("move_to_device", [True, False])
+@mock.patch("lightning.fabric.wrappers._FabricModule")
+def test_setup_module_move_to_device(fabric_module_mock, move_to_device):
+    """Test that `move_to_device` does nothing, ModelParallel decides which device parameters get moved to which device
+    (sharding)."""
+    from torch.distributed._tensor import DTensor
+
+    strategy = ModelParallelStrategy(parallelize_fn=_parallelize_feed_forward_fsdp2)
+    fabric = Fabric(accelerator="cuda", devices=2, strategy=strategy)
+    fabric.launch()
+
+    model = FeedForward()
+    fabric_model = fabric.setup_module(model, move_to_device=move_to_device)
+    fabric_module_mock.assert_not_called()
+
+    # the linear layer got sharded and each part is on the expected device
+    assert fabric_model.w1.weight.device == torch.device("cuda", fabric.local_rank)
+    assert isinstance(fabric_model.w1.weight, DTensor)
+
+    # The _DeviceDtypeModuleMixin currently can't represent the device in a meaningful way for models with pieces on
+    # different devices
+    assert fabric_model.device == torch.device("cuda", fabric.local_rank)
+    assert fabric.device == torch.device("cuda", fabric.local_rank)
+
+
+@RunIf(min_torch="2.3", min_cuda_gpus=2, skip_windows=True, standalone=True)
+@pytest.mark.parametrize(
+    ("precision", "expected_dtype"),
+    [
+        ("32-true", torch.float32),
+        ("16-true", torch.float16),
+        pytest.param("bf16-true", torch.bfloat16, marks=RunIf(bf16_cuda=True)),
+    ],
+)
+def test_module_init_context(precision, expected_dtype):
+    """Test that the module under the init-context gets moved to the right device and dtype."""
+    strategy = ModelParallelStrategy(parallelize_fn=_parallelize_feed_forward_fsdp2)
+    fabric = Fabric(accelerator="cuda", devices=2, strategy=strategy, precision=precision)
+    fabric.launch()
+
+    def _run_setup_assertions(empty_init, expected_device):
+        with fabric.init_module(empty_init=empty_init):
+            model = FeedForward()
+
+        # The model is on the CPU/meta-device until after `.setup()``
+        assert all(weight.device == expected_device for weight in model.parameters())
+        assert all(weight.dtype == expected_dtype for weight in model.parameters())
+        model = fabric.setup(model)
+        # Parameters get sharded in `.setup()` and moved to the target device
+        assert all(weight.device == torch.device("cuda", fabric.local_rank) for weight in model.parameters())
+        assert all(weight.dtype == expected_dtype for weight in model.parameters())
+
+    _run_setup_assertions(empty_init=False, expected_device=torch.device("cpu"))
+    _run_setup_assertions(empty_init=True, expected_device=torch.device("meta"))
+
+
+def _parallelize_single_linear_tp_fsdp2(model, device_mesh):
+    from torch.distributed._composable.fsdp.fully_shard import fully_shard
+    from torch.distributed.tensor.parallel import ColwiseParallel, parallelize_module
+
+    dp_mesh = device_mesh["data_parallel"]
+    tp_mesh = device_mesh["tensor_parallel"]
+
+    parallelize_module(model, tp_mesh, ColwiseParallel())
+    fully_shard(model, mesh=dp_mesh)
+    return model
+
+
+@RunIf(min_torch="2.3", min_cuda_gpus=2, standalone=True)
+@pytest.mark.parametrize(
+    "precision",
+    [
+        "32-true",
+        pytest.param("16-mixed"),
+        pytest.param("bf16-mixed", marks=RunIf(bf16_cuda=True)),
+    ],
+)
+@pytest.mark.parametrize(
+    "clip_type",
+    [
+        pytest.param("norm", marks=pytest.mark.skip("Gradient clipping by norm is not correct.")),
+        pytest.param(
+            "val",
+            marks=pytest.mark.xfail(raises=RuntimeError, reason="Clipping DTensor by value raises error in PyTorch"),
+        ),
+    ],
+)
+def test_clip_gradients(clip_type, precision):
+    if clip_type == "norm" and precision == "16-mixed":
+        pytest.skip(reason="Clipping by norm with 16-mixed is numerically unstable.")
+
+    strategy = ModelParallelStrategy(_parallelize_single_linear_tp_fsdp2)
+    fabric = Fabric(accelerator="auto", devices=2, precision=precision, strategy=strategy)
+    fabric.launch()
+
+    in_features, out_features = 32, 2
+    model = torch.nn.Linear(in_features, out_features, bias=False)
+    model.weight.data.fill_(0.01)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.1)
+    model, optimizer = fabric.setup(model, optimizer)
+
+    batch = torch.full((1, in_features), 0.1, device=fabric.device)
+    loss = model(batch).sum()
+
+    # The example is constructed such that the gradients are all the same
+    fabric.backward(loss)
+
+    if clip_type == "norm":
+        norm = torch.linalg.vector_norm(model.weight.grad.full_tensor().detach().cpu(), 2, dtype=torch.float32).item()
+        new_norm = norm / 10
+        fabric.clip_gradients(model, optimizer, max_norm=new_norm * 10)
+        assert torch.allclose(
+            torch.linalg.vector_norm(model.weight.grad.full_tensor().detach().cpu(), 2, dtype=torch.float32),
+            torch.tensor(new_norm),
+        )
+    elif clip_type == "val":
+        val = model.weight.grad.full_tensor()[0, 0].item()
+        new_val = val / 2.0
+        fabric.clip_gradients(model, optimizer, clip_val=new_val)
+        assert torch.allclose(model.weight.full_tensor().grad, torch.full_like(model.weight.grad, new_val))
+    else:
+        raise AssertionError(f"Unknown clip type: {clip_type}")
+
+    optimizer.step()
+    optimizer.zero_grad()
+
+
+# TODO: Support loading full checkpoint
+@pytest.mark.xfail(raises=NotADirectoryError, reason="Loading from full checkpoint not supported yet.")
+@RunIf(min_torch="2.3", min_cuda_gpus=4, standalone=True)
+def test_save_sharded_and_consolidate_and_load(tmp_path):
+    """Test the consolidation of a distributed (DTensor) checkpoint into a single file."""
+    strategy = ModelParallelStrategy(
+        _parallelize_feed_forward_fsdp2_tp,
+        data_parallel_size=2,
+        tensor_parallel_size=2,
+    )
+    fabric = Fabric(accelerator="cuda", devices=4, strategy=strategy)
+    fabric.launch()
+
+    model = FeedForward()
+    optimizer = torch.optim.Adam(model.parameters())
+    model, optimizer = fabric.setup(model, optimizer)
+    state = {"model": model, "optimizer": optimizer, "steps": 1}
+
+    # run one iteration to init the state of the optimizer
+    loss = model(torch.rand(1, 32, device=fabric.device)).sum()
+    fabric.backward(loss)
+    optimizer.step()
+
+    checkpoint_path_sharded = fabric.broadcast(str(tmp_path / "checkpoint_sharded"))
+    fabric.save(checkpoint_path_sharded, state)
+    assert set(os.listdir(checkpoint_path_sharded)) == {
+        ".metadata",
+        "__0_0.distcp",
+        "__1_0.distcp",
+        "__2_0.distcp",
+        "__3_0.distcp",
+    }
+
+    # consolidate the checkpoint to a single file
+    checkpoint_path_full = fabric.broadcast(str(tmp_path / "checkpoint_full.pt"))
+    if fabric.global_rank == 0:
+        checkpoint = _load_distributed_checkpoint(Path(checkpoint_path_sharded))
+        torch.save(checkpoint, checkpoint_path_full)
+    fabric.barrier()
+
+    # re-init and load from full checkpoint
+    strategy = ModelParallelStrategy(_parallelize_feed_forward_fsdp2_tp)
+    fabric = Fabric(accelerator="cuda", devices=4, strategy=strategy)
+    fabric.launch()
+
+    import time
+
+    print(checkpoint_path_full)
+    time.sleep(60)
+
+    model = FeedForward()
+    optimizer = torch.optim.Adam(model.parameters())
+    model, optimizer = fabric.setup(model, optimizer)
+    state = {"model": model, "optimizer": optimizer, "steps": 1}
+    fabric.load(checkpoint_path_full, state)

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -51,19 +51,6 @@ def test_setup_device_mesh():
 
         fabric.barrier()
 
-    # Passing sizes that don't multiply to the world size raises an error
-    for invalid_dp_size, invalid_tp_size in ((1, 1), (2, 3), (4, 2)):
-        strategy = ModelParallelStrategy(
-            parallelize_fn=(lambda m, _: m),
-            data_parallel_size=invalid_dp_size,
-            tensor_parallel_size=invalid_tp_size,
-        )
-        fabric = Fabric(accelerator="auto", devices=4, strategy=strategy)
-        with pytest.raises(RuntimeError, match="multiplied should equal the world size"):
-            fabric.launch()
-
-        fabric.barrier()
-
     # Passing "auto" will select internode and intranode dimensions automatically
     strategy = ModelParallelStrategy(
         parallelize_fn=(lambda m, _: m),

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -477,11 +477,6 @@ def test_save_sharded_and_consolidate_and_load(tmp_path):
     fabric = Fabric(accelerator="cuda", devices=4, strategy=strategy)
     fabric.launch()
 
-    import time
-
-    print(checkpoint_path_full)
-    time.sleep(60)
-
     model = FeedForward()
     optimizer = torch.optim.Adam(model.parameters())
     model, optimizer = fabric.setup(model, optimizer)

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -400,8 +400,9 @@ def _parallelize_single_linear_tp_fsdp2(model, device_mesh):
         pytest.param(
             "val",
             marks=pytest.mark.xfail(
-                raises=RecursionError, strict=False, reason="Recursion error when clipping DTensor")
+                raises=RecursionError, strict=False, reason="Recursion error when clipping DTensor"
             ),
+        ),
     ],
 )
 def test_clip_gradients(clip_type, precision):

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -141,7 +141,7 @@ def test_tensor_parallel():
     model = fabric.setup(model)
     optimizer = torch.optim.AdamW(model.parameters())
     optimizer = fabric.setup_optimizers(optimizer)
-    
+
     device_mesh = fabric.strategy.device_mesh
     assert all(tensor.device_mesh == device_mesh["tensor_parallel"] for tensor in optimizer.param_groups[0]["params"])
     assert all(isinstance(weight, DTensor) for weight in model.parameters())
@@ -434,7 +434,9 @@ def test_clip_gradients(clip_type, precision):
         val = model.weight.grad.full_tensor()[0, 0].item()
         new_val = val / 2.0
         fabric.clip_gradients(model, optimizer, clip_val=new_val)
-        assert torch.allclose(model.weight.grad.full_tensor(), torch.full_like(model.weight.grad.full_tensor(), new_val))
+        assert torch.allclose(
+            model.weight.grad.full_tensor(), torch.full_like(model.weight.grad.full_tensor(), new_val)
+        )
     else:
         raise AssertionError(f"Unknown clip type: {clip_type}")
 

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -397,7 +397,11 @@ def _parallelize_single_linear_tp_fsdp2(model, device_mesh):
     "clip_type",
     [
         pytest.param("norm", marks=pytest.mark.skip("Gradient clipping by norm is not correct.")),
-        "val",
+        pytest.param(
+            "val",
+            marks=pytest.mark.xfail(
+                raises=RecursionError, strict=False, reason="Recursion error when clipping DTensor")
+            ),
     ],
 )
 def test_clip_gradients(clip_type, precision):

--- a/tests/tests_fabric/utilities/test_init.py
+++ b/tests/tests_fabric/utilities/test_init.py
@@ -16,7 +16,11 @@ from unittest.mock import Mock
 
 import pytest
 import torch.nn
-from lightning.fabric.utilities.init import _EmptyInit, _materialize_meta_tensors
+from lightning.fabric.utilities.init import (
+    _EmptyInit,
+    _materialize_meta_tensors,
+    _has_meta_device_parameters_or_buffers
+)
 
 from tests_fabric.helpers.runif import RunIf
 
@@ -85,3 +89,30 @@ def test_materialize_meta_tensors():
     assert model.buf.device.type == "cpu"
     assert len(list(model.parameters())) == 4
     assert all(p.device.type == "cpu" for p in model.parameters())
+
+
+def test_has_meta_device_parameters_or_buffers():
+    """Test that the `_has_meta_device_parameters_or_buffers` function can find meta-device parameters in models and
+    optimizers."""
+
+    class BufferModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("buffer", torch.ones(2, device="meta"))
+
+    # nn.Module
+    module = torch.nn.Linear(2, 2)
+    meta_module = torch.nn.Linear(2, 2, device="meta")
+    buffer_meta_module = BufferModule()
+    assert not _has_meta_device_parameters_or_buffers(module)
+    assert _has_meta_device_parameters_or_buffers(meta_module)
+    assert _has_meta_device_parameters_or_buffers(torch.nn.Sequential(module, meta_module, torch.nn.ReLU()))
+    assert _has_meta_device_parameters_or_buffers(buffer_meta_module)
+    # optim.Optimizer
+    optimizer = torch.optim.SGD(module.parameters(), lr=0.1)
+    meta_optimizer = torch.optim.SGD(meta_module.parameters(), lr=0.1)
+    assert not _has_meta_device_parameters_or_buffers(optimizer)
+    assert _has_meta_device_parameters_or_buffers(meta_optimizer)
+    # unsupported objects
+    with pytest.raises(TypeError, match="Expected `torch.nn.Module` or `torch.optim.Optimizer`"):
+        _has_meta_device_parameters_or_buffers(None)

--- a/tests/tests_fabric/utilities/test_init.py
+++ b/tests/tests_fabric/utilities/test_init.py
@@ -18,8 +18,8 @@ import pytest
 import torch.nn
 from lightning.fabric.utilities.init import (
     _EmptyInit,
+    _has_meta_device_parameters_or_buffers,
     _materialize_meta_tensors,
-    _has_meta_device_parameters_or_buffers
 )
 
 from tests_fabric.helpers.runif import RunIf


### PR DESCRIPTION
## What does this PR do?

Adds a new `ModelParallelStrategy` that enables user-defined model parallelism.
```py

def parallelize_my_model(model, device_mesh):
	# User-defined function that applies the desired parallelizations specific to the model
    # (TP, FSDP2, activation checkpointing, ...)
    ...


strategy = ModelParallelStrategy(
    parallelize_fn=parallelize_my_model,
    # Define the size of the 2D parallelism
    # Set to "auto" to apply TP intra-node and DP inter-node
    data_parallel_size=2,
    tensor_parallel_size=2,
)

fabric = L.Fabric(..., strategy=strategy)
fabric.launch()

# 1. Initializes the device mesh
# 2. Runs `parallelize_fn` here
# 3. Calls `.to_empty()` if model is on meta-device
# 4. Calls `.reset_parameters()` on submodules
model = fabric.setup(model)
```
The emphasis here must be on **user-defined**. The strategy does not do anything to the model except set up the device mesh for the user to consume. It is the user's responsibility to correctly parse the device mesh and set up the parallelization in their model. This means applying TP, FSDP, activation checkpointing, etc.

See `examples/fabric/tensor_parallel` for a full example.

Future PRs will add documentation pages.

## What's not supported yet?
- Not all checkpoint features are implemented. Only supports saving and loading distributed checkpoints right now. Future PRs will add the missing code.
- Mixed precision with grad scaler not supported (16-mixed). Only bf16-mixed and bf16-true is supported. Future PRs will add the missing code.
- Trainer: Future PRs will implement the same strategy for the PL Trainer, where the `parallelize_fn` will be replaced by a hook in the LightningModule.
- HSDP (requires additional dimension of the device mesh). Could be exposed by an additional optional argument or making `data_parallel_size` accept a tuple.


cc @borda @carmocca @justusschock @awaelchli