### PR TITLE
(2/n) Support 2D Parallelism - Distributed Checkpoints

### DIFF
--- a/examples/fabric/tensor_parallel/parallelism.py
+++ b/examples/fabric/tensor_parallel/parallelism.py
@@ -31,11 +31,10 @@ def parallelize(model: Transformer, device_mesh: DeviceMesh) -> Transformer:
         # 1. Parallelize the first embedding and the last linear proj layer
         # 2. Parallelize the root norm layer over the sequence dim
         # 3. Shard the first transformer block's inputs
+
         # Parallelize the first embedding and the last linear out projection
         plan = {
-            "tok_embeddings": RowwiseParallel(
-                input_layouts=Replicate(),
-            ),
+            "tok_embeddings": RowwiseParallel(input_layouts=Replicate()),
             "output": ColwiseParallel(input_layouts=Shard(1), output_layouts=Replicate()),
             "norm": SequenceParallel(),
             "layers.0": PrepareModuleInput(

--- a/examples/fabric/tensor_parallel/train.py
+++ b/examples/fabric/tensor_parallel/train.py
@@ -30,13 +30,13 @@ def train():
 
     fabric.print(f"Number of model parameters: {sum(p.numel() for p in model.parameters()) / 1e9:.1f} B")
 
+    # Set up model and optimizer
+    model = fabric.setup(model)
+    model.init_weights()
+
     # Define the optimizer
     optimizer = torch.optim.AdamW(model.parameters(), lr=3e-3, foreach=True)
-
-    # Set up model and optimizer
-    model, optimizer = fabric.setup(model, optimizer)
-
-    model.init_weights()
+    optimizer = fabric.setup_optimizers(optimizer)
 
     # Define dataset/dataloader
     dataset = RandomTokenDataset(vocab_size=model_args.vocab_size, seq_length=128)

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -15,7 +15,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added support for PyTorch 2.3 ([#19708](https://github.com/Lightning-AI/pytorch-lightning/pull/19708))
 
--
+- Added `ModelParallelStrategy` to support 2D parallelism ([#19846](https://github.com/Lightning-AI/pytorch-lightning/pull/19846), [#19852](https://github.com/Lightning-AI/pytorch-lightning/pull/19852))
+
 
 ### Changed
 

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import itertools
+import shutil
 from contextlib import ExitStack
 from datetime import timedelta
 from pathlib import Path
@@ -21,17 +23,25 @@ from lightning_utilities.core.rank_zero import rank_zero_only as utils_rank_zero
 from torch import Tensor
 from torch.nn import Module
 from torch.optim import Optimizer
-from typing_extensions import override
+from typing_extensions import TypeGuard, override
 
 from lightning.fabric.plugins import CheckpointIO
 from lightning.fabric.plugins.collectives.torch_collective import default_pg_timeout
 from lightning.fabric.strategies.fsdp import (
     _distributed_checkpoint_load,
     _distributed_checkpoint_save,
+    _get_full_state_dict_context,
+    _is_full_checkpoint,
+    _is_sharded_checkpoint,
 )
 from lightning.fabric.strategies.launchers.subprocess_script import _SubprocessScriptLauncher
 from lightning.fabric.strategies.parallel import ParallelStrategy
-from lightning.fabric.strategies.strategy import TBroadcast, _BackwardSyncControl
+from lightning.fabric.strategies.strategy import (
+    TBroadcast,
+    _apply_filter,
+    _BackwardSyncControl,
+    _validate_keys_for_strict_loading,
+)
 from lightning.fabric.utilities.distributed import (
     ReduceOp,
     _distributed_is_initialized,
@@ -42,9 +52,10 @@ from lightning.fabric.utilities.distributed import (
 from lightning.fabric.utilities.distributed import group as _group
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_3
 from lightning.fabric.utilities.init import _materialize_distributed_module
+from lightning.fabric.utilities.load import _METADATA_FILENAME, _lazy_load, _move_state_into, _NotYetLoadedTensor
 from lightning.fabric.utilities.rank_zero import rank_zero_only
 from lightning.fabric.utilities.seed import reset_seed
-from lightning.fabric.utilities.types import _PATH
+from lightning.fabric.utilities.types import _PATH, _Stateful
 
 if TYPE_CHECKING:
     from torch.distributed.device_mesh import DeviceMesh
@@ -68,6 +79,9 @@ class ModelParallelStrategy(ParallelStrategy):
             sets this size to the number of nodes in the cluster.
         tensor_parallel_size: The number of devices within a tensor-parallel group. Defaults to ``"auto"``, which
             sets this size to the number of GPUs in a single node.
+        save_distributed_checkpoint: If ``True``, each rank saves its shard of weights and optimizer states to a file.
+            The checkpoint is a folder with as many files as the world size.
+            If ``False``, the full weights and optimizer states get assembled on rank 0 and saved to a single file.
 
     """
 
@@ -76,16 +90,18 @@ class ModelParallelStrategy(ParallelStrategy):
         parallelize_fn: Callable[[TModel, "DeviceMesh"], TModel],
         data_parallel_size: Union[Literal["auto"], int] = "auto",
         tensor_parallel_size: Union[Literal["auto"], int] = "auto",
+        save_distributed_checkpoint: bool = True,
         process_group_backend: Optional[str] = None,
         timeout: Optional[timedelta] = default_pg_timeout,
     ) -> None:
         super().__init__()
         if not _TORCH_GREATER_EQUAL_2_3:
-            raise ImportError(f"{self.__class__.__name__} requires PyTorch 2.3 or higher.")
+            raise ImportError(f"{type(self).__name__} requires PyTorch 2.3 or higher.")
         self._parallelize_fn = parallelize_fn
         self._data_parallel_size = data_parallel_size
         self._tensor_parallel_size = tensor_parallel_size
         self._num_nodes = 1
+        self._save_distributed_checkpoint = save_distributed_checkpoint
         self._process_group_backend: Optional[str] = process_group_backend
         self._timeout: Optional[timedelta] = timeout
         self._backward_sync_control = _ParallelBackwardSyncControl()
@@ -216,18 +232,35 @@ class ModelParallelStrategy(ParallelStrategy):
         storage_options: Optional[Any] = None,
         filter: Optional[Dict[str, Callable[[str, Any], bool]]] = None,
     ) -> None:
-        """Save model, optimizer, and other state to a checkpoint on disk."""
+        """Save model, optimizer, and other state to a checkpoint on disk.
+
+        If distributed checkpointing is enabled (default), the checkpoint gets saved as a directory containing one file
+        per process, with model- and optimizer shards stored per file. Additionally, it creates a metadata file
+        `meta.pt` with the rest of the user's state (only saved from rank 0).
+        If distributed checkpointing is disabled (``save_distributed_checkpoint=False``), the checkpoint will be
+        written to a single file containing the weights, optimizer state and other metadata.
+
+        """
         if storage_options is not None:
             raise TypeError(
-                f"`{self.__class__.__name__}.save_checkpoint(..., storage_options=...)` is not supported because"
-                f" `{self.__class__.__name__}` does not use the `CheckpointIO`."
+                f"`{type(self).__name__}.save_checkpoint(..., storage_options=...)` is not supported because"
+                f" `{type(self).__name__}` does not use the `CheckpointIO`."
             )
-        if filter is not None:
-            raise NotImplementedError(f"{self.__class__.__name__} does not yet support the `filter` argument.")
-
+        if filter is not None and self._save_distributed_checkpoint:
+            # https://github.com/pytorch/pytorch/issues/105379
+            raise NotImplementedError(
+                f"{type(self).__name__} doesn't support loading distributed filtered checkpoints,"
+                " so saving them is disabled."
+            )
         # broadcast the path from rank 0 to ensure all the states are saved in a common path
         path = Path(self.broadcast(path))
-        _distributed_checkpoint_save(state, path)
+        _save_checkpoint(
+            path=path,
+            state=state,
+            full_state_dict=(not self._save_distributed_checkpoint),
+            rank=self.global_rank,
+            filter=filter,
+        )
 
     @override
     def load_checkpoint(
@@ -236,17 +269,32 @@ class ModelParallelStrategy(ParallelStrategy):
         state: Optional[Union[Module, Optimizer, Dict[str, Union[Module, Optimizer, Any]]]] = None,
         strict: bool = True,
     ) -> Dict[str, Any]:
-        if isinstance(state, (Module, Optimizer)):
-            raise NotImplementedError(
-                "Loading a module or optimizer object from a checkpoint directly is not yet supported."
-            )
-        if strict is False:
-            raise NotImplementedError(f"Non-strict loading is not yet supported in {self.__class__.__name__}.")
+        """Load the contents from a checkpoint and restore the state of the given objects.
 
+        Currently does not support loading the optimizer state if the model is distributed but the checkpoint is a full,
+        non-distributed checkpoint.
+
+        """
+        if not state:
+            raise ValueError(
+                f"Got {type(self).__name__}.load_checkpoint(..., state={state!r}) but a state with at least "
+                " a model instance to reload is required. Pass it in like so:"
+                f" {type(self).__name__}.load_checkpoint(..., state={{'model': model, ...}})"
+            )
         # broadcast the path from rank 0 to ensure all the states are loaded from a common path
         path = Path(self.broadcast(path))
-        _distributed_checkpoint_load(state, path)  # type: ignore[arg-type]
-        return {}
+
+        if isinstance(state, Module):
+            _load_raw_module_state_from_path(path, module=state, world_size=self.world_size, strict=strict)
+            return {}
+
+        if isinstance(state, Optimizer):
+            raise NotImplementedError(
+                f"Loading a single optimizer object from a checkpoint is not supported yet with"
+                f" {type(self).__name__}."
+            )
+
+        return _load_checkpoint(path=path, state=state, strict=strict)
 
     def _setup_distributed(self) -> None:
         reset_seed()
@@ -310,3 +358,206 @@ class _FSDPNoSync(ContextManager):
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         self._set_requires_grad_sync(self._enabled)
+
+
+def _save_checkpoint(
+    path: Path,
+    state: Dict[str, Union[Module, Optimizer, Any]],
+    full_state_dict: bool,
+    rank: int,
+    filter: Optional[Dict[str, Callable[[str, Any], bool]]] = None,
+) -> None:
+    if path.is_dir() and full_state_dict and not _is_sharded_checkpoint(path):
+        raise IsADirectoryError(f"The checkpoint path exists and is a directory: {path}")
+
+    modules = [module for module in state.values() if _has_dtensor_modules(module)]
+    if len(modules) == 0:
+        raise ValueError(
+            "Could not find a distributed model in the provided checkpoint state. Please provide the model as"
+            " part of the state like so: `save_checkpoint(..., state={'model': model, ...})`. Make sure"
+            " you set up the model (and optimizers if any) through the strategy before saving the checkpoint."
+        )
+    if len(modules) > 1:
+        raise ValueError(
+            "Found multiple distributed models in the given state. Saving distributed checkpoints is"
+            " currently limited to a single model per checkpoint. To save multiple models, call the"
+            " save method for each model separately with a different path."
+        )
+    module = modules[0]
+
+    from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict, get_optimizer_state_dict
+
+    state_dict_options = StateDictOptions(full_state_dict=full_state_dict, cpu_offload=True)
+
+    # replace the modules and optimizer objects in the state with their local state dict
+    # and separate the user's metadata
+    converted_state: Dict[str, Any] = {}
+    metadata: Dict[str, Any] = {}
+    for key, obj in state.items():
+        converted: Any
+        if isinstance(obj, Module):
+            converted = get_model_state_dict(obj, options=state_dict_options)
+            target_dict = converted_state
+        elif isinstance(obj, Optimizer):
+            converted = get_optimizer_state_dict(module, obj, options=state_dict_options)
+            target_dict = converted_state
+        else:  # everything not a module or optimizer is considered metadata
+            converted = obj.state_dict() if isinstance(obj, _Stateful) else obj
+            target_dict = metadata
+        _apply_filter(key, filter or {}, converted, target_dict)
+
+    if full_state_dict:
+        if _is_sharded_checkpoint(path):
+            shutil.rmtree(path)
+        converted_state.update(metadata)
+        if rank == 0:
+            torch.save(converted_state, path)
+    else:
+        if path.is_file():
+            path.unlink()
+        path.mkdir(parents=True, exist_ok=True)
+        _distributed_checkpoint_save(converted_state, path)
+        if rank == 0:
+            torch.save(metadata, path / _METADATA_FILENAME)
+
+
+def _load_checkpoint(
+    path: Path,
+    state: Dict[str, Union[Module, Optimizer, Any]],
+    strict: bool = True,
+) -> Dict[str, Any]:
+    from torch.distributed.checkpoint.state_dict import (
+        StateDictOptions,
+        get_model_state_dict,
+        get_optimizer_state_dict,
+        set_optimizer_state_dict,
+    )
+
+    modules = {key: module for key, module in state.items() if _has_dtensor_modules(module)}
+    if len(modules) == 0:
+        raise ValueError(
+            "Could not find a distributed model in the provided checkpoint state. Please provide the model as"
+            " part of the state like so: `load_checkpoint(..., state={'model': model, ...})`. Make sure"
+            " you set up the model (and optimizers if any) through the strategy before loading the checkpoint."
+        )
+    optimizers = {key: optim for key, optim in state.items() if isinstance(optim, Optimizer)}
+    if len(modules) > 1:
+        raise ValueError(
+            "Found multiple distributed models in the given state. Loading distributed checkpoints is"
+            " currently limited to a single model per checkpoint. To load multiple models, call the"
+            " load method for each model separately with a different path."
+        )
+    module_key, module = list(modules.items())[0]
+
+    if _is_sharded_checkpoint(path):
+        state_dict_options = StateDictOptions(cpu_offload=True)
+
+        module_state = {module_key: get_model_state_dict(module)}
+        _distributed_checkpoint_load(module_state, path)
+        module.load_state_dict(module_state[module_key], strict=strict)
+
+        # the optimizer states must be loaded separately
+        for optim_key, optim in optimizers.items():
+            optim_state = {optim_key: get_optimizer_state_dict(module, optim)}
+            _distributed_checkpoint_load(optim_state, path)
+            set_optimizer_state_dict(module, optim, optim_state_dict=optim_state[optim_key], options=state_dict_options)
+
+        # Load metadata (anything not a module or optimizer)
+        metadata = torch.load(path / _METADATA_FILENAME)
+        requested_metadata_keys = state.keys() - modules.keys() - optimizers.keys()
+        _validate_keys_for_strict_loading(requested_metadata_keys, metadata.keys(), strict=strict)
+        for key in requested_metadata_keys:
+            if key not in metadata:
+                continue
+            state[key] = metadata.pop(key)
+
+        # return the remaining metadata that wasn't requested as part of `state`
+        return metadata
+
+    if _is_full_checkpoint(path):
+        # TODO: Support loading optimizer states
+        if any(isinstance(obj, Optimizer) for obj in state.values()):
+            raise NotImplementedError(
+                "Loading the optimizer states from a non-distributed checkpoint into a distributed model"
+                " is currently not supported."
+            )
+
+        checkpoint = torch.load(path, mmap=True, map_location="cpu")
+        _load_raw_module_state(state_dict=checkpoint.pop(module_key), module=module, world_size=1, strict=strict)
+
+        requested_metadata_keys = state.keys() - modules.keys() - optimizers.keys()
+        _validate_keys_for_strict_loading(requested_metadata_keys, checkpoint.keys(), strict=strict)
+
+        # Load metadata (anything not a module or optimizer)
+        _move_state_into(source=checkpoint, destination=state, keys=requested_metadata_keys)
+
+        # return the remaining metadata that wasn't requested as part of `state`
+        return checkpoint
+
+    raise ValueError(
+        f"The path {str(path)!r} does not point to a valid checkpoint. Make sure the path points to either a"
+        " directory with distributed checkpoint shards, or a single file with a full checkpoint."
+    )
+
+
+def _has_dtensor_modules(module: object) -> TypeGuard[Module]:
+    from torch.distributed._tensor import DTensor
+
+    return isinstance(module, Module) and any(isinstance(t, DTensor) for t in module.parameters())
+
+
+def _load_raw_module_state_from_path(path: Path, module: Module, world_size: int, strict: bool = True) -> None:
+    """Loads the state dict from a file path into the FSDP module."""
+    if not _is_full_checkpoint(path):
+        raise ValueError(
+            "Failed to load checkpoint directly into the model. The given path must be a single file containing the"
+            f" full state dict: {path}"
+        )
+    # Use `lazy_load` instead of `torch.load` here to avoid storing a copy of the full checkpoint per rank
+    _load_raw_module_state(state_dict=_lazy_load(path), module=module, world_size=world_size, strict=strict)
+
+
+def _load_raw_module_state(state_dict: Dict[str, Any], module: Module, world_size: int, strict: bool = True) -> None:
+    """Loads the state dict into the module by gathering all weights first and then and writing back to each shard."""
+    from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+    if _TORCH_GREATER_EQUAL_2_3 and _has_dtensor_modules(module):
+        _load_dtensor_state_dict(state_dict, module=module, strict=strict)
+    elif isinstance(module, FSDP):
+        with _get_full_state_dict_context(module, world_size=world_size, rank0_only=False):
+            module.load_state_dict(state_dict, strict=strict)
+    else:
+        module.load_state_dict(state_dict, strict=strict)
+
+
+def _load_dtensor_state_dict(state_dict: Dict[str, Any], module: Module, strict: bool = True) -> None:
+    # Note: There is currently no standard way in PyTorch to load a single-file checkpoint into a
+    # DTensor module and/or optimizer. We manually reshard and assign the tensors to the model, but don't
+    # support loading the optimizer state yet. Caveat: Custom `Module.load_state_dict()` methods are not supported
+    from torch.distributed._tensor import DTensor, distribute_tensor
+
+    module_keys = {name for name, _ in itertools.chain(module.named_parameters(), module.named_buffers())}
+    state_dict_keys = set(state_dict.keys())
+    if strict and module_keys != state_dict_keys:
+        raise KeyError(
+            "The state-dict keys in the model and checkpoint don't match. To disable strict loading,"
+            " set `strict=False`."
+        )
+
+    for name, param in itertools.chain(module.named_parameters(), module.named_buffers()):
+        if name not in state_dict:
+            # Strict loading already handled above
+            continue
+
+        loaded_tensor = state_dict[name]
+        if isinstance(loaded_tensor, _NotYetLoadedTensor):
+            loaded_tensor = loaded_tensor._load_tensor()
+        if isinstance(param, DTensor):
+            loaded_tensor = distribute_tensor(
+                tensor=loaded_tensor,
+                device_mesh=param.device_mesh,
+                placements=param.placements,
+            )
+        with torch.no_grad():
+            param.copy_(loaded_tensor)
+        del loaded_tensor

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -530,6 +530,7 @@ def _load_raw_module_state(state_dict: Dict[str, Any], module: Module, world_siz
         module.load_state_dict(state_dict, strict=strict)
 
 
+@torch.no_grad()
 def _load_dtensor_state_dict(state_dict: Dict[str, Any], module: Module, strict: bool = True) -> None:
     # Note: There is currently no standard way in PyTorch to load a single-file checkpoint into a
     # DTensor module and/or optimizer. We manually reshard and assign the tensors to the model, but don't
@@ -558,6 +559,5 @@ def _load_dtensor_state_dict(state_dict: Dict[str, Any], module: Module, strict:
                 device_mesh=param.device_mesh,
                 placements=param.placements,
             )
-        with torch.no_grad():
-            param.copy_(loaded_tensor)
+        param.copy_(loaded_tensor)
         del loaded_tensor

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -538,9 +538,11 @@ def _load_dtensor_state_dict(state_dict: Dict[str, Any], module: Module, strict:
     from torch.distributed._tensor import DTensor, distribute_tensor
 
     if strict:
-        module_keys = {name for name, _ in itertools.chain(module.named_parameters(), module.named_buffers())}
+        module_param_keys = {name for name, _ in module.named_parameters()}
+        module_buffer_keys = {name for name, _ in module.named_buffers()}
+        module_buffer_keys = module_buffer_keys - module._non_persistent_buffers_set
         state_dict_keys = set(state_dict.keys())
-        if module_keys != state_dict_keys:
+        if (module_param_keys | module_buffer_keys) != state_dict_keys:
             raise KeyError(
                 "The state-dict keys in the model and checkpoint don't match. To disable strict loading,"
                 " set `strict=False`."

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -537,13 +537,14 @@ def _load_dtensor_state_dict(state_dict: Dict[str, Any], module: Module, strict:
     # support loading the optimizer state yet. Caveat: Custom `Module.load_state_dict()` methods are not supported
     from torch.distributed._tensor import DTensor, distribute_tensor
 
-    module_keys = {name for name, _ in itertools.chain(module.named_parameters(), module.named_buffers())}
-    state_dict_keys = set(state_dict.keys())
-    if strict and module_keys != state_dict_keys:
-        raise KeyError(
-            "The state-dict keys in the model and checkpoint don't match. To disable strict loading,"
-            " set `strict=False`."
-        )
+    if strict:
+        module_keys = {name for name, _ in itertools.chain(module.named_parameters(), module.named_buffers())}
+        state_dict_keys = set(state_dict.keys())
+        if module_keys != state_dict_keys:
+            raise KeyError(
+                "The state-dict keys in the model and checkpoint don't match. To disable strict loading,"
+                " set `strict=False`."
+            )
 
     for name, param in itertools.chain(module.named_parameters(), module.named_buffers()):
         if name not in state_dict:

--- a/src/lightning/fabric/utilities/imports.py
+++ b/src/lightning/fabric/utilities/imports.py
@@ -28,7 +28,9 @@ _IS_INTERACTIVE = hasattr(sys, "ps1") or bool(sys.flags.interactive)
 
 _TORCH_GREATER_EQUAL_2_1 = compare_version("torch", operator.ge, "2.1.0")
 _TORCH_GREATER_EQUAL_2_2 = compare_version("torch", operator.ge, "2.2.0")
-_TORCH_GREATER_EQUAL_2_3 = compare_version("torch", operator.ge, "2.3.0", use_base_version=True)
+_TORCH_GREATER_EQUAL_2_3 = compare_version("torch", operator.ge, "2.3.0")
+_TORCH_GREATER_EQUAL_2_4 = compare_version("torch", operator.ge, "2.4.0", use_base_version=True)
+
 _TORCH_EQUAL_2_0 = compare_version("torch", operator.ge, "2.0.0") and not _TORCH_GREATER_EQUAL_2_1
 
 _PYTHON_GREATER_EQUAL_3_8_0 = (sys.version_info.major, sys.version_info.minor) >= (3, 8)

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -41,11 +41,11 @@ from lightning.fabric.strategies.fsdp import (
     _init_sharding_strategy,
     _is_full_checkpoint,
     _is_sharded_checkpoint,
-    _load_raw_module_state,
     _move_torchmetrics_to_device,
     _optimizer_has_flat_params,
     _setup_activation_checkpointing,
 )
+from lightning.fabric.strategies.model_parallel import _load_raw_module_state
 from lightning.fabric.utilities.distributed import (
     _distributed_is_initialized,
     _get_default_process_group_backend_for_device,

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -313,6 +313,7 @@ def test_load_checkpoint_no_state(tmp_path):
 
 @mock.patch("lightning.fabric.strategies.fsdp.FSDPStrategy.broadcast", lambda _, x: x)
 @mock.patch("lightning.fabric.strategies.model_parallel._lazy_load", Mock())
+@mock.patch("lightning.fabric.strategies.model_parallel.torch.load", Mock())
 def test_load_checkpoint_one_fsdp_module_required(tmp_path):
     """Test that the FSDP strategy can only load one FSDP model per checkpoint."""
     strategy = FSDPStrategy()

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -283,7 +283,6 @@ def test_save_checkpoint_path_exists(shutil_mock, torch_save_mock, __, ___, tmp_
     assert path.is_dir()
 
 
-@mock.patch("lightning.fabric.strategies.fsdp.FSDPStrategy.broadcast", lambda _, x: x)
 def test_save_checkpoint_one_fsdp_module_required(tmp_path):
     """Test that the FSDP strategy can only save one FSDP model per checkpoint."""
     strategy = FSDPStrategy()
@@ -292,7 +291,7 @@ def test_save_checkpoint_one_fsdp_module_required(tmp_path):
     with pytest.raises(ValueError, match="Could not find a FSDP model in the provided checkpoint state."):
         strategy.save_checkpoint(path=tmp_path, state={})
     with pytest.raises(ValueError, match="Could not find a FSDP model in the provided checkpoint state."):
-        strategy.load_checkpoint(path=tmp_path, state={"model": torch.nn.Linear(3, 3)})
+        strategy.save_checkpoint(path=tmp_path, state={"model": torch.nn.Linear(3, 3)})
 
     # multiple FSDP models
     model1 = Mock(spec=FullyShardedDataParallel)
@@ -313,7 +312,7 @@ def test_load_checkpoint_no_state(tmp_path):
 
 
 @mock.patch("lightning.fabric.strategies.fsdp.FSDPStrategy.broadcast", lambda _, x: x)
-@mock.patch("lightning.fabric.strategies.fsdp._lazy_load", Mock())
+@mock.patch("lightning.fabric.strategies.model_parallel._lazy_load", Mock())
 def test_load_checkpoint_one_fsdp_module_required(tmp_path):
     """Test that the FSDP strategy can only load one FSDP model per checkpoint."""
     strategy = FSDPStrategy()
@@ -334,6 +333,7 @@ def test_load_checkpoint_one_fsdp_module_required(tmp_path):
 
     # A raw nn.Module instead of a dictionary is ok
     model = Mock(spec=nn.Module)
+    model.parameters.return_value = [torch.zeros(2, 1)]
     path = tmp_path / "full.ckpt"
     path.touch()
     strategy.load_checkpoint(path=path, state=model)

--- a/tests/tests_fabric/strategies/test_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_fsdp_integration.py
@@ -489,7 +489,7 @@ def test_save_filter(tmp_path):
     fabric.save(checkpoint_path, state, filter=filter)
     checkpoint = torch.load(checkpoint_path)["model"]
     assert set(checkpoint) == {"bias"}
-    assert isinstance(checkpoint["bias"], torch.Tensor)
+    assert type(checkpoint["bias"]) is torch.Tensor
 
     fabric.strategy._state_dict_type = "sharded"
     checkpoint_path = tmp_path / "sharded"

--- a/tests/tests_fabric/strategies/test_model_parallel.py
+++ b/tests/tests_fabric/strategies/test_model_parallel.py
@@ -21,6 +21,7 @@ import torch
 import torch.nn as nn
 from lightning.fabric.plugins.environments import LightningEnvironment
 from lightning.fabric.strategies import ModelParallelStrategy
+from lightning.fabric.strategies.fsdp import _is_sharded_checkpoint
 from lightning.fabric.strategies.model_parallel import _ParallelBackwardSyncControl
 from torch.optim import Adam
 
@@ -78,31 +79,6 @@ def test_checkpoint_io_unsupported():
 
     with pytest.raises(NotImplementedError, match="does not support setting a `CheckpointIO` plugin"):
         strategy.checkpoint_io = Mock()
-
-
-@RunIf(min_torch="2.3")
-def test_save_filter_unsupported(tmp_path):
-    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
-    with pytest.raises(NotImplementedError, match="does not yet support the `filter` argument"):
-        strategy.save_checkpoint(tmp_path / "checkpoint.pth", state={}, filter=Mock())
-
-
-@RunIf(min_torch="2.3")
-def test_load_raw_unsupported(tmp_path):
-    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
-    model = nn.Linear(2, 2)
-    optimizer = Adam(model.parameters())
-    with pytest.raises(NotImplementedError, match="object from a checkpoint directly is not yet supported"):
-        strategy.load_checkpoint(tmp_path / "checkpoint.pth", state=model)
-    with pytest.raises(NotImplementedError, match="object from a checkpoint directly is not yet supported"):
-        strategy.load_checkpoint(tmp_path / "checkpoint.pth", state=optimizer)
-
-
-@RunIf(min_torch="2.3")
-def test_load_non_strict_unsupported(tmp_path):
-    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
-    with pytest.raises(NotImplementedError, match="Non-strict loading is not yet supported"):
-        strategy.load_checkpoint(tmp_path / "checkpoint.pth", state={}, strict=False)
 
 
 @RunIf(min_torch="2.3")
@@ -171,6 +147,160 @@ def test_save_checkpoint_storage_options(tmp_path):
         TypeError, match=escape("ModelParallelStrategy.save_checkpoint(..., storage_options=...)` is not")
     ):
         strategy.save_checkpoint(path=tmp_path, state=Mock(), storage_options=Mock())
+
+
+@RunIf(min_torch="2.3")
+@mock.patch("lightning.fabric.strategies.model_parallel.ModelParallelStrategy.broadcast", lambda _, x: x)
+@mock.patch("lightning.fabric.strategies.model_parallel._has_dtensor_modules", return_value=True)
+@mock.patch("torch.distributed.checkpoint.state_dict.get_model_state_dict", return_value={})
+@mock.patch("torch.distributed.checkpoint.state_dict.get_optimizer_state_dict", return_value={})
+@mock.patch("lightning.fabric.strategies.model_parallel.torch.save")
+@mock.patch("lightning.fabric.strategies.model_parallel.shutil")
+def test_save_checkpoint_path_exists(shutil_mock, torch_save_mock, _, __, ___, tmp_path):
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m), save_distributed_checkpoint=False)
+
+    # save_distributed_checkpoint=False, path exists, path is not a sharded checkpoint: error
+    path = tmp_path / "not-empty"
+    path.mkdir()
+    (path / "file").touch()
+    assert not _is_sharded_checkpoint(path)
+    with pytest.raises(IsADirectoryError, match="exists and is a directory"):
+        strategy.save_checkpoint(path=path, state=Mock())
+
+    # save_distributed_checkpoint=False, path exists, path is a sharded checkpoint: no error (overwrite)
+    path = tmp_path / "sharded-checkpoint"
+    path.mkdir()
+    (path / "meta.pt").touch()
+    assert _is_sharded_checkpoint(path)
+    model = Mock()
+    model.modules.return_value = [model]
+    strategy.save_checkpoint(path=path, state={"model": model})
+    shutil_mock.rmtree.assert_called_once_with(path)
+
+    # save_distributed_checkpoint=False, path exists, path is a file: no error (overwrite)
+    path = tmp_path / "file.pt"
+    path.touch()
+    model = Mock(spec=nn.Module)
+    torch_save_mock.reset_mock()
+    strategy.save_checkpoint(path=path, state={"model": model})
+    torch_save_mock.assert_called_once()
+
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m), save_distributed_checkpoint=True)
+    save_mock = mock.patch("torch.distributed.checkpoint.save")
+
+    # save_distributed_checkpoint=True, path exists, path is a folder: no error (overwrite)
+    path = tmp_path / "not-empty-2"
+    path.mkdir()
+    (path / "file").touch()
+    model = Mock(spec=nn.Module)
+    with save_mock:
+        strategy.save_checkpoint(path=path, state={"model": model})
+    assert (path / "file").exists()
+
+    # save_distributed_checkpoint=True, path exists, path is a file: no error (overwrite)
+    path = tmp_path / "file-2.pt"
+    path.touch()
+    model = Mock(spec=nn.Module)
+    with save_mock:
+        strategy.save_checkpoint(path=path, state={"model": model})
+    assert path.is_dir()
+
+
+@RunIf(min_torch="2.3")
+def test_save_checkpoint_one_dist_module_required(tmp_path):
+    """Test that the ModelParallelStrategy strategy can only save one distributed model per checkpoint."""
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+
+    # missing DTensor model
+    with pytest.raises(ValueError, match="Could not find a distributed model in the provided checkpoint state."):
+        strategy.save_checkpoint(path=tmp_path, state={})
+    with pytest.raises(ValueError, match="Could not find a distributed model in the provided checkpoint state."):
+        strategy.save_checkpoint(path=tmp_path, state={"model": torch.nn.Linear(3, 3)})
+
+    # multiple DTensor models
+    with mock.patch("lightning.fabric.strategies.model_parallel._has_dtensor_modules", return_value=True):
+        model1 = Mock(spec=nn.Module)
+        model1.modules.return_value = [model1]
+        model2 = Mock(spec=nn.Module)
+        model2.modules.return_value = [model2]
+        with pytest.raises(ValueError, match="Found multiple distributed models in the given state."):
+            strategy.save_checkpoint(path=tmp_path, state={"model1": model1, "model2": model2})
+
+
+@RunIf(min_torch="2.3")
+def test_load_checkpoint_no_state(tmp_path):
+    """Test that the ModelParallelStrategy strategy can't load the full state without access to a model instance from
+    the user."""
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+    with pytest.raises(ValueError, match=escape("Got ModelParallelStrategy.load_checkpoint(..., state=None")):
+        strategy.load_checkpoint(path=tmp_path, state=None)
+    with pytest.raises(ValueError, match=escape("Got ModelParallelStrategy.load_checkpoint(..., state={})")):
+        strategy.load_checkpoint(path=tmp_path, state={})
+
+
+@RunIf(min_torch="2.3")
+@mock.patch("lightning.fabric.strategies.model_parallel.ModelParallelStrategy.broadcast", lambda _, x: x)
+@mock.patch("lightning.fabric.strategies.model_parallel._lazy_load", Mock())
+def test_load_checkpoint_one_dist_module_required(tmp_path):
+    """Test that the ModelParallelStrategy strategy can only load one distributed model per checkpoint."""
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+
+    # missing DTensor model
+    with pytest.raises(ValueError, match="Could not find a distributed model in the provided checkpoint state."):
+        strategy.load_checkpoint(path=tmp_path, state={"other": "data"})
+    with pytest.raises(ValueError, match="Could not find a distributed model in the provided checkpoint state."):
+        strategy.load_checkpoint(path=tmp_path, state={"model": torch.nn.Linear(3, 3)})
+
+    # multiple DTensor models
+    with mock.patch("lightning.fabric.strategies.model_parallel._has_dtensor_modules", return_value=True):
+        model1 = Mock(spec=nn.Module)
+        model1.modules.return_value = [model1]
+        model2 = Mock(spec=nn.Module)
+        model2.modules.return_value = [model2]
+        with pytest.raises(ValueError, match="Found multiple distributed models in the given state."):
+            strategy.load_checkpoint(path=tmp_path, state={"model1": model1, "model2": model2})
+
+    # A raw nn.Module instead of a dictionary is ok
+    model = Mock(spec=nn.Module)
+    model.parameters.return_value = [torch.zeros(2, 1)]
+    path = tmp_path / "full.ckpt"
+    path.touch()
+    strategy.load_checkpoint(path=path, state=model)
+
+
+@RunIf(min_torch="2.3")
+@mock.patch("lightning.fabric.strategies.model_parallel._has_dtensor_modules", return_value=True)
+def test_load_unknown_checkpoint_type(_, tmp_path):
+    """Test that the strategy validates the contents at the checkpoint path."""
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+    model = Mock()
+    path = tmp_path / "empty_dir"  # neither a single file nor a directory with meta file
+    path.mkdir()
+    with pytest.raises(ValueError, match="does not point to a valid checkpoint"):
+        strategy.load_checkpoint(path=path, state={"model": model})
+
+
+@RunIf(min_torch="2.3")
+def test_load_raw_checkpoint_validate_single_file(tmp_path):
+    """Test that we validate the given checkpoint is a single file when loading a raw PyTorch state-dict checkpoint."""
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+    model = Mock(spec=nn.Module)
+    path = tmp_path / "folder"
+    path.mkdir()
+    with pytest.raises(ValueError, match="The given path must be a single file containing the full state dict"):
+        strategy.load_checkpoint(path=path, state=model)
+
+
+@RunIf(min_torch="2.3")
+def test_load_raw_checkpoint_optimizer_unsupported(tmp_path):
+    """Validate that the ModelParallelStrategy strategy does not yet support loading the raw PyTorch state-dict for an
+    optimizer."""
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+    optimizer = Mock(spec=torch.optim.Optimizer)
+    with pytest.raises(
+        NotImplementedError, match="Loading a single optimizer object from a checkpoint is not supported"
+    ):
+        strategy.load_checkpoint(path=tmp_path, state=optimizer)
 
 
 @RunIf(min_torch="2.3")

--- a/tests/tests_fabric/strategies/test_model_parallel.py
+++ b/tests/tests_fabric/strategies/test_model_parallel.py
@@ -228,6 +228,28 @@ def test_save_checkpoint_one_dist_module_required(tmp_path):
 
 
 @RunIf(min_torch="2.3")
+@mock.patch("lightning.fabric.strategies.model_parallel.torch.load", Mock())
+@mock.patch("lightning.fabric.strategies.model_parallel._TORCH_GREATER_EQUAL_2_4", False)
+def test_load_full_checkpoint_support(tmp_path):
+    """Test that loading non-distributed checkpoints into distributed models requires PyTorch >= 2.4."""
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
+    model = Mock(spec=nn.Module)
+    model.parameters.return_value = [torch.zeros(2, 1)]
+    path = tmp_path / "full.ckpt"
+    path.touch()
+
+    with pytest.raises(ImportError, match="Loading .* into a distributed model requires PyTorch >= 2.4"), mock.patch(
+        "lightning.fabric.strategies.model_parallel._has_dtensor_modules", return_value=True
+    ):
+        strategy.load_checkpoint(path=path, state={"model": model})
+
+    with pytest.raises(ImportError, match="Loading .* into a distributed model requires PyTorch >= 2.4"), mock.patch(
+        "lightning.fabric.strategies.model_parallel._has_dtensor_modules", return_value=True
+    ):
+        strategy.load_checkpoint(path=path, state=model)
+
+
+@RunIf(min_torch="2.3")
 def test_load_checkpoint_no_state(tmp_path):
     """Test that the ModelParallelStrategy strategy can't load the full state without access to a model instance from
     the user."""
@@ -240,7 +262,7 @@ def test_load_checkpoint_no_state(tmp_path):
 
 @RunIf(min_torch="2.3")
 @mock.patch("lightning.fabric.strategies.model_parallel.ModelParallelStrategy.broadcast", lambda _, x: x)
-@mock.patch("lightning.fabric.strategies.model_parallel._lazy_load", Mock())
+@mock.patch("lightning.fabric.strategies.model_parallel.torch.load", Mock())
 def test_load_checkpoint_one_dist_module_required(tmp_path):
     """Test that the ModelParallelStrategy strategy can only load one distributed model per checkpoint."""
     strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -215,6 +215,24 @@ def test_fsdp2_tensor_parallel():
         optimizer.zero_grad()
 
 
+def _train(fabric, model=None, optimizer=None):
+    fabric.seed_everything(0)
+
+    if model is None:
+        with fabric.init_module(empty_init=True):
+            model = FeedForward()
+        model = fabric.setup(model)
+    if optimizer is None:
+        optimizer = torch.optim.AdamW(model.parameters())
+        optimizer = fabric.setup_optimizers(optimizer)
+
+    output = model(torch.rand(2, 32, device=fabric.device))
+    fabric.backward(output.sum())
+    optimizer.step()
+    optimizer.zero_grad()
+    return model, optimizer
+
+
 @RunIf(min_torch="2.3", min_cuda_gpus=4, standalone=True)
 @pytest.mark.parametrize(
     "precision",
@@ -234,17 +252,7 @@ def test_train_save_load(precision, tmp_path):
     )
     fabric = Fabric(accelerator="cuda", devices=4, strategy=strategy, precision=precision)
     fabric.launch()
-
-    fabric.seed_everything(0)
-    with fabric.init_module(empty_init=True):
-        model = FeedForward()
-    model = fabric.setup(model)
-    optimizer = torch.optim.AdamW(model.parameters())
-    optimizer = fabric.setup_optimizers(optimizer)
-    output = model(torch.rand(2, 32, device=fabric.device))
-    fabric.backward(output.sum())
-    optimizer.step()
-    optimizer.zero_grad()
+    model, optimizer = _train(fabric)
 
     checkpoint_path = fabric.broadcast(str(tmp_path / "dist-checkpoint"))
 
@@ -257,6 +265,7 @@ def test_train_save_load(precision, tmp_path):
         "__1_0.distcp",
         "__2_0.distcp",
         "__3_0.distcp",
+        "meta.pt",
     }
 
     # re-init all objects and resume
@@ -267,17 +276,7 @@ def test_train_save_load(precision, tmp_path):
     )
     fabric = Fabric(accelerator="cuda", devices=4, strategy=strategy, precision=precision)
     fabric.launch()
-
-    fabric.seed_everything(0)
-    with fabric.init_module(empty_init=True):
-        model = FeedForward()
-    model = fabric.setup(model)
-    optimizer = torch.optim.AdamW(model.parameters())
-    optimizer = fabric.setup_optimizers(optimizer)
-    output = model(torch.rand(2, 32, device=fabric.device))
-    fabric.backward(output.sum())
-    optimizer.step()
-    optimizer.zero_grad()
+    model, optimizer = _train(fabric)
 
     # check correctness with loaded state
     state = {"model": model, "optimizer": optimizer, "steps": 0}
@@ -286,20 +285,172 @@ def test_train_save_load(precision, tmp_path):
         torch.testing.assert_close(p0, p1, atol=0, rtol=0, equal_nan=True)
 
     # check user data in state reloaded
-    # TODO: This should be 1, torch.distributed.checkpoint only supports tensor data
-    assert state["steps"] == 0
+    assert state["steps"] == 1
     assert not metadata
 
-    # TODO: Test strict and non-strict loading here once supported
     # attempt to load a key not in the metadata checkpoint
-    # state = {"model": model, "coconut": 11}
-    # with pytest.raises(KeyError, match="The requested state contains a key 'coconut' that does not exist"):
-    #     fabric.load(checkpoint_path, state)
+    state = {"model": model, "coconut": 11}
+    with pytest.raises(KeyError, match="The requested state contains a key 'coconut' that does not exist"):
+        fabric.load(checkpoint_path, state)
 
-    # # `strict=False` ignores the missing key
-    # state = {"model": trainer.model, "coconut": 11}
-    # fabric.load(checkpoint_path, state, strict=False)
-    # assert state["coconut"] == 11
+    # `strict=False` ignores the missing key
+    state = {"model": model, "coconut": 11}
+    fabric.load(checkpoint_path, state, strict=False)
+    assert state["coconut"] == 11
+
+
+@RunIf(min_torch="2.3", min_cuda_gpus=2, standalone=True)
+def test_save_full_state_dict(tmp_path):
+    """Test that ModelParallelStrategy saves the full state into a single file with
+    `save_distributed_checkpoint=False`."""
+    from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict
+
+    strategy = ModelParallelStrategy(
+        _parallelize_feed_forward_fsdp2,
+        data_parallel_size=2,
+        tensor_parallel_size=1,
+        save_distributed_checkpoint=False,
+    )
+    fabric = Fabric(accelerator="cuda", strategy=strategy, devices=2)
+    fabric.launch()
+    model, optimizer = _train(fabric)
+
+    checkpoint_path = Path(fabric.broadcast(str(tmp_path / "fsdp-checkpoint.pt")))
+    state = {"model": model, "optimizer": optimizer, "steps": 1}
+    fabric.save(checkpoint_path, state)
+
+    checkpoint = torch.load(checkpoint_path)
+    assert checkpoint["steps"] == 1
+    loaded_state_dict = checkpoint["model"]
+
+    # assert the correct state model was saved
+    state_dict = model.state_dict()
+    assert set(loaded_state_dict.keys()) == set(state_dict.keys())
+    for param_name in state_dict:
+        assert torch.equal(loaded_state_dict[param_name], state_dict[param_name].full_tensor().cpu())
+    params_before = [p.full_tensor().cpu() for p in model.parameters()]
+
+    # assert the correct optimizer state was saved
+    optimizer_state_before = get_optimizer_state_dict(model, optimizer)
+    assert set(checkpoint["optimizer"].keys()) == set(optimizer_state_before.keys()) == {"state", "param_groups"}
+
+    # 1. verify the FSDP state can be loaded back into a FSDP model/strategy directly
+    strategy = ModelParallelStrategy(_parallelize_feed_forward_fsdp2, data_parallel_size=2, tensor_parallel_size=1)
+    fabric = Fabric(accelerator="cuda", strategy=strategy, devices=2)
+    fabric.launch()
+    model, optimizer = _train(fabric)
+
+    # TODO: Support loading optimizer states from full checkpoint
+    with pytest.raises(NotImplementedError, match="Loading the optimizer states .* not supported"):
+        fabric.load(checkpoint_path, {"model": model, "optimizer": optimizer})
+
+    metadata = fabric.load(checkpoint_path, {"model": model})
+    assert metadata == {"steps": 1, "optimizer": mock.ANY}
+
+    params_after = [p.full_tensor() for p in model.parameters()]
+    assert all(torch.equal(p0.cpu(), p1.cpu()) for p0, p1 in zip(params_before, params_after))
+
+    # TODO: assert the correct optimizer state was loaded
+    # optimizer_state_after = get_optimizer_state_dict(model, optimizer)
+    # assert set(optimizer_state_after.keys()) == set(optimizer_state_before.keys()) == {"state", "param_groups"}
+    # torch.testing.assert_close(optimizer_state_after["state"], optimizer_state_before["state"], atol=0, rtol=0)
+    # assert optimizer_state_after["param_groups"] == optimizer_state_before["param_groups"]
+
+    # run a step to verify the optimizer state is correct
+    _train(fabric, model, optimizer)
+
+    # 2. verify the FSDP state can be loaded back into a single-device model/strategy
+    fabric = Fabric(accelerator="cpu", devices=1)
+    model, optimizer = _train(fabric)
+    metadata = fabric.load(checkpoint_path, {"model": model, "optimizer": optimizer})
+    assert metadata == {"steps": 1}
+    params_after = list(model.parameters())
+    assert all(torch.equal(p0, p1) for p0, p1 in zip(params_before, params_after))
+
+    # get optimizer state after loading
+    normal_checkpoint_path = Path(fabric.broadcast(str(tmp_path / "normal-checkpoint.pt")))
+    fabric.save(normal_checkpoint_path, {"model": model, "optimizer": optimizer, "steps": 2})
+
+    # TODO: assert the correct optimizer state was loaded
+    # optimizer_state_after = torch.load(normal_checkpoint_path)["optimizer"]
+    # assert set(optimizer_state_after.keys()) == set(optimizer_state_before.keys()) == {"state", "param_groups"}
+    # torch.testing.assert_close(optimizer_state_after["state"], optimizer_state_before["state"], atol=0, rtol=0)
+
+    # run a step to verify the optimizer state is correct
+    _train(fabric, model, optimizer)
+
+    # 3. verify that a single-device model/strategy states can be loaded into a FSDP model/strategy
+    strategy = ModelParallelStrategy(_parallelize_feed_forward_fsdp2, data_parallel_size=2, tensor_parallel_size=1)
+    fabric = Fabric(accelerator="cuda", strategy=strategy, devices=2)
+    fabric.launch()
+    model, optimizer = _train(fabric)
+
+    # TODO: Support loading optimizer states from full checkpoint
+    with pytest.raises(NotImplementedError, match="Loading the optimizer states .* not supported"):
+        fabric.load(checkpoint_path, {"model": model, "optimizer": optimizer})
+    metadata = fabric.load(normal_checkpoint_path, {"model": model})
+    assert metadata == {"steps": 2, "optimizer": mock.ANY}
+
+    params_after = [p.full_tensor() for p in model.parameters()]
+    assert all(torch.equal(p0.cpu(), p1.cpu()) for p0, p1 in zip(params_before, params_after))
+
+    # TODO: assert the correct optimizer state was loaded
+    # optimizer_state_after = get_optimizer_state_dict(model, optimizer)
+    # assert set(optimizer_state_after.keys()) == set(optimizer_state_before.keys()) == {"state", "param_groups"}
+    # torch.testing.assert_close(optimizer_state_after["state"], optimizer_state_before["state"], atol=0, rtol=0)
+    # assert optimizer_state_after["param_groups"] == optimizer_state_before["param_groups"]
+
+    # run a step to verify the optimizer state is correct
+    _train(fabric, model, optimizer)
+
+
+@RunIf(min_cuda_gpus=2, standalone=True)
+def test_load_full_state_dict_into_sharded_model(tmp_path):
+    """Test that the strategy can load a full-state checkpoint into a distributed model."""
+    fabric = Fabric(accelerator="cuda", devices=1)
+    fabric.seed_everything(0)
+    model, optimizer = _train(fabric)
+
+    # Save a full-state-dict checkpoint
+    checkpoint_path = Path(fabric.broadcast(str(tmp_path / "full-checkpoint.pt")))
+    state = {"model": model, "optimizer": optimizer, "steps": 1}
+    fabric.save(checkpoint_path, state)
+
+    # Gather all weights and store a copy manually
+    params_before = torch.cat([p.cpu().view(-1) for p in model.parameters()])
+
+    # Create a FSDP sharded model
+    strategy = ModelParallelStrategy(_parallelize_feed_forward_fsdp2, data_parallel_size=2, tensor_parallel_size=1)
+    fabric = Fabric(accelerator="cuda", strategy=strategy, devices=2)
+    fabric.launch()
+    model, optimizer = _train(fabric)
+
+    # TODO: Support loading optimizer states from full checkpoint
+    with pytest.raises(NotImplementedError, match="Loading the optimizer states .* not supported"):
+        state = {"model": model, "optimizer": optimizer, "steps": 44}
+        fabric.load(checkpoint_path, state)
+
+    state = {"model": model, "steps": 44}
+    fabric.load(checkpoint_path, state)
+    assert state["steps"] == 1
+
+    # Gather all weights and compare
+    params_after = torch.cat([p.full_tensor().cpu().view(-1) for p in model.parameters()])
+    assert torch.equal(params_before, params_after)
+
+    # Create a raw state-dict checkpoint to test `Fabric.load_raw` too
+    raw_checkpoint_path = checkpoint_path.with_name("model-state-dict")
+    if fabric.global_rank == 0:
+        checkpoint = torch.load(checkpoint_path)
+        torch.save(checkpoint["model"], raw_checkpoint_path)
+    fabric.barrier()
+
+    _train(fabric, model, optimizer)
+    fabric.load_raw(raw_checkpoint_path, model)
+
+    # Gather all weights and compare
+    params_after = torch.cat([p.full_tensor().cpu().view(-1) for p in model.parameters()])
+    assert torch.equal(params_before, params_after)
 
 
 @RunIf(min_torch="2.3", min_cuda_gpus=2, skip_windows=True, standalone=True)
@@ -357,6 +508,33 @@ def test_module_init_context(precision, expected_dtype):
 
     _run_setup_assertions(empty_init=False, expected_device=torch.device("cpu"))
     _run_setup_assertions(empty_init=True, expected_device=torch.device("meta"))
+
+
+@RunIf(min_cuda_gpus=2, standalone=True)
+def test_save_filter(tmp_path):
+    strategy = ModelParallelStrategy(
+        parallelize_fn=_parallelize_feed_forward_fsdp2,
+        save_distributed_checkpoint=False,
+    )
+    fabric = Fabric(accelerator="cuda", strategy=strategy, devices=2)
+    fabric.launch()
+    model = FeedForward()
+    model = fabric.setup_module(model)
+
+    tmp_path = Path(fabric.broadcast(str(tmp_path)))
+    state = {"model": model}
+    filter = {"model": lambda k, v: "bias" in k}
+
+    checkpoint_path = tmp_path / "full.pth"
+    fabric.save(checkpoint_path, state, filter=filter)
+    checkpoint = torch.load(checkpoint_path)["model"]
+    assert set(checkpoint) == {"w1.bias", "w2.bias", "w3.bias"}
+    assert type(checkpoint["w1.bias"]) is torch.Tensor
+
+    fabric.strategy._save_distributed_checkpoint = True
+    checkpoint_path = tmp_path / "distributed"
+    with pytest.raises(NotImplementedError, match="doesn't support loading distributed filtered"):
+        fabric.save(checkpoint_path, state, filter=filter)
 
 
 def _parallelize_single_linear_tp_fsdp2(model, device_mesh):
@@ -436,8 +614,6 @@ def test_clip_gradients(clip_type, precision):
     optimizer.zero_grad()
 
 
-# TODO: Support loading full checkpoint
-@pytest.mark.xfail(raises=NotADirectoryError, reason="Loading from full checkpoint not supported yet.")
 @RunIf(min_torch="2.3", min_cuda_gpus=4, standalone=True)
 def test_save_sharded_and_consolidate_and_load(tmp_path):
     """Test the consolidation of a distributed (DTensor) checkpoint into a single file."""
@@ -450,8 +626,9 @@ def test_save_sharded_and_consolidate_and_load(tmp_path):
     fabric.launch()
 
     model = FeedForward()
+    model = fabric.setup(model)
     optimizer = torch.optim.Adam(model.parameters())
-    model, optimizer = fabric.setup(model, optimizer)
+    optimizer = fabric.setup_optimizers(optimizer)
     state = {"model": model, "optimizer": optimizer, "steps": 1}
 
     # run one iteration to init the state of the optimizer
@@ -467,6 +644,7 @@ def test_save_sharded_and_consolidate_and_load(tmp_path):
         "__1_0.distcp",
         "__2_0.distcp",
         "__3_0.distcp",
+        "meta.pt",
     }
 
     # consolidate the checkpoint to a single file
@@ -477,12 +655,23 @@ def test_save_sharded_and_consolidate_and_load(tmp_path):
     fabric.barrier()
 
     # re-init and load from full checkpoint
-    strategy = ModelParallelStrategy(_parallelize_feed_forward_fsdp2_tp)
+    strategy = ModelParallelStrategy(
+        _parallelize_feed_forward_fsdp2_tp,
+        data_parallel_size=2,
+        tensor_parallel_size=2,
+    )
     fabric = Fabric(accelerator="cuda", devices=4, strategy=strategy)
     fabric.launch()
 
     model = FeedForward()
+    model = fabric.setup(model)
     optimizer = torch.optim.Adam(model.parameters())
-    model, optimizer = fabric.setup(model, optimizer)
+    optimizer = fabric.setup_optimizers(optimizer)
     state = {"model": model, "optimizer": optimizer, "steps": 1}
+
+    # TODO: Support loading optimizer states from full checkpoint
+    with pytest.raises(NotImplementedError, match="Loading the optimizer states .* not supported"):
+        fabric.load(checkpoint_path_full, state)
+
+    state = {"model": model, "steps": 1}
     fabric.load(checkpoint_path_full, state)

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -299,7 +299,7 @@ def test_train_save_load(precision, tmp_path):
     assert state["coconut"] == 11
 
 
-@RunIf(min_torch="2.3", min_cuda_gpus=2, standalone=True)
+@RunIf(min_torch="2.4", min_cuda_gpus=2, standalone=True)
 def test_save_full_state_dict(tmp_path):
     """Test that ModelParallelStrategy saves the full state into a single file with
     `save_distributed_checkpoint=False`."""
@@ -404,7 +404,7 @@ def test_save_full_state_dict(tmp_path):
     _train(fabric, model, optimizer)
 
 
-@RunIf(min_cuda_gpus=2, standalone=True)
+@RunIf(min_torch="2.4", min_cuda_gpus=2, standalone=True)
 def test_load_full_state_dict_into_sharded_model(tmp_path):
     """Test that the strategy can load a full-state checkpoint into a distributed model."""
     fabric = Fabric(accelerator="cuda", devices=1)
@@ -510,7 +510,7 @@ def test_module_init_context(precision, expected_dtype):
     _run_setup_assertions(empty_init=True, expected_device=torch.device("meta"))
 
 
-@RunIf(min_cuda_gpus=2, standalone=True)
+@RunIf(min_torch="2.3", min_cuda_gpus=2, standalone=True)
 def test_save_filter(tmp_path):
     strategy = ModelParallelStrategy(
         parallelize_fn=_parallelize_feed_forward_fsdp2,


### PR DESCRIPTION
## What does this PR do?

Follow up to  #19846

Adds the checkpointing logic to support all features we have in Fabric. This uses the new `torch.distributed.checkpoint` APIs from PyTorch 2.3+. 

The caveat is that loading non-distributed checkpoints into a distributed model is now more difficult. I have not yet been able to resolve all edge cases around loading optimizer state, so for this iteration of the PR it is not yet supported to load optimizer states.


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19852.org.readthedocs.build/en/19852/

<!-- readthedocs-preview pytorch-lightning end -->