### PR TITLE
(3/n) Support 2D Parallelism - Efficient loading of full-state checkpoints

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added support for PyTorch 2.3 ([#19708](https://github.com/Lightning-AI/pytorch-lightning/pull/19708))
 
-- Added `ModelParallelStrategy` to support 2D parallelism ([#19846](https://github.com/Lightning-AI/pytorch-lightning/pull/19846), [#19852](https://github.com/Lightning-AI/pytorch-lightning/pull/19852))
+- Added `ModelParallelStrategy` to support 2D parallelism ([#19846](https://github.com/Lightning-AI/pytorch-lightning/pull/19846), [#19852](https://github.com/Lightning-AI/pytorch-lightning/pull/19852), [#19870](https://github.com/Lightning-AI/pytorch-lightning/pull/19870))
 
 
 ### Changed

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -484,7 +484,7 @@ def _load_checkpoint(
             raise ImportError("Loading a non-distributed checkpoint into a distributed model requires PyTorch >= 2.4.")
 
         checkpoint = torch.load(path, mmap=True, map_location="cpu")
-        _load_raw_module_state(checkpoint.pop(module_key), module, world_size=self.world_size, strict=strict)
+        _load_raw_module_state(checkpoint.pop(module_key), module, strict=strict)
 
         requested_metadata_keys = state.keys() - modules.keys() - optimizers.keys()
         _validate_keys_for_strict_loading(requested_metadata_keys, checkpoint.keys(), strict=strict)
@@ -519,7 +519,9 @@ def _load_raw_module_state_from_path(path: Path, module: Module, world_size: int
     _load_raw_module_state(state_dict=state_dict, module=module, world_size=world_size, strict=strict)
 
 
-def _load_raw_module_state(state_dict: Dict[str, Any], module: Module, world_size: int, strict: bool = True) -> None:
+def _load_raw_module_state(
+    state_dict: Dict[str, Any], module: Module, world_size: int = 1, strict: bool = True
+) -> None:
     """Loads the state dict into the module by gathering all weights first and then and writing back to each shard."""
     from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -534,7 +534,7 @@ def _load_raw_module_state(
 
         state_dict_options = StateDictOptions(
             broadcast_from_rank0=True,  # type: ignore[call-arg]
-            full_state_dict=True, 
+            full_state_dict=True,
             strict=strict,  # gets ignored at the moment
         )
 
@@ -562,7 +562,7 @@ def _load_raw_module_state(
 def _named_parameters_and_buffers_to_load(module: Module) -> Generator:
     """Returns parameters and buffers, with non-persistent buffers excluded."""
     for param_name, param in itertools.chain(
-        module.named_buffers(recurse=False), 
+        module.named_buffers(recurse=False),
         module.named_parameters(recurse=False),
     ):
         if param_name in module._non_persistent_buffers_set:

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -535,7 +535,9 @@ def _load_raw_module_state(
         state_dict_options = StateDictOptions(broadcast_from_rank0=True, full_state_dict=True, strict=strict)  # type: ignore[call-arg]
 
         for submodule_name, submodule in module.named_modules():
-            for param_name, _ in itertools.chain(submodule.named_buffers(recurse=False), submodule.named_parameters(recurse=False)):
+            for param_name, _ in itertools.chain(
+                submodule.named_buffers(recurse=False), submodule.named_parameters(recurse=False)
+            ):
                 if param_name in submodule._non_persistent_buffers_set:
                     continue
                 full_param_name = f"{submodule_name}.{param_name}"

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from copy import deepcopy
 from pathlib import Path
 from unittest import mock
 
@@ -20,10 +21,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from lightning.fabric import Fabric
+from lightning.fabric.strategies.model_parallel import ModelParallelStrategy, _load_raw_module_state
 from lightning.fabric.utilities.load import _load_distributed_checkpoint
 from torch.utils.data import DataLoader, DistributedSampler
-from copy import deepcopy
-from lightning.fabric.strategies.model_parallel import ModelParallelStrategy, _load_raw_module_state
 
 from tests_fabric.helpers.datasets import RandomDataset
 from tests_fabric.helpers.runif import RunIf
@@ -680,8 +680,8 @@ def test_save_sharded_and_consolidate_and_load(tmp_path):
 
 @RunIf(min_torch="2.4", min_cuda_gpus=2, standalone=True)
 def test_load_raw_module_state():
-    from torch.distributed.tensor.parallel import parallelize_module, ColwiseParallel
     from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor.parallel import ColwiseParallel, parallelize_module
 
     class CustomModel(nn.Module):
         def __init__(self):
@@ -691,24 +691,24 @@ def test_load_raw_module_state():
             self.layer2 = nn.Linear(4, 4)
             self.register_buffer("persistent_buffer", torch.rand(2), persistent=True)
             self.register_buffer("non_persistent_buffer", torch.rand(2), persistent=False)
-            
+
     fabric = Fabric(accelerator="cuda", devices=2)
     fabric.launch()
     fabric.seed_everything(0)
-    
+
     with fabric.init_module():
         model = CustomModel()
-    
+
     state_dict = deepcopy(model.state_dict())
 
     with fabric.init_module():
         model = CustomModel()
 
-    device_mesh = init_device_mesh("cuda", mesh_shape=(2,), mesh_dim_names=("tp", ))
+    device_mesh = init_device_mesh("cuda", mesh_shape=(2,), mesh_dim_names=("tp",))
     plan = {"layer1": ColwiseParallel()}
     parallelize_module(model, device_mesh, plan)
     _load_raw_module_state(state_dict, model, strict=True)
-    
+
     assert torch.equal(model.parameter, state_dict["parameter"])
     assert torch.equal(model.layer1.weight.full_tensor(), state_dict["layer1.weight"])
     assert torch.equal(model.layer2.weight, state_dict["layer2.weight"])
@@ -717,5 +717,5 @@ def test_load_raw_module_state():
     state_dict.pop("parameter")
     with pytest.raises(KeyError, match="The model contains a key 'parameter' that does not exist"):
         _load_raw_module_state(state_dict, model, strict=True)
-        
+
     _load_raw_module_state(state_dict, model, strict=False)

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -20,9 +20,10 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from lightning.fabric import Fabric
-from lightning.fabric.strategies import ModelParallelStrategy
 from lightning.fabric.utilities.load import _load_distributed_checkpoint
 from torch.utils.data import DataLoader, DistributedSampler
+from copy import deepcopy
+from lightning.fabric.strategies.model_parallel import ModelParallelStrategy, _load_raw_module_state
 
 from tests_fabric.helpers.datasets import RandomDataset
 from tests_fabric.helpers.runif import RunIf
@@ -675,3 +676,46 @@ def test_save_sharded_and_consolidate_and_load(tmp_path):
 
     state = {"model": model, "steps": 1}
     fabric.load(checkpoint_path_full, state)
+
+
+@RunIf(min_torch="2.4", min_cuda_gpus=2, standalone=True)
+def test_load_raw_module_state():
+    from torch.distributed.tensor.parallel import parallelize_module, ColwiseParallel
+    from torch.distributed.device_mesh import init_device_mesh
+
+    class CustomModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.parameter = nn.Parameter(torch.rand(2, 2))
+            self.layer1 = nn.Linear(4, 4)
+            self.layer2 = nn.Linear(4, 4)
+            self.register_buffer("persistent_buffer", torch.rand(2), persistent=True)
+            self.register_buffer("non_persistent_buffer", torch.rand(2), persistent=False)
+            
+    fabric = Fabric(accelerator="cuda", devices=2)
+    fabric.launch()
+    fabric.seed_everything(0)
+    
+    with fabric.init_module():
+        model = CustomModel()
+    
+    state_dict = deepcopy(model.state_dict())
+
+    with fabric.init_module():
+        model = CustomModel()
+
+    device_mesh = init_device_mesh("cuda", mesh_shape=(2,), mesh_dim_names=("tp", ))
+    plan = {"layer1": ColwiseParallel()}
+    parallelize_module(model, device_mesh, plan)
+    _load_raw_module_state(state_dict, model, strict=True)
+    
+    assert torch.equal(model.parameter, state_dict["parameter"])
+    assert torch.equal(model.layer1.weight.full_tensor(), state_dict["layer1.weight"])
+    assert torch.equal(model.layer2.weight, state_dict["layer2.weight"])
+    assert torch.equal(model.persistent_buffer, state_dict["persistent_buffer"])
+
+    state_dict.pop("parameter")
+    with pytest.raises(KeyError, match="The model contains a key 'parameter' that does not exist"):
+        _load_raw_module_state(state_dict, model, strict=True)
+        
+    _load_raw_module_state(state_dict, model, strict=False)


### PR DESCRIPTION
## What does this PR do?

Follow-up to #19852. 

I found that loading large full-state-dict checkpoints into a distributed model can lead to OOM (e.g. Llama 3 70B) because PyTorch's approach of loading on rank-0, then broadcasting and redistributing is applied to the entire checkpoint at once, instead of on a per-parameter or per-module basis (see [comment](https://github.com/pytorch/pytorch/pull/125338#discussion_r1600497541)).

In this PR, I load the checkpoint per-parameter, which seems to work as it should.

**Mini inference benchmark on Llama 3 8B (8xA100)**
Before:
4.64 GB (peak memory usage), 13.43 seconds to load
Now: 
3.20 GB (peak memory usage), 13.72 seconds to load

**Llama 3 70B (8xA100)**
Before: 
OOM
Now: 
20.01 GB (peak memory usage), 40.73 seconds to load

Benchmarks done with [this LitGPT branch](https://github.com/Lightning-AI/litgpt/pull/1421).


cc @justusschock @awaelchli @carmocca @borda