### PR TITLE
(4/n) Support 2D Parallelism - Loading optimizer states correctly

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added support for PyTorch 2.3 ([#19708](https://github.com/Lightning-AI/pytorch-lightning/pull/19708))
 
-- Added `ModelParallelStrategy` to support 2D parallelism ([#19846](https://github.com/Lightning-AI/pytorch-lightning/pull/19846), [#19852](https://github.com/Lightning-AI/pytorch-lightning/pull/19852), [#19870](https://github.com/Lightning-AI/pytorch-lightning/pull/19870))
+- Added `ModelParallelStrategy` to support 2D parallelism ([#19846](https://github.com/Lightning-AI/pytorch-lightning/pull/19846), [#19852](https://github.com/Lightning-AI/pytorch-lightning/pull/19852), [#19870](https://github.com/Lightning-AI/pytorch-lightning/pull/19870), [#19872](https://github.com/Lightning-AI/pytorch-lightning/pull/19872))
 
 
 ### Changed

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -529,7 +529,6 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
 
         from torch.distributed.checkpoint.optimizer import load_sharded_optimizer_state_dict
         from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-        from torch.distributed.fsdp import OptimStateKeyType
 
         modules = {key: module for key, module in state.items() if _has_fsdp_modules(module)}
         if len(modules) == 0:
@@ -590,8 +589,10 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
         if _is_full_checkpoint(path):
             checkpoint = _lazy_load(path)
 
-            from lightning.fabric.strategies.model_parallel import _load_raw_module_state
-            from lightning.fabric.strategies.model_parallel import _rekey_optimizer_state_if_needed
+            from lightning.fabric.strategies.model_parallel import (
+                _load_raw_module_state,
+                _rekey_optimizer_state_if_needed,
+            )
 
             _load_raw_module_state(checkpoint.pop(module_key), module=module, world_size=self.world_size, strict=strict)
 

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -579,8 +579,8 @@ def _named_parameters_and_buffers_to_load(module: Module) -> Generator:
 
 
 def _rekey_optimizer_state_if_needed(optimizer_state_dict: Dict[str, Any], module: Module) -> Dict[str, Any]:
-    """Handles the case where the optimizer state is saved from a normal optimizer and converts the keys to
-    parameter names."""
+    """Handles the case where the optimizer state is saved from a normal optimizer and converts the keys to parameter
+    names."""
     from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
     from torch.distributed.fsdp import OptimStateKeyType
 

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -91,7 +91,6 @@ def _parallelize_feed_forward_tp(model, device_mesh):
 
 def _parallelize_feed_forward_fsdp2(model, device_mesh):
     from torch.distributed._composable.fsdp.fully_shard import fully_shard
-    from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
 
     dp_mesh = device_mesh["data_parallel"]
     assert dp_mesh.ndim == 1  # Hybrid-sharding not supported
@@ -101,8 +100,12 @@ def _parallelize_feed_forward_fsdp2(model, device_mesh):
     fully_shard(model.w2, mesh=dp_mesh)
     fully_shard(model.w3, mesh=dp_mesh)
 
-    # Activation checkpointing
-    model = checkpoint_wrapper(model)
+    # TODO: Re-enable activation checkpointing
+    # Currently, state dict keys get prefixed with '_checkpoint_wrapper' in the keys
+    # which leads to mismatches when loading weights into a checkpoint-wrapped module.
+    # PyTorch should handle this automatically.
+
+    # model = checkpoint_wrapper(model)
 
     return model
 
@@ -341,21 +344,17 @@ def test_save_full_state_dict(tmp_path):
     fabric.launch()
     model, optimizer = _train(fabric)
 
-    # TODO: Support loading optimizer states from full checkpoint
-    with pytest.raises(NotImplementedError, match="Loading the optimizer states .* not supported"):
-        fabric.load(checkpoint_path, {"model": model, "optimizer": optimizer})
-
-    metadata = fabric.load(checkpoint_path, {"model": model})
-    assert metadata == {"steps": 1, "optimizer": mock.ANY}
+    metadata = fabric.load(checkpoint_path, {"model": model, "optimizer": optimizer})
+    assert metadata == {"steps": 1}
 
     params_after = [p.full_tensor() for p in model.parameters()]
     assert all(torch.equal(p0.cpu(), p1.cpu()) for p0, p1 in zip(params_before, params_after))
 
-    # TODO: assert the correct optimizer state was loaded
-    # optimizer_state_after = get_optimizer_state_dict(model, optimizer)
-    # assert set(optimizer_state_after.keys()) == set(optimizer_state_before.keys()) == {"state", "param_groups"}
-    # torch.testing.assert_close(optimizer_state_after["state"], optimizer_state_before["state"], atol=0, rtol=0)
-    # assert optimizer_state_after["param_groups"] == optimizer_state_before["param_groups"]
+    optimizer_state_after = get_optimizer_state_dict(model, optimizer)
+    optimizer_state_after["param_groups"][0]["betas"] = tuple(optimizer_state_after["param_groups"][0]["betas"])
+    assert set(optimizer_state_after.keys()) == set(optimizer_state_before.keys()) == {"state", "param_groups"}
+    torch.testing.assert_close(optimizer_state_after["state"], optimizer_state_before["state"], atol=0, rtol=0)
+    assert optimizer_state_after["param_groups"] == optimizer_state_before["param_groups"]
 
     # run a step to verify the optimizer state is correct
     _train(fabric, model, optimizer)
@@ -372,10 +371,12 @@ def test_save_full_state_dict(tmp_path):
     normal_checkpoint_path = Path(fabric.broadcast(str(tmp_path / "normal-checkpoint.pt")))
     fabric.save(normal_checkpoint_path, {"model": model, "optimizer": optimizer, "steps": 2})
 
-    # TODO: assert the correct optimizer state was loaded
-    # optimizer_state_after = torch.load(normal_checkpoint_path)["optimizer"]
-    # assert set(optimizer_state_after.keys()) == set(optimizer_state_before.keys()) == {"state", "param_groups"}
-    # torch.testing.assert_close(optimizer_state_after["state"], optimizer_state_before["state"], atol=0, rtol=0)
+    optimizer_state_after = torch.load(normal_checkpoint_path)["optimizer"]
+    assert set(optimizer_state_after.keys()) == set(optimizer_state_before.keys()) == {"state", "param_groups"}
+    assert torch.equal(
+        optimizer_state_after["state"][0]["exp_avg"],
+        optimizer_state_before["state"]["_forward_module.w1.weight"]["exp_avg"].full_tensor().cpu(),
+    )
 
     # run a step to verify the optimizer state is correct
     _train(fabric, model, optimizer)
@@ -386,20 +387,17 @@ def test_save_full_state_dict(tmp_path):
     fabric.launch()
     model, optimizer = _train(fabric)
 
-    # TODO: Support loading optimizer states from full checkpoint
-    with pytest.raises(NotImplementedError, match="Loading the optimizer states .* not supported"):
-        fabric.load(checkpoint_path, {"model": model, "optimizer": optimizer})
-    metadata = fabric.load(normal_checkpoint_path, {"model": model})
-    assert metadata == {"steps": 2, "optimizer": mock.ANY}
+    metadata = fabric.load(normal_checkpoint_path, {"model": model, "optimizer": optimizer})
+    assert metadata == {"steps": 2}
 
     params_after = [p.full_tensor() for p in model.parameters()]
     assert all(torch.equal(p0.cpu(), p1.cpu()) for p0, p1 in zip(params_before, params_after))
 
-    # TODO: assert the correct optimizer state was loaded
-    # optimizer_state_after = get_optimizer_state_dict(model, optimizer)
-    # assert set(optimizer_state_after.keys()) == set(optimizer_state_before.keys()) == {"state", "param_groups"}
-    # torch.testing.assert_close(optimizer_state_after["state"], optimizer_state_before["state"], atol=0, rtol=0)
-    # assert optimizer_state_after["param_groups"] == optimizer_state_before["param_groups"]
+    optimizer_state_after = get_optimizer_state_dict(model, optimizer)
+    optimizer_state_after["param_groups"][0]["betas"] = tuple(optimizer_state_after["param_groups"][0]["betas"])
+    assert set(optimizer_state_after.keys()) == set(optimizer_state_before.keys()) == {"state", "param_groups"}
+    torch.testing.assert_close(optimizer_state_after["state"], optimizer_state_before["state"], atol=0, rtol=0)
+    assert optimizer_state_after["param_groups"] == optimizer_state_before["param_groups"]
 
     # run a step to verify the optimizer state is correct
     _train(fabric, model, optimizer)
@@ -426,12 +424,7 @@ def test_load_full_state_dict_into_sharded_model(tmp_path):
     fabric.launch()
     model, optimizer = _train(fabric)
 
-    # TODO: Support loading optimizer states from full checkpoint
-    with pytest.raises(NotImplementedError, match="Loading the optimizer states .* not supported"):
-        state = {"model": model, "optimizer": optimizer, "steps": 44}
-        fabric.load(checkpoint_path, state)
-
-    state = {"model": model, "steps": 44}
+    state = {"model": model, "optimizer": optimizer, "steps": 44}
     fabric.load(checkpoint_path, state)
     assert state["steps"] == 1
 
@@ -669,12 +662,6 @@ def test_save_sharded_and_consolidate_and_load(tmp_path):
     optimizer = torch.optim.Adam(model.parameters())
     optimizer = fabric.setup_optimizers(optimizer)
     state = {"model": model, "optimizer": optimizer, "steps": 1}
-
-    # TODO: Support loading optimizer states from full checkpoint
-    with pytest.raises(NotImplementedError, match="Loading the optimizer states .* not supported"):
-        fabric.load(checkpoint_path_full, state)
-
-    state = {"model": model, "steps": 1}
     fabric.load(checkpoint_path_full, state)
 
 


### PR DESCRIPTION
## What does this PR do?

This PR adds the missing loading logic for optimizer states. When loading a regular optimizer state dict into a distributed optimizer, we need to convert the parameter keys from ids to fully qualified names. This conversion function is currently under the FSDP1 API, but is not FSDP1 specific. [In a conversation on the PyTorch Slack](https://pytorch.slack.com/archives/C3PDTEV8E/p1715603705177599) it was discussed that PyTorch should probably support that directly in the `set_optimizer_state_dict` function in the future, so we will be able to simplify this logic hopefully.


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19872.org.readthedocs.build/en/19872/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @awaelchli @carmocca @justusschock