### PR TITLE
Remove redundant code to set the device on the LightningModule

### DIFF
--- a/src/lightning/pytorch/strategies/deepspeed.py
+++ b/src/lightning/pytorch/strategies/deepspeed.py
@@ -337,10 +337,6 @@ class DeepSpeedStrategy(DDPStrategy):
         assert self.accelerator is not None
         self.accelerator.setup(trainer)
 
-        # we set the device so that optimizers can be created with distributed comms.
-        assert self.lightning_module is not None
-        self.lightning_module._device = self.root_device
-
         assert self.model is not None
         self.model = self.precision_plugin.convert_module(self.model)
         self.model = self._setup_model(self.model)

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -305,10 +305,6 @@ class FSDPStrategy(ParallelStrategy):
         if trainer.state.fn == TrainerFn.FITTING and self._layer_sync:
             self.model = self._layer_sync.apply(self.model)
 
-        # we set the device so that optimizers can be created with distributed comms.
-        assert self.lightning_module is not None
-        self.lightning_module._device = self.root_device
-
         self.model = self.precision_plugin.convert_module(self.model)
 
         if is_overridden("configure_sharded_model", self.lightning_module):


### PR DESCRIPTION
## What does this PR do?

This removes some lines that are no longer needed.
They were originally added in #12985, but then later we decided to set the device earlier in the Trainer: #18021. There are tests for this.


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19877.org.readthedocs.build/en/19877/

<!-- readthedocs-preview pytorch-lightning end -->

cc @justusschock @awaelchli