### PR TITLE
Enable loss-parallel in example

### DIFF
--- a/examples/fabric/tensor_parallel/parallelism.py
+++ b/examples/fabric/tensor_parallel/parallelism.py
@@ -35,7 +35,13 @@ def parallelize(model: Transformer, device_mesh: DeviceMesh) -> Transformer:
         # Parallelize the first embedding and the last linear out projection
         plan = {
             "tok_embeddings": RowwiseParallel(input_layouts=Replicate()),
-            "output": ColwiseParallel(input_layouts=Shard(1), output_layouts=Replicate()),
+            "output": ColwiseParallel(
+                input_layouts=Shard(1), 
+                # Optional: Shard the output along the class dimension to compute the loss in parallel.
+                # See `loss_parallel` in `train.py`
+                output_layouts=Shard(-1),
+                use_local_output=False,
+            ),
             "norm": SequenceParallel(),
             "layers.0": PrepareModuleInput(
                 input_layouts=(Replicate(), None),

--- a/examples/fabric/tensor_parallel/parallelism.py
+++ b/examples/fabric/tensor_parallel/parallelism.py
@@ -36,7 +36,7 @@ def parallelize(model: Transformer, device_mesh: DeviceMesh) -> Transformer:
         plan = {
             "tok_embeddings": RowwiseParallel(input_layouts=Replicate()),
             "output": ColwiseParallel(
-                input_layouts=Shard(1), 
+                input_layouts=Shard(1),
                 # Optional: Shard the output along the class dimension to compute the loss in parallel.
                 # See `loss_parallel` in `train.py`
                 output_layouts=Shard(-1),

--- a/examples/fabric/tensor_parallel/train.py
+++ b/examples/fabric/tensor_parallel/train.py
@@ -57,8 +57,8 @@ def train():
 
         with loss_parallel():
             loss = F.cross_entropy(output.reshape(-1, output.size(-1)), labels.reshape(-1))
+            fabric.backward(loss)
 
-        fabric.backward(loss)
         optimizer.step()
         optimizer.zero_grad()
         fabric.print(f"Iteration {i} complete")

--- a/examples/pytorch/tensor_parallel/parallelism.py
+++ b/examples/pytorch/tensor_parallel/parallelism.py
@@ -35,7 +35,13 @@ def parallelize(model: Transformer, device_mesh: DeviceMesh) -> Transformer:
         # Parallelize the first embedding and the last linear out projection
         plan = {
             "tok_embeddings": RowwiseParallel(input_layouts=Replicate()),
-            "output": ColwiseParallel(input_layouts=Shard(1), output_layouts=Replicate()),
+            "output": ColwiseParallel(
+                input_layouts=Shard(1), 
+                # Optional: Shard the output along the class dimension to compute the loss in parallel.
+                # See `loss_parallel` in `train.py`
+                output_layouts=Shard(-1),
+                use_local_output=False,
+            ),
             "norm": SequenceParallel(),
             "layers.0": PrepareModuleInput(
                 input_layouts=(Replicate(), None),

--- a/examples/pytorch/tensor_parallel/parallelism.py
+++ b/examples/pytorch/tensor_parallel/parallelism.py
@@ -36,7 +36,7 @@ def parallelize(model: Transformer, device_mesh: DeviceMesh) -> Transformer:
         plan = {
             "tok_embeddings": RowwiseParallel(input_layouts=Replicate()),
             "output": ColwiseParallel(
-                input_layouts=Shard(1), 
+                input_layouts=Shard(1),
                 # Optional: Shard the output along the class dimension to compute the loss in parallel.
                 # See `loss_parallel` in `train.py`
                 output_layouts=Shard(-1),

--- a/examples/pytorch/tensor_parallel/train.py
+++ b/examples/pytorch/tensor_parallel/train.py
@@ -1,6 +1,7 @@
 import lightning as L
 import torch
 import torch.nn.functional as F
+from torch.distributed.tensor.parallel import loss_parallel
 from data import RandomTokenDataset
 from lightning.pytorch.strategies import ModelParallelStrategy
 from model import ModelArgs, Transformer
@@ -26,7 +27,13 @@ class Llama2(L.LightningModule):
         inputs = batch[:, :-1]
         labels = batch[:, 1:]
         output = self.model(inputs)
-        return F.cross_entropy(output.reshape(-1, output.size(-1)), labels.reshape(-1))
+        # Optional: Parallelize loss computation across class dimension (see parallelism.py)
+        with loss_parallel():
+            return F.cross_entropy(output.reshape(-1, output.size(-1)), labels.reshape(-1))
+
+    def backward(self, *args, **kwargs):
+        with loss_parallel():
+            super().backward(*args, **kwargs)
 
     def configure_optimizers(self):
         return torch.optim.AdamW(self.model.parameters(), lr=3e-3, foreach=True)

--- a/examples/pytorch/tensor_parallel/train.py
+++ b/examples/pytorch/tensor_parallel/train.py
@@ -5,7 +5,6 @@ from data import RandomTokenDataset
 from lightning.pytorch.strategies import ModelParallelStrategy
 from model import ModelArgs, Transformer
 from parallelism import parallelize
-from torch.distributed.tensor.parallel import loss_parallel
 from torch.utils.data import DataLoader
 
 
@@ -27,8 +26,7 @@ class Llama2(L.LightningModule):
         inputs = batch[:, :-1]
         labels = batch[:, 1:]
         output = self.model(inputs)
-        with loss_parallel():
-            return F.cross_entropy(output.reshape(-1, output.size(-1)), labels.reshape(-1))
+        return F.cross_entropy(output.reshape(-1, output.size(-1)), labels.reshape(-1))
 
     def configure_optimizers(self):
         return torch.optim.AdamW(self.model.parameters(), lr=3e-3, foreach=True)

--- a/examples/pytorch/tensor_parallel/train.py
+++ b/examples/pytorch/tensor_parallel/train.py
@@ -1,11 +1,11 @@
 import lightning as L
 import torch
 import torch.nn.functional as F
-from torch.distributed.tensor.parallel import loss_parallel
 from data import RandomTokenDataset
 from lightning.pytorch.strategies import ModelParallelStrategy
 from model import ModelArgs, Transformer
 from parallelism import parallelize
+from torch.distributed.tensor.parallel import loss_parallel
 from torch.utils.data import DataLoader
 
 


### PR DESCRIPTION
## What does this PR do?

Enables [loss_parallel](https://pytorch.org/docs/stable/distributed.tensor.parallel.html#torch.distributed.tensor.parallel.loss_parallel) for loss computation and backward as suggested by @carmocca https://github.com/Lightning-AI/pytorch-lightning/pull/19879#discussion_r1606220966. In Fabric the user has convenient control over that. In LightningModule, the user has to override the backward hook in addition to the modification in the training step hook.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19882.org.readthedocs.build/en/19882/

<!-- readthedocs-preview pytorch-lightning end -->

cc @carmocca @justusschock @awaelchli