### PR TITLE
Remove the requirement for FSDPStrategy subclasses to only support GPU

### DIFF
--- a/src/lightning/fabric/connector.py
+++ b/src/lightning/fabric/connector.py
@@ -429,7 +429,7 @@ class _Connector:
                 f" platform. We recommed `Fabric(strategy='ddp_spawn')` instead."
             )
         if (
-            strategy_flag in _FSDP_ALIASES or isinstance(self._strategy_flag, FSDPStrategy)
+            strategy_flag in _FSDP_ALIASES or type(self._strategy_flag) is FSDPStrategy
         ) and self._accelerator_flag not in ("cuda", "gpu"):
             raise ValueError(
                 "You selected the FSDP strategy but FSDP is only available on GPU. Set `Fabric(accelerator='gpu', ...)`"

--- a/tests/tests_fabric/test_connector.py
+++ b/tests/tests_fabric/test_connector.py
@@ -978,6 +978,16 @@ def test_fsdp_unsupported_on_cpu(_):
     with pytest.raises(ValueError, match="You selected the FSDP strategy but FSDP is only available on GPU"):
         _Connector(accelerator="cpu", strategy="fsdp")
 
+    class FSDPStrategySubclass(FSDPStrategy):
+        pass
+
+    class AcceleratorSubclass(CPUAccelerator):
+        pass
+
+    # we allow subclasses of FSDPStrategy to be used with other accelerators
+    _Connector(accelerator="cpu", strategy=FSDPStrategySubclass())
+    _Connector(accelerator=AcceleratorSubclass(), strategy=FSDPStrategySubclass())
+
 
 def test_connector_defaults_match_fabric_defaults():
     """Test that the default values for the init arguments of Connector match the ones in Fabric."""


### PR DESCRIPTION
## What does this PR do?

Adds the same change as in #19781 to Fabric.
For the same reason as in the previous PR, I'm labelling this as a "change" not a fix, as this relaxes a requirement that was strict intentionally until now.

Asked by https://github.com/Lightning-AI/pytorch-lightning/issues/19753#issuecomment-2124681153


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19894.org.readthedocs.build/en/19894/

<!-- readthedocs-preview pytorch-lightning end -->