### PR TITLE
Error for unsupported precision types with ModelParallelStrategy

### DIFF
--- a/src/lightning/fabric/connector.py
+++ b/src/lightning/fabric/connector.py
@@ -62,6 +62,7 @@ from lightning.fabric.strategies import (
 )
 from lightning.fabric.strategies.ddp import _DDP_FORK_ALIASES
 from lightning.fabric.strategies.fsdp import _FSDP_ALIASES, FSDPStrategy
+from lightning.fabric.strategies.model_parallel import ModelParallelStrategy
 from lightning.fabric.utilities import rank_zero_info, rank_zero_warn
 from lightning.fabric.utilities.device_parser import _determine_root_gpu_device
 from lightning.fabric.utilities.imports import _IS_INTERACTIVE
@@ -460,6 +461,13 @@ class _Connector:
             return DeepSpeedPrecision(self._precision_input)  # type: ignore
         if isinstance(self.strategy, FSDPStrategy):
             return FSDPPrecision(precision=self._precision_input)  # type: ignore[arg-type]
+        if isinstance(self.strategy, ModelParallelStrategy) and self._precision_input not in (
+            "32-true", "bf16-mixed", "bf16-true", "16-true"
+        ):
+            raise ValueError(
+                f"The `ModelParallelStrategy` does not support `Fabric(..., precision={self._precision_input!r})`."
+                " Choose a different precision."
+            )
         if self._precision_input in ("16-true", "bf16-true"):
             return HalfPrecision(self._precision_input)  # type: ignore
         if self._precision_input == "32-true":

--- a/src/lightning/fabric/connector.py
+++ b/src/lightning/fabric/connector.py
@@ -462,7 +462,10 @@ class _Connector:
         if isinstance(self.strategy, FSDPStrategy):
             return FSDPPrecision(precision=self._precision_input)  # type: ignore[arg-type]
         if isinstance(self.strategy, ModelParallelStrategy) and self._precision_input not in (
-            "32-true", "bf16-mixed", "bf16-true", "16-true"
+            "32-true",
+            "bf16-mixed",
+            "bf16-true",
+            "16-true",
         ):
             raise ValueError(
                 f"The `ModelParallelStrategy` does not support `Fabric(..., precision={self._precision_input!r})`."

--- a/src/lightning/fabric/connector.py
+++ b/src/lightning/fabric/connector.py
@@ -461,15 +461,11 @@ class _Connector:
             return DeepSpeedPrecision(self._precision_input)  # type: ignore
         if isinstance(self.strategy, FSDPStrategy):
             return FSDPPrecision(precision=self._precision_input)  # type: ignore[arg-type]
-        if isinstance(self.strategy, ModelParallelStrategy) and self._precision_input not in (
-            "32-true",
-            "bf16-mixed",
-            "bf16-true",
-            "16-true",
-        ):
+        mp_precision_supported = ("32-true", "bf16-mixed", "bf16-true", "16-true")
+        if isinstance(self.strategy, ModelParallelStrategy) and self._precision_input not in mp_precision_supported:
             raise ValueError(
                 f"The `ModelParallelStrategy` does not support `Fabric(..., precision={self._precision_input!r})`."
-                " Choose a different precision."
+                f" Choose a different precision among: {', '.join(mp_precision_supported)}."
             )
         if self._precision_input in ("16-true", "bf16-true"):
             return HalfPrecision(self._precision_input)  # type: ignore

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -530,7 +530,10 @@ class _AcceleratorConnector:
         ):
             raise RuntimeError("Bitsandbytes is only supported on CUDA GPUs.")
         mp_precision_supported = ("32-true", "bf16-mixed", "bf16-true", "16-true")
-        if isinstance(self._strategy_flag, ModelParallelStrategy) and self._precision_flag not in mp_precision_supported:
+        if (
+            isinstance(self._strategy_flag, ModelParallelStrategy)
+            and self._precision_flag not in mp_precision_supported
+        ):
             raise ValueError(
                 f"The `ModelParallelStrategy` does not support `Fabric(..., precision={self._precision_flag!r})`."
                 f" Choose a different precision among: {', '.join(mp_precision_supported)}."

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -529,15 +529,11 @@ class _AcceleratorConnector:
             self.accelerator, CUDAAccelerator
         ):
             raise RuntimeError("Bitsandbytes is only supported on CUDA GPUs.")
-        if isinstance(self._strategy_flag, ModelParallelStrategy) and self._precision_flag not in (
-            "32-true",
-            "bf16-mixed",
-            "bf16-true",
-            "16-true",
-        ):
+        mp_precision_supported = ("32-true", "bf16-mixed", "bf16-true", "16-true")
+        if isinstance(self._strategy_flag, ModelParallelStrategy) and self._precision_flag not in mp_precision_supported:
             raise ValueError(
-                f"The `ModelParallelStrategy` does not support `Trainer(..., precision={self._precision_flag!r})`."
-                " Choose a different precision."
+                f"The `ModelParallelStrategy` does not support `Fabric(..., precision={self._precision_flag!r})`."
+                f" Choose a different precision among: {', '.join(mp_precision_supported)}."
             )
 
         if _habana_available_and_importable():

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -529,6 +529,14 @@ class _AcceleratorConnector:
             self.accelerator, CUDAAccelerator
         ):
             raise RuntimeError("Bitsandbytes is only supported on CUDA GPUs.")
+        if isinstance(self._strategy_flag, ModelParallelStrategy) and self._precision_flag not in (
+            "32-true", "bf16-mixed", "bf16-true", "16-true"
+        ):
+            raise ValueError(
+                f"The `ModelParallelStrategy` does not support `Trainer(..., precision={self._precision_flag!r})`."
+                " Choose a different precision."
+            )
+            
         if _habana_available_and_importable():
             from lightning_habana import HPUAccelerator
 

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -530,13 +530,16 @@ class _AcceleratorConnector:
         ):
             raise RuntimeError("Bitsandbytes is only supported on CUDA GPUs.")
         if isinstance(self._strategy_flag, ModelParallelStrategy) and self._precision_flag not in (
-            "32-true", "bf16-mixed", "bf16-true", "16-true"
+            "32-true",
+            "bf16-mixed",
+            "bf16-true",
+            "16-true",
         ):
             raise ValueError(
                 f"The `ModelParallelStrategy` does not support `Trainer(..., precision={self._precision_flag!r})`."
                 " Choose a different precision."
             )
-            
+
         if _habana_available_and_importable():
             from lightning_habana import HPUAccelerator
 

--- a/tests/tests_fabric/test_connector.py
+++ b/tests/tests_fabric/test_connector.py
@@ -23,7 +23,6 @@ import lightning.fabric
 import pytest
 import torch
 import torch.distributed
-
 from lightning.fabric import Fabric
 from lightning.fabric.accelerators import XLAAccelerator
 from lightning.fabric.accelerators.accelerator import Accelerator
@@ -869,9 +868,10 @@ def test_precision_selection_amp_ddp(strategy, devices, is_custom_plugin, plugin
     assert isinstance(connector.precision, plugin_cls)
 
 
-@pytest.mark.parametrize(("precision", "raises"), [
-    ("32-true", False), ("16-true", False), ("bf16-true", False), ("16-mixed", True), ("bf16-mixed", False)
-])
+@pytest.mark.parametrize(
+    ("precision", "raises"),
+    [("32-true", False), ("16-true", False), ("bf16-true", False), ("16-mixed", True), ("bf16-mixed", False)],
+)
 @mock.patch("lightning.fabric.accelerators.mps.MPSAccelerator.is_available", return_value=False)
 def test_precision_selection_model_parallel(_, precision, raises):
     error_context = pytest.raises(ValueError, match=f"does not support .*{precision}") if raises else nullcontext()

--- a/tests/tests_fabric/test_connector.py
+++ b/tests/tests_fabric/test_connector.py
@@ -868,6 +868,7 @@ def test_precision_selection_amp_ddp(strategy, devices, is_custom_plugin, plugin
     assert isinstance(connector.precision, plugin_cls)
 
 
+@RunIf(min_torch="2.3")
 @pytest.mark.parametrize(
     ("precision", "raises"),
     [("32-true", False), ("16-true", False), ("bf16-true", False), ("16-mixed", True), ("bf16-mixed", False)],

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -1067,6 +1067,7 @@ def test_bitsandbytes_precision_cuda_required(monkeypatch):
         _AcceleratorConnector(accelerator="cpu", plugins=BitsandbytesPrecision(mode="int8"))
 
 
+@RunIf(min_torch="2.3")
 @pytest.mark.parametrize(
     ("precision", "raises"),
     [("32-true", False), ("16-true", False), ("bf16-true", False), ("16-mixed", True), ("bf16-mixed", False)],

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -14,6 +14,7 @@
 import inspect
 import os
 import sys
+from contextlib import nullcontext
 from typing import Any, Dict
 from unittest import mock
 from unittest.mock import Mock
@@ -48,6 +49,7 @@ from lightning.pytorch.strategies import (
     DDPStrategy,
     DeepSpeedStrategy,
     FSDPStrategy,
+    ModelParallelStrategy,
     SingleDeviceStrategy,
     SingleDeviceXLAStrategy,
     XLAStrategy,
@@ -1063,3 +1065,13 @@ def test_bitsandbytes_precision_cuda_required(monkeypatch):
     monkeypatch.setitem(sys.modules, "bitsandbytes", Mock())
     with pytest.raises(RuntimeError, match="Bitsandbytes is only supported on CUDA GPUs"):
         _AcceleratorConnector(accelerator="cpu", plugins=BitsandbytesPrecision(mode="int8"))
+
+
+@pytest.mark.parametrize(
+    ("precision", "raises"),
+    [("32-true", False), ("16-true", False), ("bf16-true", False), ("16-mixed", True), ("bf16-mixed", False)],
+)
+def test_precision_selection_model_parallel(precision, raises, mps_count_0):
+    error_context = pytest.raises(ValueError, match=f"does not support .*{precision}") if raises else nullcontext()
+    with error_context:
+        _AcceleratorConnector(precision=precision, strategy=ModelParallelStrategy())


### PR DESCRIPTION
## What does this PR do?

Adds error handling if user passes `precision="16-mixed"`. This would require a sharded gradscaler to be configured, but we opted for not supporting this at the moment. `precision="bf16-mixed"` (bfloat) is still supported, as it doesn't require a grad scaler. Other precisions such as bitsandbytes are also not allowed (they don't compose with this strategy) by design.



cc @borda @carmocca @justusschock @awaelchli