### PR TITLE
Add Studio badge to tensor parallel docs

### DIFF
--- a/docs/source-fabric/advanced/model_parallel/tp.rst
+++ b/docs/source-fabric/advanced/model_parallel/tp.rst
@@ -8,7 +8,7 @@ This method is most effective for models with very large layers, significantly e
 
 .. raw:: html
 
-    <a target="_blank" href="https://lightning.ai/lightning-ai/studios/tensor-parallelism-supercharging-large-model-training-with-pytorch-lightning">
+    <a target="_blank" href="https://lightning.ai/lightning-ai/studios/tensor-parallelism-supercharging-large-model-training-with-lightning-fabric">
       <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio" style="width: auto; max-width: none;"/>
     </a>
 

--- a/docs/source-fabric/advanced/model_parallel/tp.rst
+++ b/docs/source-fabric/advanced/model_parallel/tp.rst
@@ -13,9 +13,6 @@ This method is most effective for models with very large layers, significantly e
     </a>
 
 
-.. note:: Tensor Parallelism in Lightning Fabric as well as PyTorch is experimental. The APIs may change in the future.
-
-
 ----
 
 
@@ -204,7 +201,8 @@ Later in the code, when you call ``fabric.setup(model)``, Fabric will apply the 
 
         fabric.print(f"Peak memory usage: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
-|
+
+.. note:: Tensor Parallelism in Lightning Fabric as well as PyTorch is experimental. The APIs may change in the future.
 
 When measuring the peak memory consumption, we should see that doubling the number of GPUs reduces the memory consumption roughly by half:
 

--- a/docs/source-fabric/advanced/model_parallel/tp.rst
+++ b/docs/source-fabric/advanced/model_parallel/tp.rst
@@ -199,7 +199,7 @@ Later in the code, when you call ``fabric.setup(model)``, Fabric will apply the 
 
 |
 
-When measuring the peak memory consumption, we should see that doubling the number of GPUs reduces the memory consuption roughly by half:
+When measuring the peak memory consumption, we should see that doubling the number of GPUs reduces the memory consumption roughly by half:
 
 
 .. list-table::

--- a/docs/source-fabric/advanced/model_parallel/tp.rst
+++ b/docs/source-fabric/advanced/model_parallel/tp.rst
@@ -6,7 +6,14 @@ Tensor parallelism is a technique for training large models by distributing laye
 However, for smaller models, the communication overhead may outweigh its benefits.
 This method is most effective for models with very large layers, significantly enhancing performance and memory efficiency.
 
-.. note:: This is an experimental feature.
+.. raw:: html
+
+    <a target="_blank" href="https://lightning.ai/lightning-ai/studios/tensor-parallelism-supercharging-large-model-training-with-pytorch-lightning">
+      <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio" style="width: auto; max-width: none;"/>
+    </a>
+
+
+.. note:: Tensor Parallelism in Lightning Fabric as well as PyTorch is experimental. The APIs may change in the future.
 
 
 ----

--- a/docs/source-fabric/advanced/model_parallel/tp_fsdp.rst
+++ b/docs/source-fabric/advanced/model_parallel/tp_fsdp.rst
@@ -13,8 +13,6 @@ The :doc:`Tensor Parallelism documentation <tp>` and a general understanding of 
       <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio" style="width: auto; max-width: none;"/>
     </a>
 
-.. note:: 2D Parallelism in Lightning Fabric as well as PyTorch is experimental. The APIs may change in the future.
-
 
 ----
 
@@ -188,7 +186,7 @@ Finally, the tensor parallelism will apply to each group, splitting the sharded 
 
         fabric.print(f"Peak memory usage: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
-|
+.. note:: 2D Parallelism in Lightning Fabric as well as PyTorch is experimental. The APIs may change in the future.
 
 Beyond this toy example, we recommend you study our `LLM 2D Parallel Example (Llama 3) <https://github.com/Lightning-AI/pytorch-lightning/tree/master/examples/fabric/tensor_parallel>`_.
 

--- a/docs/source-fabric/advanced/model_parallel/tp_fsdp.rst
+++ b/docs/source-fabric/advanced/model_parallel/tp_fsdp.rst
@@ -9,7 +9,7 @@ The :doc:`Tensor Parallelism documentation <tp>` and a general understanding of 
 
 .. raw:: html
 
-    <a target="_blank" href="https://lightning.ai/lightning-ai/studios/tensor-parallelism-supercharging-large-model-training-with-pytorch-lightning">
+    <a target="_blank" href="https://lightning.ai/lightning-ai/studios/tensor-parallelism-supercharging-large-model-training-with-lightning-fabric">
       <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio" style="width: auto; max-width: none;"/>
     </a>
 

--- a/docs/source-fabric/advanced/model_parallel/tp_fsdp.rst
+++ b/docs/source-fabric/advanced/model_parallel/tp_fsdp.rst
@@ -7,7 +7,13 @@ This hybrid approach balances the trade-offs of each method, optimizing memory u
 
 The :doc:`Tensor Parallelism documentation <tp>` and a general understanding of `FSDP <https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html>`_ are a prerequisite for this tutorial.
 
-.. note:: This is an experimental feature.
+.. raw:: html
+
+    <a target="_blank" href="https://lightning.ai/lightning-ai/studios/tensor-parallelism-supercharging-large-model-training-with-pytorch-lightning">
+      <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio" style="width: auto; max-width: none;"/>
+    </a>
+
+.. note:: 2D Parallelism in Lightning Fabric as well as PyTorch is experimental. The APIs may change in the future.
 
 
 ----

--- a/docs/source-pytorch/advanced/model_parallel/tp.rst
+++ b/docs/source-pytorch/advanced/model_parallel/tp.rst
@@ -12,8 +12,6 @@ This method is most effective for models with very large layers, significantly e
       <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio" style="width: auto; max-width: none;"/>
     </a>
 
-.. note:: Tensor Parallelism in PyTorch Lightning as well as PyTorch is experimental. The APIs may change in the future.
-
 
 ----
 
@@ -221,7 +219,7 @@ When ``trainer.fit(...)`` (or ``validate()``, ``test``, etc.) gets called, the T
 
         trainer.print(f"Peak memory usage: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
-|
+.. note:: Tensor Parallelism in PyTorch Lightning as well as PyTorch is experimental. The APIs may change in the future.
 
 When measuring the peak memory consumption, we should see that doubling the number of GPUs reduces the memory consumption roughly by half:
 

--- a/docs/source-pytorch/advanced/model_parallel/tp.rst
+++ b/docs/source-pytorch/advanced/model_parallel/tp.rst
@@ -6,7 +6,13 @@ Tensor parallelism is a technique for training large models by distributing laye
 However, for smaller models, the communication overhead may outweigh its benefits.
 This method is most effective for models with very large layers, significantly enhancing performance and memory efficiency.
 
-.. note:: This is an experimental feature.
+.. raw:: html
+
+    <a target="_blank" href="https://lightning.ai/lightning-ai/studios/tensor-parallelism-supercharging-large-model-training-with-pytorch-lightning">
+      <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio" style="width: auto; max-width: none;"/>
+    </a>
+
+.. note:: Tensor Parallelism in PyTorch Lightning as well as PyTorch is experimental. The APIs may change in the future.
 
 
 ----

--- a/docs/source-pytorch/advanced/model_parallel/tp.rst
+++ b/docs/source-pytorch/advanced/model_parallel/tp.rst
@@ -217,7 +217,7 @@ When ``trainer.fit(...)`` (or ``validate()``, ``test``, etc.) gets called, the T
 
 |
 
-When measuring the peak memory consumption, we should see that doubling the number of GPUs reduces the memory consuption roughly by half:
+When measuring the peak memory consumption, we should see that doubling the number of GPUs reduces the memory consumption roughly by half:
 
 
 .. list-table::

--- a/docs/source-pytorch/advanced/model_parallel/tp_fsdp.rst
+++ b/docs/source-pytorch/advanced/model_parallel/tp_fsdp.rst
@@ -7,7 +7,13 @@ This hybrid approach balances the trade-offs of each method, optimizing memory u
 
 The :doc:`Tensor Parallelism documentation <tp>` and a general understanding of `FSDP <https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html>`_ are a prerequisite for this tutorial.
 
-.. note:: This is an experimental feature.
+.. raw:: html
+
+    <a target="_blank" href="https://lightning.ai/lightning-ai/studios/tensor-parallelism-supercharging-large-model-training-with-pytorch-lightning">
+      <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio" style="width: auto; max-width: none;"/>
+    </a>
+
+.. note:: 2D Parallelism in PyTorch Lightning as well as PyTorch is experimental. The APIs may change in the future.
 
 
 ----

--- a/docs/source-pytorch/advanced/model_parallel/tp_fsdp.rst
+++ b/docs/source-pytorch/advanced/model_parallel/tp_fsdp.rst
@@ -13,8 +13,6 @@ The :doc:`Tensor Parallelism documentation <tp>` and a general understanding of 
       <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio" style="width: auto; max-width: none;"/>
     </a>
 
-.. note:: 2D Parallelism in PyTorch Lightning as well as PyTorch is experimental. The APIs may change in the future.
-
 
 ----
 
@@ -196,7 +194,7 @@ Finally, the tensor parallelism will apply to each group, splitting the sharded 
         trainer.print(f"Peak memory usage: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
 
-|
+.. note:: 2D Parallelism in PyTorch Lightning as well as PyTorch is experimental. The APIs may change in the future.
 
 Beyond this toy example, we recommend you study our `LLM 2D Parallel Example (Llama 3) <https://github.com/Lightning-AI/pytorch-lightning/tree/master/examples/pytorch/tensor_parallel>`_.
 

--- a/examples/fabric/tensor_parallel/README.md
+++ b/examples/fabric/tensor_parallel/README.md
@@ -1,6 +1,6 @@
 ## Tensor Parallel and 2D Parallel
 
-This example shows how to apply tensor-parallelism to your model (here Llama 2 7B) with the `ModelParallelStrategy`, and how it can be combined with FSDP (2D parallelism).
+This example shows how to apply tensor-parallelism to your model (here Llama 3 7B) with the `ModelParallelStrategy`, and how it can be combined with FSDP (2D parallelism).
 PyTorch 2.3+ and a machine with at least 4 GPUs and 24 GB memory each are required to run this example.
 
 ```bash

--- a/examples/pytorch/tensor_parallel/README.md
+++ b/examples/pytorch/tensor_parallel/README.md
@@ -1,6 +1,6 @@
 ## Tensor Parallel and 2D Parallel
 
-This example shows how to apply tensor-parallelism to your model (here Llama 2 7B) with the `ModelParallelStrategy`, and how it can be combined with FSDP (2D parallelism).
+This example shows how to apply tensor-parallelism to your model (here Llama 3 7B) with the `ModelParallelStrategy`, and how it can be combined with FSDP (2D parallelism).
 PyTorch 2.3+ and a machine with at least 4 GPUs and 24 GB memory each are required to run this example.
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Adds a badge that allows the docs reader to open the Studio and follow the tutorial by running all code examples without installing anything. 




<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19913.org.readthedocs.build/en/19913/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli