### PR TITLE
Check if CometLogger experiment is alive

### DIFF
--- a/src/lightning/pytorch/loggers/comet.py
+++ b/src/lightning/pytorch/loggers/comet.py
@@ -268,7 +268,7 @@ class CometLogger(Logger):
             self.logger.experiment.some_comet_function()
 
         """
-        if self._experiment is not None and self.experiment.alive:
+        if self._experiment is not None and self._experiment.alive:
             return self._experiment
 
         if self._future_experiment_key is not None:

--- a/src/lightning/pytorch/loggers/comet.py
+++ b/src/lightning/pytorch/loggers/comet.py
@@ -268,7 +268,7 @@ class CometLogger(Logger):
             self.logger.experiment.some_comet_function()
 
         """
-        if self._experiment is not None:
+        if self._experiment is not None and self.experiment.alive:
             return self._experiment
 
         if self._future_experiment_key is not None:

--- a/tests/tests_pytorch/loggers/test_comet.py
+++ b/tests/tests_pytorch/loggers/test_comet.py
@@ -67,6 +67,20 @@ def test_comet_logger_online(comet_mock):
 
 
 @mock.patch.dict(os.environ, {})
+def test_comet_experiment_resets_if_not_alive(comet_mock):
+    """Test that the CometLogger creates a new experiment if the old one is not alive anymore."""
+    logger = CometLogger()
+    assert logger._experiment is None
+    alive_experiment = Mock(alive=True)
+    logger._experiment = alive_experiment
+    assert logger.experiment is alive_experiment
+
+    unalive_experiment = Mock(alive=False)
+    logger._experiment = unalive_experiment
+    assert logger.experiment is not unalive_experiment
+
+
+@mock.patch.dict(os.environ, {})
 def test_comet_logger_no_api_key_given(comet_mock):
     """Test that CometLogger fails to initialize if both api key and save_dir are missing."""
     with pytest.raises(MisconfigurationException, match="requires either api_key or save_dir"):


### PR DESCRIPTION

## What does this PR do?

A tiny patch to align how the CometLogger class checks if the the underlying Comet Experiment object it holds needs to be reactivated. Solves cases where CometClient suddenly stops being able to log (e.g due to another Experiment instance being created by any other source).

Fixes #19900


## PR review



<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19915.org.readthedocs.build/en/19915/

<!-- readthedocs-preview pytorch-lightning end -->