### PR TITLE
Update docstring for `self.log` about keys in distributed training

### DIFF
--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -405,7 +405,7 @@ class LightningModule(
         The default behavior per hook is documented here: :ref:`extensions/logging:Automatic Logging`.
 
         Args:
-            name: key to log.
+            name: key to log. Must be identical across all processes if using DDP or any other distributed strategy.
             value: value to log. Can be a ``float``, ``Tensor``, or a ``Metric``.
             prog_bar: if ``True`` logs to the progress bar.
             logger: if ``True`` logs to the logger.
@@ -569,6 +569,7 @@ class LightningModule(
 
         Args:
             dictionary: key value pairs.
+                Keys must be identical across all processes if using DDP or any other distributed strategy.
                 The values can be a ``float``, ``Tensor``, ``Metric``, or ``MetricCollection``.
             prog_bar: if ``True`` logs to the progress base.
             logger: if ``True`` logs to the logger.


### PR DESCRIPTION
## What does this PR do?

A user logged keys inconsistently across ranks, leading to hangs at the reduction in the end of the epoch.
This should not be allowed, but I couldn't yet find a good way to enforce this in the code. For now I'm adding a note to the docstring. 



<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19917.org.readthedocs.build/en/19917/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda