### PR TITLE
Disable skipping training step in distributed training

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -28,7 +28,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Relaxed the requirement for custom batch samplers to expose `drop_last` for prediction ([#19678](https://github.com/Lightning-AI/pytorch-lightning/pull/19678))
 
--
+- It is no longer allowed to skip `training_step()` by returning `None` in distributed training ([#19918](https://github.com/Lightning-AI/pytorch-lightning/pull/19918))
+
 
 ### Deprecated
 

--- a/src/lightning/pytorch/loops/optimization/automatic.py
+++ b/src/lightning/pytorch/loops/optimization/automatic.py
@@ -320,6 +320,8 @@ class _AutomaticOptimization(_Loop):
         if training_step_output is None and trainer.world_size > 1:
             raise RuntimeError(
                 "Skipping the `training_step` by returning None in distributed training is not supported."
+                " It is recommended that you rewrite your training logic to avoid having to skip the step in the first"
+                " place."
             )
 
         return self.output_result_cls.from_training_step_output(training_step_output, trainer.accumulate_grad_batches)

--- a/src/lightning/pytorch/loops/optimization/automatic.py
+++ b/src/lightning/pytorch/loops/optimization/automatic.py
@@ -314,8 +314,12 @@ class _AutomaticOptimization(_Loop):
         """
         trainer = self.trainer
 
-        # manually capture logged metrics
         training_step_output = call._call_strategy_hook(trainer, "training_step", *kwargs.values())
         self.trainer.strategy.post_training_step()  # unused hook - call anyway for backward compatibility
+
+        if training_step_output is None and trainer.world_size > 0:
+            raise RuntimeError(
+                "Skipping the `training_step` by returning None in distributed training is not supported."
+            )
 
         return self.output_result_cls.from_training_step_output(training_step_output, trainer.accumulate_grad_batches)

--- a/src/lightning/pytorch/loops/optimization/automatic.py
+++ b/src/lightning/pytorch/loops/optimization/automatic.py
@@ -317,7 +317,7 @@ class _AutomaticOptimization(_Loop):
         training_step_output = call._call_strategy_hook(trainer, "training_step", *kwargs.values())
         self.trainer.strategy.post_training_step()  # unused hook - call anyway for backward compatibility
 
-        if training_step_output is None and trainer.world_size > 0:
+        if training_step_output is None and trainer.world_size > 1:
             raise RuntimeError(
                 "Skipping the `training_step` by returning None in distributed training is not supported."
             )

--- a/tests/tests_pytorch/loops/optimization/test_automatic_loop.py
+++ b/tests/tests_pytorch/loops/optimization/test_automatic_loop.py
@@ -87,6 +87,7 @@ def test_warning_invalid_trainstep_output(tmp_path, case):
 @pytest.mark.parametrize("world_size", [1, 2])
 def test_skip_training_step_not_allowed(world_size, tmp_path):
     """Test that skipping the training_step in distributed training is not allowed."""
+
     class TestModel(BoringModel):
         def training_step(self, batch, batch_idx):
             return None
@@ -98,6 +99,10 @@ def test_skip_training_step_not_allowed(world_size, tmp_path):
         barebones=True,
     )
     trainer.strategy.world_size = world_size
-    error_context = pytest.raises(RuntimeError, match="Skipping the `training_step` .* is not supported") if world_size > 1 else nullcontext()
+    error_context = (
+        pytest.raises(RuntimeError, match="Skipping the `training_step` .* is not supported")
+        if world_size > 1
+        else nullcontext()
+    )
     with error_context:
         trainer.fit(model)

--- a/tests/tests_pytorch/loops/optimization/test_automatic_loop.py
+++ b/tests/tests_pytorch/loops/optimization/test_automatic_loop.py
@@ -98,7 +98,7 @@ def test_skip_training_step_not_allowed(world_size, tmp_path):
         max_steps=1,
         barebones=True,
     )
-    trainer.strategy.world_size = world_size
+    trainer.strategy.world_size = world_size  # mock world size without launching processes
     error_context = (
         pytest.raises(RuntimeError, match="Skipping the `training_step` .* is not supported")
         if world_size > 1

--- a/tests/tests_pytorch/loops/optimization/test_optimizer_loop.py
+++ b/tests/tests_pytorch/loops/optimization/test_optimizer_loop.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from contextlib import nullcontext
 from typing import Dict, Generic, Iterator, Mapping, TypeVar
 
 import pytest
@@ -81,4 +81,23 @@ def test_warning_invalid_trainstep_output(tmp_path, case):
     trainer = Trainer(default_root_dir=tmp_path, fast_dev_run=1)
 
     with pytest.raises(MisconfigurationException, match=match):
+        trainer.fit(model)
+
+
+@pytest.mark.parametrize("world_size", [1, 2])
+def test_skip_training_step_not_allowed(world_size, tmp_path):
+    """Test that skipping the training_step in distributed training is not allowed."""
+    class TestModel(BoringModel):
+        def training_step(self, batch, batch_idx):
+            return None
+
+    model = TestModel()
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        max_steps=1,
+        barebones=True,
+    )
+    trainer.strategy.world_size = world_size
+    error_context = pytest.raises(RuntimeError, match="Skipping the `training_step` .* is not supported") if world_size > 1 else nullcontext()
+    with error_context:
         trainer.fit(model)

--- a/tests/tests_pytorch/models/test_hooks.py
+++ b/tests/tests_pytorch/models/test_hooks.py
@@ -178,6 +178,8 @@ def test_transfer_batch_hook_ddp(tmp_path):
         def training_step(self, batch, batch_idx):
             assert batch.samples.device == self.device
             assert isinstance(batch_idx, int)
+            # the actual training step is not needed for the assertions
+            return super().training_step(torch.rand(1, 32, device=self.device), batch_idx)
 
         def train_dataloader(self):
             return torch.utils.data.DataLoader(RandomDataset(32, 64), collate_fn=collate_fn)

--- a/tests/tests_pytorch/trainer/test_dataloaders.py
+++ b/tests/tests_pytorch/trainer/test_dataloaders.py
@@ -641,7 +641,8 @@ class MultiProcessModel(BoringModel):
 
     def training_step(self, batch, batch_idx):
         self.batches_seen.append(batch)
-        return super().training_step(batch, batch_idx)
+        # the actual training step is not needed for the assertions below
+        return super().training_step(torch.rand(1, 32, device=self.device), batch_idx)
 
     def on_train_epoch_end(self):
         world_size = 2
@@ -811,8 +812,10 @@ class TestModelUniqueDDPSampling(BoringModel):
         super().__init__()
         self.seen_samples = []
 
-    def training_step(self, batch):
+    def training_step(self, batch, batch_idx):
         self.seen_samples.extend(batch.tolist())
+        # the actual training step is not needed for the test
+        return super().training_step(torch.rand(1, 32, device=self.device), batch_idx)
 
     def on_train_end(self):
         seen_samples = self.all_gather(self.seen_samples)

--- a/tests/tests_pytorch/trainer/test_dataloaders.py
+++ b/tests/tests_pytorch/trainer/test_dataloaders.py
@@ -641,6 +641,7 @@ class MultiProcessModel(BoringModel):
 
     def training_step(self, batch, batch_idx):
         self.batches_seen.append(batch)
+        return super().training_step(batch, batch_idx)
 
     def on_train_epoch_end(self):
         world_size = 2


### PR DESCRIPTION
## What does this PR do?

We currently allow a user to return None from the training step to skip it. This works fine in single-device execution, but is an ill-defined behavior for distributed training. If the decision whether to skip or not is different on each rank, the epoch will inconsistently progress and eventually lead to a hang in all-reduce towards the end of epoch, when some ranks have finished the epoch and some not. 

As an action, I'm proposing in this PR to simply disable this by raising an error.
It is [already documented](https://github.com/Lightning-AI/pytorch-lightning/blob/98005bbed0b7ded09a4b88c6fb6f72527a451d33/src/lightning/pytorch/core/module.py#L719-L721) as not supported, just not enforced.

### Alternative

A potential way to allow skipping properly was discussed in #5243. Here would be my implementation for it:
```py
def sync_training_step_output_if_needed(output, trainer):
    lightning_module = trainer.lightning_module
    if output is None and not lightning_module.training_step_can_skip and trainer.world_size > 1:
        raise RuntimeError(
            "Skipping the `training_step` by returning None in distributed training is only supported by explicitly"
            " setting `self.training_step_can_skip = True` in your LightningModule. This will introduce additional"
            " syncs and potentially slow down training. Consider rewriting your training step to avoid returning None."
        )
    if lightning_module.training_step_can_skip:
        # If any rank skips training step, all ranks must skip their training step
        is_any_output_none = trainer.strategy.reduce_boolean_decision(output is None, all=False)
        output = None if is_any_output_none else output
    return output
```
However, it's unclear whether there is a strong need for this today. I recommend that if users/customers find use cases for this where the extra overhead is justified, we revisit this and add this implementation with the opt-in flag on LightningModule.


### Is this a breaking change?

Strictly speaking it should be considered a breaking change. However, the question remains how anyone could rely on this behavior without running into deadlocks at the epoch end. We already document it is not supported. The concern in this PR is that it is better to leave the user with a meaningful error message than letting the deadlock happen.



<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19918.org.readthedocs.build/en/19918/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @justusschock @carmocca