### PR TITLE
Update code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-* @lantiga @borda @tchaton @awaelchli
+* @lantiga @borda @tchaton @awaelchli @justusschock
 
 # CI/CD and configs
 /.actions/                  @borda @ethanwharris @justusschock
@@ -28,17 +28,13 @@
 /docs/source-app/                           @williamfalcon @lantiga @tchaton
 
 # PyTorch Lightning
-/src/lightning/pytorch                      @williamfalcon @awaelchli @justusschock
-/src/pytorch_lightning                      @williamfalcon @awaelchli @justusschock
-/tests/tests_pytorch                        @awaelchli @justusschock @borda
+/src/lightning/pytorch                      @lantiga @borda @tchaton @awaelchli @justusschock
 
 # Lightning Data
 /src/lightning/data/                        @tchaton @lantiga
 
 # Lightning Fabric
-/src/lightning/fabric                       @awaelchli @justusschock
-/src/lightning_fabric                       @awaelchli @justusschock
-/tests/tests_fabric                         @awaelchli @justusschock
+/src/lightning/fabric                       @lantiga @borda @tchaton @awaelchli @justusschock
 
 # Lightning App
 /src/lightning/app                          @tchaton @lantiga @awaelchli @ethanwharris


### PR DESCRIPTION
## What does this PR do?

In the previous PR #19922, I made a mistake. Right now it would require the review of Will Falcon for everything under PL, which was not the goal.
The goal was to make it so that any of the 5 of us (lantiga, thomas, justus, jirka, me) approval counts for the major parts of the code base. So this should hopefully fix it. 


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19925.org.readthedocs.build/en/19925/

<!-- readthedocs-preview pytorch-lightning end -->