### PR TITLE
Update FlopCounterMode usage in throughput.py

### DIFF
--- a/src/lightning/fabric/utilities/throughput.py
+++ b/src/lightning/fabric/utilities/throughput.py
@@ -296,7 +296,7 @@ def measure_flops(
         raise ImportError("`measure_flops` requires PyTorch >= 2.1.")
     from torch.utils.flop_counter import FlopCounterMode
 
-    flop_counter = FlopCounterMode(model, display=False)
+    flop_counter = FlopCounterMode(display=False)
     with flop_counter:
         if loss_fn is None:
             forward_fn()


### PR DESCRIPTION
`mods` argument is not needed anymore for `FlopCounterMode`: https://github.com/pytorch/pytorch/blob/ffe506e85350a505be5698c871d50b2fc614406d/torch/utils/flop_counter.py#L595-L596



<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19926.org.readthedocs.build/en/19926/

<!-- readthedocs-preview pytorch-lightning end -->