### PR TITLE
Destroy process group in atexit handler

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added `ModelParallelStrategy` to support 2D parallelism ([#19846](https://github.com/Lightning-AI/pytorch-lightning/pull/19846), [#19852](https://github.com/Lightning-AI/pytorch-lightning/pull/19852), [#19870](https://github.com/Lightning-AI/pytorch-lightning/pull/19870), [#19872](https://github.com/Lightning-AI/pytorch-lightning/pull/19872))
 
+- Added a call to `torch.distributed.destroy_process_group` in atexit handler if process group needs destruction ([#19931](https://github.com/Lightning-AI/pytorch-lightning/pull/19931))
+
 
 ### Changed
 

--- a/src/lightning/fabric/utilities/distributed.py
+++ b/src/lightning/fabric/utilities/distributed.py
@@ -306,6 +306,8 @@ def _init_dist_connection(
 
 def _destroy_dist_connection() -> None:
     if _distributed_is_initialized():
+        # ensure at least one collective op ran, otherwise `destroy_process_group()` hangs
+        torch.distributed.barrier()
         torch.distributed.destroy_process_group()
 
 

--- a/src/lightning/fabric/utilities/distributed.py
+++ b/src/lightning/fabric/utilities/distributed.py
@@ -1,3 +1,4 @@
+import atexit
 import contextlib
 import logging
 import os
@@ -291,6 +292,9 @@ def _init_dist_connection(
     log.info(f"Initializing distributed: GLOBAL_RANK: {global_rank}, MEMBER: {global_rank + 1}/{world_size}")
     torch.distributed.init_process_group(torch_distributed_backend, rank=global_rank, world_size=world_size, **kwargs)
 
+    # PyTorch >= 2.4 warns about undestroyed process group, so we need to do it at program exit
+    atexit.register(_destroy_dist_connection)
+
     # On rank=0 let everyone know training is starting
     rank_zero_info(
         f"{'-' * 100}\n"
@@ -298,6 +302,11 @@ def _init_dist_connection(
         f"All distributed processes registered. Starting with {world_size} processes\n"
         f"{'-' * 100}\n"
     )
+
+
+def _destroy_dist_connection() -> None:
+    if _distributed_is_initialized():
+        torch.distributed.destroy_process_group()
 
 
 def _get_default_process_group_backend_for_device(device: torch.device) -> str:

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added `ModelParallelStrategy` to support 2D parallelism ([#19878](https://github.com/Lightning-AI/pytorch-lightning/pull/19878), [#19888](https://github.com/Lightning-AI/pytorch-lightning/pull/19888))
 
+- Added a call to `torch.distributed.destroy_process_group` in atexit handler if process group needs destruction ([#19931](https://github.com/Lightning-AI/pytorch-lightning/pull/19931))
 
 
 ### Changed

--- a/tests/tests_fabric/conftest.py
+++ b/tests/tests_fabric/conftest.py
@@ -23,7 +23,7 @@ import pytest
 import torch.distributed
 from lightning.fabric.accelerators import XLAAccelerator
 from lightning.fabric.strategies.launchers.subprocess_script import _ChildProcessObserver
-from lightning.fabric.utilities.distributed import _distributed_is_initialized
+from lightning.fabric.utilities.distributed import _destroy_dist_connection
 
 if sys.version_info >= (3, 9):
     from concurrent.futures.process import _ExecutorManagerThread
@@ -78,8 +78,7 @@ def restore_env_variables():
 def teardown_process_group():
     """Ensures that the distributed process group gets closed before the next test runs."""
     yield
-    if _distributed_is_initialized():
-        torch.distributed.destroy_process_group()
+    _destroy_dist_connection()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/tests_fabric/utilities/test_distributed.py
+++ b/tests/tests_fabric/utilities/test_distributed.py
@@ -226,3 +226,6 @@ def test_infinite_barrier():
 def test_init_dist_connection_registers_destruction_handler(_, atexit_mock):
     _init_dist_connection(LightningEnvironment(), "nccl")
     atexit_mock.register.assert_called_once_with(_destroy_dist_connection)
+    atexit_mock.reset_mock()
+    _init_dist_connection(LightningEnvironment(), "gloo")
+    atexit_mock.register.assert_not_called()

--- a/tests/tests_fabric/utilities/test_distributed.py
+++ b/tests/tests_fabric/utilities/test_distributed.py
@@ -1,10 +1,8 @@
-import atexit
 import functools
 import os
 from functools import partial
 from pathlib import Path
 from unittest import mock
-from unittest.mock import Mock
 
 import pytest
 import torch
@@ -13,13 +11,13 @@ from lightning.fabric.plugins.environments import LightningEnvironment
 from lightning.fabric.strategies import DDPStrategy, SingleDeviceStrategy
 from lightning.fabric.strategies.launchers.multiprocessing import _MultiProcessingLauncher
 from lightning.fabric.utilities.distributed import (
+    _destroy_dist_connection,
     _gather_all_tensors,
     _InfiniteBarrier,
+    _init_dist_connection,
     _set_num_threads_if_needed,
     _suggested_max_num_threads,
     _sync_ddp,
-    _destroy_dist_connection,
-    _init_dist_connection,
     is_shared_filesystem,
 )
 

--- a/tests/tests_pytorch/conftest.py
+++ b/tests/tests_pytorch/conftest.py
@@ -27,7 +27,7 @@ import pytest
 import torch.distributed
 from lightning.fabric.plugins.environments.lightning import find_free_network_port
 from lightning.fabric.strategies.launchers.subprocess_script import _ChildProcessObserver
-from lightning.fabric.utilities.distributed import _distributed_is_initialized
+from lightning.fabric.utilities.distributed import _destroy_dist_connection, _distributed_is_initialized
 from lightning.fabric.utilities.imports import _IS_WINDOWS
 from lightning.pytorch.accelerators import XLAAccelerator
 from lightning.pytorch.trainer.connectors.signal_connector import _SignalConnector
@@ -123,8 +123,7 @@ def restore_signal_handlers():
 def teardown_process_group():
     """Ensures that the distributed process group gets closed before the next test runs."""
     yield
-    if _distributed_is_initialized():
-        torch.distributed.destroy_process_group()
+    _destroy_dist_connection()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## What does this PR do?

PyTorch 2.4 added a warning if you don't explicitly call `torch.distributed.destroy_process_group()` at the end of your program:

```
[rank0]:[W602 08:42:46.129824551 ProcessGroupNCCL.cpp:1126] Warning: WARNING: process group has NOT been destroyed before we destruct ProcessGroupNCCL. 
On normal program exit, the application should call destroy_process_group to ensure that any pending NCCL operations have finished in this process. 
In rare cases this process can exit before this point and block the progress of another member of the process group. 
This constraint has always been present,  but this warning has only been added since PyTorch 2.4 (function operator())
```

This will become annoying to users of Lightning because in the vast majority of cases it's completely harmless. The warning is emitted from the C module, so it can't be suppressed via Python. In the spirit of Lightning and making code agnostic to strategy/accelerator, we don't want users to have to make this call manually and remember it every time.

In this PR, I propose to register the destruction in atexit so it runs every time the program exits normally. 


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19931.org.readthedocs.build/en/19931/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli