### PR TITLE
Fix strict loading from distributed checkpoints vs PyTorch nightly

### DIFF
--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -275,12 +275,7 @@ class ModelParallelStrategy(ParallelStrategy):
         state: Optional[Union[Module, Optimizer, Dict[str, Union[Module, Optimizer, Any]]]] = None,
         strict: bool = True,
     ) -> Dict[str, Any]:
-        """Load the contents from a checkpoint and restore the state of the given objects.
-
-        Currently does not support loading the optimizer state if the model is distributed but the checkpoint is a full,
-        non-distributed checkpoint.
-
-        """
+        """Load the contents from a checkpoint and restore the state of the given objects."""
         if not state:
             raise ValueError(
                 f"Got {type(self).__name__}.load_checkpoint(..., state={state!r}) but a state with at least "

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -559,14 +559,14 @@ def _load_raw_module_state(
         state_dict_options = StateDictOptions(
             broadcast_from_rank0=True,  # type: ignore[call-arg]
             full_state_dict=True,
-            strict=strict,  # gets ignored at the moment
+            # must be set False to allow loading each param separately below
+            strict=False,
         )
 
         for submodule_name, submodule in module.named_modules():
             for param_name, _ in _named_parameters_and_buffers_to_load(submodule):
                 full_param_name = f"{submodule_name}{'.' if submodule_name else ''}{param_name}"
                 if full_param_name not in state_dict:
-                    # Note: PyTorch does not currently respect the `strict` setting in state_dict_options!
                     if not strict:
                         continue
                     raise KeyError(


### PR DESCRIPTION
## What does this PR do?

PyTorch 2.4 previously ignored the `strict=True` setting in `StateDictOptions`, but this was fixed recently: https://github.com/pytorch/pytorch/issues/126285

Our per-parameter loading logic needs to be adjusted now. Since loading each param separately means only a subset of the module is loaded with every call, we must set `strict=False` now internally or PyTorch will error. We have a custom strict check anyway: https://github.com/Lightning-AI/pytorch-lightning/blob/fd86ea7356f842a32cd7eeca160f390e60ebca77/src/lightning/fabric/strategies/model_parallel.py#L570-L574

and this test was previously passing:
https://github.com/Lightning-AI/pytorch-lightning/blob/fd86ea7356f842a32cd7eeca160f390e60ebca77/tests/tests_fabric/strategies/test_model_parallel_integration.py#L658
With the PyTorch nightly update it broke, and this PR now makes it pass again.


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19946.org.readthedocs.build/en/19946/

<!-- readthedocs-preview pytorch-lightning end -->

cc @awaelchli @carmocca @justusschock