### PR TITLE
docs: Bump HPU ref `1.6.0.rc0`

### DIFF
--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -91,7 +91,7 @@ _transform_changelog(
 assist_local.AssistantCLI.pull_docs_files(
     gh_user_repo="Lightning-AI/lightning-Habana",
     target_dir="docs/source-pytorch/integrations/hpu",
-    checkout="refs/tags/1.4.0",
+    checkout="1.6.0.rc0",
 )
 
 # Copy strategies docs as single pages


### PR DESCRIPTION
**This is automated update with the latest HPU
  [release](https://github.com/Lightning-AI/lightning-habana/releases/tag/1.6.0.rc0)!**

Go to `docs/source-pytorch/conf.py` and find section `assist_local.AssistantCLI.pull_docs_files(...` for Habana and bump the reference to `1.6.0.rc0`
Please, proceed with this update in timely manner...

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19967.org.readthedocs.build/en/19967/

<!-- readthedocs-preview pytorch-lightning end -->