### PR TITLE
Better graceful shutdown for KeyboardInterrupt

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## [unreleased] - YYYY-MM-DD
+
+### Added
+
+-
+
+-
+
+### Changed
+
+-
+
+-
+
+### Deprecated
+
+-
+
+-
+
+### Removed
+
+-
+
+-
+
+### Fixed
+
+-
+
+-
+
+
+
 ## [2.3.0] - 2024-06-13
 
 ### Added

--- a/src/lightning/fabric/utilities/distributed.py
+++ b/src/lightning/fabric/utilities/distributed.py
@@ -2,6 +2,7 @@ import atexit
 import contextlib
 import logging
 import os
+import signal
 import time
 from contextlib import nullcontext
 from datetime import timedelta
@@ -306,8 +307,11 @@ def _init_dist_connection(
 
 
 def _destroy_dist_connection() -> None:
+    # Don't allow Ctrl+C to interrupt this handler
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     if _distributed_is_initialized():
         torch.distributed.destroy_process_group()
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 
 def _get_default_process_group_backend_for_device(device: torch.device) -> str:

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+
+## [unreleased] - YYYY-MM-DD
+
+### Added
+
+-
+
+-
+
+### Changed
+
+- Triggering KeyboardInterrupt (Ctrl+C) during `.fit()`, `.evaluate()`, `.test()` or `.predict()` now terminates all processes launched by the Trainer and exits the program ([#19976](https://github.com/Lightning-AI/pytorch-lightning/pull/19976))
+
+-
+
+### Deprecated
+
+-
+
+-
+
+### Removed
+
+-
+
+-
+
+### Fixed
+
+-
+
+-
+
+
+
 ## [2.3.0] - 2024-06-13
 
 ### Added

--- a/src/lightning/pytorch/strategies/launchers/multiprocessing.py
+++ b/src/lightning/pytorch/strategies/launchers/multiprocessing.py
@@ -259,7 +259,7 @@ class _MultiProcessingLauncher(_Launcher):
     def kill(self, signum: _SIGNUM) -> None:
         for proc in self.procs:
             if proc.is_alive() and proc.pid is not None:
-                log.info(f"pid {os.getpid()} killing {proc.pid} with {signum}")
+                log.debug(f"Process {os.getpid()} is terminating {proc.pid} with {signum}")
                 with suppress(ProcessLookupError):
                     os.kill(proc.pid, signum)
 

--- a/src/lightning/pytorch/strategies/launchers/subprocess_script.py
+++ b/src/lightning/pytorch/strategies/launchers/subprocess_script.py
@@ -107,7 +107,7 @@ class _SubprocessScriptLauncher(_Launcher):
     @override
     def kill(self, signum: _SIGNUM) -> None:
         for proc in self.procs:
-            log.info(f"pid {os.getpid()} killing {proc.pid} with {signum}")
+            log.debug(f"Process {os.getpid()} is terminating {proc.pid} with {signum}")
             # this skips subprocesses already terminated
             proc.send_signal(signum)
 

--- a/src/lightning/pytorch/trainer/call.py
+++ b/src/lightning/pytorch/trainer/call.py
@@ -21,6 +21,7 @@ from packaging.version import Version
 import lightning.pytorch as pl
 from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
 from lightning.pytorch.callbacks import Checkpoint, EarlyStopping
+from lightning.pytorch.strategies.launchers import _SubprocessScriptLauncher
 from lightning.pytorch.trainer.states import TrainerStatus
 from lightning.pytorch.utilities.exceptions import _TunerExitException
 from lightning.pytorch.utilities.model_helpers import is_overridden
@@ -55,7 +56,7 @@ def _call_and_handle_interrupt(trainer: "pl.Trainer", trainer_fn: Callable, *arg
         # user could press Ctrl+C many times, disable KeyboardInterrupt for shutdown
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         launcher = trainer.strategy.launcher
-        if launcher is not None:
+        if isinstance(launcher, _SubprocessScriptLauncher):
             launcher.kill(signal.SIGKILL)
         exit(0)
     except BaseException as exception:

--- a/src/lightning/pytorch/trainer/call.py
+++ b/src/lightning/pytorch/trainer/call.py
@@ -25,7 +25,7 @@ from lightning.pytorch.strategies.launchers import _SubprocessScriptLauncher
 from lightning.pytorch.trainer.states import TrainerStatus
 from lightning.pytorch.utilities.exceptions import _TunerExitException
 from lightning.pytorch.utilities.model_helpers import is_overridden
-from lightning.pytorch.utilities.rank_zero import rank_zero_warn
+from lightning.pytorch.utilities.rank_zero import rank_zero_info, rank_zero_warn
 
 log = logging.getLogger(__name__)
 
@@ -52,14 +52,13 @@ def _call_and_handle_interrupt(trainer: "pl.Trainer", trainer_fn: Callable, *arg
         trainer.state.stage = None
 
     except KeyboardInterrupt as exception:
-        rank_zero_warn("Detected KeyboardInterrupt, attempting graceful shutdown...")
+        rank_zero_info("\nDetected KeyboardInterrupt, attempting graceful shutdown ...")
         # user could press Ctrl+C many times, disable KeyboardInterrupt for shutdown
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         _interrupt(trainer, exception)
-        launcher = trainer.strategy.launcher
-        if isinstance(launcher, _SubprocessScriptLauncher):
-            launcher.kill(signal.SIGKILL)
+        trainer._teardown()
         exit(1)
+
     except BaseException as exception:
         _interrupt(trainer, exception)
         trainer._teardown()
@@ -76,6 +75,9 @@ def _interrupt(trainer: "pl.Trainer", exception: BaseException) -> None:
     trainer.strategy.on_exception(exception)
     for logger in trainer.loggers:
         logger.finalize("failed")
+    launcher = trainer.strategy.launcher
+    if isinstance(launcher, _SubprocessScriptLauncher):
+        launcher.kill(signal.SIGKILL)
 
 
 def _call_setup_hook(trainer: "pl.Trainer") -> None:

--- a/src/lightning/pytorch/trainer/call.py
+++ b/src/lightning/pytorch/trainer/call.py
@@ -22,6 +22,7 @@ import lightning.pytorch as pl
 from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
 from lightning.pytorch.callbacks import Checkpoint, EarlyStopping
 from lightning.pytorch.strategies.launchers import _SubprocessScriptLauncher
+from lightning.pytorch.trainer.connectors.signal_connector import _get_sigkill_signal
 from lightning.pytorch.trainer.states import TrainerStatus
 from lightning.pytorch.utilities.exceptions import _TunerExitException
 from lightning.pytorch.utilities.model_helpers import is_overridden
@@ -59,7 +60,7 @@ def _call_and_handle_interrupt(trainer: "pl.Trainer", trainer_fn: Callable, *arg
         trainer._teardown()
         launcher = trainer.strategy.launcher
         if isinstance(launcher, _SubprocessScriptLauncher):
-            launcher.kill(signal.SIGKILL)
+            launcher.kill(_get_sigkill_signal())
         exit(1)
 
     except BaseException as exception:

--- a/src/lightning/pytorch/trainer/call.py
+++ b/src/lightning/pytorch/trainer/call.py
@@ -59,7 +59,7 @@ def _call_and_handle_interrupt(trainer: "pl.Trainer", trainer_fn: Callable, *arg
 
         launcher = trainer.strategy.launcher
         if launcher is not None:
-            launcher.kill(signal.SIGTERM)
+            launcher.kill(signal.SIGKILL)
         exit(0)
     except BaseException as exception:
         _interrupt(trainer, exception)

--- a/src/lightning/pytorch/trainer/call.py
+++ b/src/lightning/pytorch/trainer/call.py
@@ -55,10 +55,11 @@ def _call_and_handle_interrupt(trainer: "pl.Trainer", trainer_fn: Callable, *arg
         rank_zero_warn("Detected KeyboardInterrupt, attempting graceful shutdown...")
         # user could press Ctrl+C many times, disable KeyboardInterrupt for shutdown
         signal.signal(signal.SIGINT, signal.SIG_IGN)
+        _interrupt(trainer, exception)
         launcher = trainer.strategy.launcher
         if isinstance(launcher, _SubprocessScriptLauncher):
             launcher.kill(signal.SIGKILL)
-        exit(0)
+        exit(1)
     except BaseException as exception:
         _interrupt(trainer, exception)
         trainer._teardown()

--- a/src/lightning/pytorch/trainer/call.py
+++ b/src/lightning/pytorch/trainer/call.py
@@ -50,17 +50,15 @@ def _call_and_handle_interrupt(trainer: "pl.Trainer", trainer_fn: Callable, *arg
         trainer.state.status = TrainerStatus.FINISHED
         trainer.state.stage = None
 
-    # TODO: Unify both exceptions below, where `KeyboardError` doesn't re-raise
     except KeyboardInterrupt as exception:
         rank_zero_warn("Detected KeyboardInterrupt, attempting graceful shutdown...")
         # user could press Ctrl+c many times... only shutdown once
         if not trainer.interrupted:
             _interrupt(trainer, exception)
-
-        launcher = trainer.strategy.launcher
-        if launcher is not None:
-            launcher.kill(signal.SIGKILL)
-        exit(0)
+            launcher = trainer.strategy.launcher
+            if launcher is not None:
+                launcher.kill(signal.SIGKILL)
+            exit(0)
     except BaseException as exception:
         _interrupt(trainer, exception)
         trainer._teardown()

--- a/src/lightning/pytorch/trainer/call.py
+++ b/src/lightning/pytorch/trainer/call.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import signal
 from copy import deepcopy
 from typing import Any, Callable, Dict, Optional, Type, Union
 
@@ -55,6 +56,11 @@ def _call_and_handle_interrupt(trainer: "pl.Trainer", trainer_fn: Callable, *arg
         # user could press Ctrl+c many times... only shutdown once
         if not trainer.interrupted:
             _interrupt(trainer, exception)
+
+        launcher = trainer.strategy.launcher
+        if launcher is not None:
+            launcher.kill(signal.SIGTERM)
+        exit(0)
     except BaseException as exception:
         _interrupt(trainer, exception)
         trainer._teardown()

--- a/src/lightning/pytorch/trainer/connectors/signal_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/signal_connector.py
@@ -54,7 +54,7 @@ class _SignalConnector:
             sigterm_handlers.append(self._sigterm_handler_fn)
 
         # Windows seems to have signal incompatibilities
-        if not self._is_on_windows():
+        if not _IS_WINDOWS:
             sigusr = environment.requeue_signal if isinstance(environment, SLURMEnvironment) else signal.SIGUSR1
             assert sigusr is not None
             if sigusr_handlers and not self._has_already_handler(sigusr):
@@ -156,10 +156,6 @@ class _SignalConnector:
         return set(signal.Signals)
 
     @staticmethod
-    def _is_on_windows() -> bool:
-        return sys.platform == "win32"
-
-    @staticmethod
     def _has_already_handler(signum: _SIGNUM) -> bool:
         return signal.getsignal(signum) not in (None, signal.SIG_DFL)
 
@@ -172,3 +168,7 @@ class _SignalConnector:
         state = self.__dict__.copy()
         state["_original_handlers"] = {}
         return state
+
+
+def _get_sigkill_signal() -> _SIGNUM:
+    return signal.SIGTERM if _IS_WINDOWS else signal.SIGKILL

--- a/src/lightning/pytorch/trainer/connectors/signal_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/signal_connector.py
@@ -2,7 +2,6 @@ import logging
 import os
 import re
 import signal
-import sys
 import threading
 from subprocess import call
 from types import FrameType

--- a/tests/tests_pytorch/callbacks/progress/test_rich_progress_bar.py
+++ b/tests/tests_pytorch/callbacks/progress/test_rich_progress_bar.py
@@ -143,7 +143,7 @@ def test_rich_progress_bar_keyboard_interrupt(tmp_path):
 
     with mock.patch(
         "lightning.pytorch.callbacks.progress.rich_progress.Progress.stop", autospec=True
-    ) as mock_progress_stop:
+    ) as mock_progress_stop, pytest.raises(SystemExit):
         progress_bar = RichProgressBar()
         trainer = Trainer(
             default_root_dir=tmp_path,

--- a/tests/tests_pytorch/callbacks/test_lambda_function.py
+++ b/tests/tests_pytorch/callbacks/test_lambda_function.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from functools import partial
 
+import pytest
+
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import Callback, LambdaCallback
 from lightning.pytorch.demos.boring_classes import BoringModel
@@ -23,10 +25,13 @@ from tests_pytorch.models.test_hooks import get_members
 def test_lambda_call(tmp_path):
     seed_everything(42)
 
+    class CustomException(Exception):
+        pass
+
     class CustomModel(BoringModel):
         def on_train_epoch_start(self):
             if self.current_epoch > 1:
-                raise KeyboardInterrupt
+                raise CustomException("Custom exception to trigger `on_exception` hooks")
 
     checker = set()
 
@@ -59,7 +64,8 @@ def test_lambda_call(tmp_path):
         limit_predict_batches=1,
         callbacks=[LambdaCallback(**hooks_args)],
     )
-    trainer.fit(model, ckpt_path=ckpt_path)
+    with pytest.raises(CustomException):
+        trainer.fit(model, ckpt_path=ckpt_path)
     trainer.test(model)
     trainer.predict(model)
 

--- a/tests/tests_pytorch/callbacks/test_lambda_function.py
+++ b/tests/tests_pytorch/callbacks/test_lambda_function.py
@@ -14,7 +14,6 @@
 from functools import partial
 
 import pytest
-
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import Callback, LambdaCallback
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/trainer/test_states.py
+++ b/tests/tests_pytorch/trainer/test_states.py
@@ -84,5 +84,6 @@ def test_interrupt_state_on_keyboard_interrupt(tmp_path, extra_params):
 
     trainer = Trainer(callbacks=[InterruptCallback()], default_root_dir=tmp_path, **extra_params)
 
-    trainer.fit(model)
+    with pytest.raises(SystemExit):
+        trainer.fit(model)
     assert trainer.interrupted

--- a/tests/tests_pytorch/trainer/test_trainer.py
+++ b/tests/tests_pytorch/trainer/test_trainer.py
@@ -28,6 +28,7 @@ import pytest
 import torch
 import torch.nn as nn
 from lightning.fabric.utilities.cloud_io import _load as pl_load
+from lightning.fabric.utilities.imports import _IS_WINDOWS
 from lightning.fabric.utilities.seed import seed_everything
 from lightning.pytorch import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.accelerators import CPUAccelerator, CUDAAccelerator
@@ -1038,7 +1039,7 @@ def test_keyboard_interrupt(tmp_path):
     with pytest.raises(SystemExit) as exc_info:
         trainer.fit(model)
     assert exc_info.value.args[0] == 1
-    trainer.strategy._launcher.kill.assert_called_once_with(9)
+    trainer.strategy._launcher.kill.assert_called_once_with(15 if _IS_WINDOWS else 9)
 
 
 @pytest.mark.parametrize("precision", ["32-true", pytest.param("16-mixed", marks=RunIf(min_cuda_gpus=1))])

--- a/tests/tests_pytorch/trainer/test_trainer.py
+++ b/tests/tests_pytorch/trainer/test_trainer.py
@@ -1007,7 +1007,8 @@ def test_on_exception_hook(tmp_path):
     )
     assert not trainer.interrupted
     assert handle_interrupt_callback.exception is None
-    trainer.fit(model)
+    with pytest.raises(SystemExit):
+        trainer.fit(model)
     assert trainer.interrupted
     assert isinstance(handle_interrupt_callback.exception, KeyboardInterrupt)
     with pytest.raises(MisconfigurationException):
@@ -2042,7 +2043,7 @@ def test_trainer_calls_strategy_on_exception(exception_type, tmp_path):
 
     trainer = Trainer(default_root_dir=tmp_path)
     with mock.patch("lightning.pytorch.strategies.strategy.Strategy.on_exception") as on_exception_mock, suppress(
-        Exception
+        Exception, SystemExit
     ):
         trainer.fit(ExceptionModel())
     on_exception_mock.assert_called_once_with(exception)
@@ -2061,7 +2062,7 @@ def test_trainer_calls_datamodule_on_exception(exception_type, tmp_path):
     datamodule.on_exception = Mock()
     trainer = Trainer(default_root_dir=tmp_path)
 
-    with suppress(Exception):
+    with suppress(Exception, SystemExit):
         trainer.fit(ExceptionModel(), datamodule=datamodule)
     datamodule.on_exception.assert_called_once_with(exception)
 


### PR DESCRIPTION
## What does this PR do?

When the user sends KeyboardInterrupt (Ctrl+C), Lightning runs shutdown logic. However, it does not guarantee that all processes get stopped. Users sometimes get hanging zombie processes. Furthermore, our logic does not play well when the user spams Ctrl+C repeatedly. This PR addresses both concerns. 

Video Demo:
https://www.loom.com/share/a7e105baab5a493b89412434abb7c7fc?sid=1ab5b6b4-f9a1-46a1-888d-726336c5f360


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19976.org.readthedocs.build/en/19976/

<!-- readthedocs-preview pytorch-lightning end -->