### PR TITLE
Updated Fabric trainer example to not call `self.trainer.model` during validation

### DIFF
--- a/examples/fabric/build_your_own_trainer/trainer.py
+++ b/examples/fabric/build_your_own_trainer/trainer.py
@@ -284,7 +284,7 @@ class MyCustomTrainer:
                 "but you passed a validation dataloder. Skipping Validation."
             )
             return
-        
+
         if not is_overridden("on_validation_model_eval", _unwrap_objects(model)):
             model.eval()
         else:

--- a/examples/fabric/build_your_own_trainer/trainer.py
+++ b/examples/fabric/build_your_own_trainer/trainer.py
@@ -157,13 +157,17 @@ class MyCustomTrainer:
         model, optimizer = self.fabric.setup(model, optimizer)
 
         if not is_overridden("on_validation_model_eval", _unwrap_objects(model)):
+
             def ovme(s) -> None:
                 s.eval()
+
             model.on_validation_model_eval = MethodType(ovme, model)
 
         if not is_overridden("on_validation_model_train", _unwrap_objects(model)):
+
             def ovmt(s) -> None:
                 s.train()
+
             model.on_validation_model_train = MethodType(ovmt, model)
 
         # assemble state (current epoch and global step will be added in save)

--- a/examples/fabric/build_your_own_trainer/trainer.py
+++ b/examples/fabric/build_your_own_trainer/trainer.py
@@ -156,6 +156,16 @@ class MyCustomTrainer:
         assert optimizer is not None
         model, optimizer = self.fabric.setup(model, optimizer)
 
+        if not is_overridden("on_validation_model_eval", _unwrap_objects(model)):
+            def ovme(s) -> None:
+                s.eval()
+            model.on_validation_model_eval = MethodType(ovme, model)
+
+        if not is_overridden("on_validation_model_train", _unwrap_objects(model)):
+            def ovmt(s) -> None:
+                s.train()
+            model.on_validation_model_train = MethodType(ovmt, model)
+
         # assemble state (current epoch and global step will be added in save)
         state = {"model": model, "optim": optimizer, "scheduler": scheduler_cfg}
 

--- a/examples/fabric/build_your_own_trainer/trainer.py
+++ b/examples/fabric/build_your_own_trainer/trainer.py
@@ -278,7 +278,7 @@ class MyCustomTrainer:
         val_loader: Optional[torch.utils.data.DataLoader],
         limit_batches: Union[int, float] = float("inf"),
     ):
-        """The validation loop ruunning a single validation epoch.
+        """The validation loop running a single validation epoch.
 
         Args:
             model: the LightningModule to evaluate


### PR DESCRIPTION
Before, using the trainer would result in:

AttributeError: Your LightningModule code tried to access `self.trainer.model` but this attribute is not available when using Fabric with a LightningModule.

Which would occur during validation when 'on_validation_model_eval' and 'on_validation_model_train' were called, as they do not work with fabric. This change allows the model to be switched between train and eval mode (which the original behavior intends) without relying on calling 'self.trainer.model'. A check is added for overridden methods to not change a user's code.

Fixes #19992


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--19993.org.readthedocs.build/en/19993/

<!-- readthedocs-preview pytorch-lightning end -->