### PR TITLE
Update `test_lightning_cli_help` for future change in jsonargparse

### DIFF
--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -466,7 +466,7 @@ def test_lightning_cli_help():
     ), pytest.raises(SystemExit):
         any_model_any_data_cli()
 
-    assert "--data.init_args.data_dir" in out.getvalue()
+    assert ("--data.data_dir" in out.getvalue()) or ("--data.init_args.data_dir" in out.getvalue())
 
 
 def test_lightning_cli_print_config():


### PR DESCRIPTION
## What does this PR do?

In the next release of jsonargparse, the output of `--help.<class> <class-path>` will no longer show the options with a `.init_args` prefix, see https://github.com/omni-us/jsonargparse/pull/533. The short notation that avoided the need to include `.init_args` in the options was implemented long ago. But the help was not updated accordingly to suggest the simpler option.

This pull request updates the `test_lightning_cli_help` which will start failing once the next version of jsonargparse comes out.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20002.org.readthedocs.build/en/20002/

<!-- readthedocs-preview pytorch-lightning end -->