### PR TITLE
Fix torch-numpy compatibility conflict in tests

### DIFF
--- a/requirements/fabric/base.txt
+++ b/requirements/fabric/base.txt
@@ -6,4 +6,4 @@ torch >=2.0.0, <2.4.0
 fsspec[http] >=2022.5.0, <2024.4.0
 packaging >=20.0, <=23.1
 typing-extensions >=4.4.0, <4.10.0
-lightning-utilities >=0.8.0, <0.12.0
+lightning-utilities >=0.10.0, <0.12.0

--- a/requirements/fabric/base.txt
+++ b/requirements/fabric/base.txt
@@ -1,7 +1,7 @@
 # NOTE: the upper bound for the package version is only set for CI stability, and it is dropped while installing this package
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
-numpy >=1.17.2, <1.27.0
+numpy >=1.17.2  #, <1.27.0  FIXME undo
 torch >=2.0.0, <2.4.0
 fsspec[http] >=2022.5.0, <2024.4.0
 packaging >=20.0, <=23.1

--- a/requirements/fabric/base.txt
+++ b/requirements/fabric/base.txt
@@ -1,7 +1,7 @@
 # NOTE: the upper bound for the package version is only set for CI stability, and it is dropped while installing this package
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
-numpy >=1.17.2  #, <1.27.0  FIXME undo
+numpy >=1.17.2, <1.27.0
 torch >=2.0.0, <2.4.0
 fsspec[http] >=2022.5.0, <2024.4.0
 packaging >=20.0, <=23.1

--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -9,4 +9,4 @@ fsspec[http] >=2022.5.0, <2024.4.0
 torchmetrics >=0.7.0, <1.3.0  # needed for using fixed compare_version
 packaging >=20.0, <=23.1
 typing-extensions >=4.4.0, <4.10.0
-lightning-utilities >=0.8.0, <0.12.0
+lightning-utilities >=0.10.0, <0.12.0

--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -1,7 +1,7 @@
 # NOTE: the upper bound for the package version is only set for CI stability, and it is dropped while installing this package
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
-numpy >=1.17.2,  # <1.27.0 FIXME undo
+numpy >=1.17.2, <1.27.0
 torch >=2.0.0, <2.4.0
 tqdm >=4.57.0, <4.67.0
 PyYAML >=5.4, <6.1.0

--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -1,7 +1,7 @@
 # NOTE: the upper bound for the package version is only set for CI stability, and it is dropped while installing this package
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
-numpy >=1.17.2, <1.27.0
+numpy >=1.17.2,  # <1.27.0 FIXME undo
 torch >=2.0.0, <2.4.0
 tqdm >=4.57.0, <4.67.0
 PyYAML >=5.4, <6.1.0

--- a/src/lightning/fabric/utilities/testing/_runif.py
+++ b/src/lightning/fabric/utilities/testing/_runif.py
@@ -17,7 +17,7 @@ import sys
 from typing import Dict, List, Optional, Tuple
 
 import torch
-from lightning_utilities.core.imports import compare_version
+from lightning_utilities.core.imports import compare_version, RequirementCache
 from packaging.version import Version
 
 from lightning.fabric.accelerators import XLAAccelerator
@@ -112,7 +112,7 @@ def _runif_reasons(
             reasons.append("Standalone execution")
         kwargs["standalone"] = True
 
-    if deepspeed and not _DEEPSPEED_AVAILABLE:
+    if deepspeed and not (_DEEPSPEED_AVAILABLE and RequirementCache(module="deepspeed.utils")):
         reasons.append("Deepspeed")
 
     if dynamo:

--- a/tests/tests_fabric/strategies/test_ddp_integration.py
+++ b/tests/tests_fabric/strategies/test_ddp_integration.py
@@ -18,9 +18,8 @@ from unittest.mock import Mock
 
 import pytest
 import torch
-from lightning_utilities.core.imports import RequirementCache
-
 from lightning.fabric import Fabric
+from lightning_utilities.core.imports import RequirementCache
 from torch._dynamo import OptimizedModule
 from torch.nn.parallel.distributed import DistributedDataParallel
 

--- a/tests/tests_fabric/strategies/test_ddp_integration.py
+++ b/tests/tests_fabric/strategies/test_ddp_integration.py
@@ -18,6 +18,8 @@ from unittest.mock import Mock
 
 import pytest
 import torch
+from lightning_utilities.core.imports import RequirementCache
+
 from lightning.fabric import Fabric
 from torch._dynamo import OptimizedModule
 from torch.nn.parallel.distributed import DistributedDataParallel
@@ -27,6 +29,10 @@ from tests_fabric.strategies.test_single_device import _run_test_clip_gradients
 from tests_fabric.test_fabric import BoringModel
 
 
+@pytest.mark.skipif(
+    RequirementCache("torch<2.4") and RequirementCache("numpy>=2.0"),
+    reason="torch.distributed not compatible with numpy>=2.0",
+)
 @pytest.mark.parametrize(
     "accelerator",
     [

--- a/tests/tests_fabric/utilities/test_distributed.py
+++ b/tests/tests_fabric/utilities/test_distributed.py
@@ -6,8 +6,6 @@ from unittest import mock
 
 import pytest
 import torch
-from lightning_utilities.core.imports import RequirementCache
-
 from lightning.fabric.accelerators import CPUAccelerator, CUDAAccelerator, MPSAccelerator
 from lightning.fabric.plugins.environments import LightningEnvironment
 from lightning.fabric.strategies import DDPStrategy, SingleDeviceStrategy
@@ -22,6 +20,7 @@ from lightning.fabric.utilities.distributed import (
     _sync_ddp,
     is_shared_filesystem,
 )
+from lightning_utilities.core.imports import RequirementCache
 
 from tests_fabric.helpers.runif import RunIf
 

--- a/tests/tests_fabric/utilities/test_distributed.py
+++ b/tests/tests_fabric/utilities/test_distributed.py
@@ -6,6 +6,8 @@ from unittest import mock
 
 import pytest
 import torch
+from lightning_utilities.core.imports import RequirementCache
+
 from lightning.fabric.accelerators import CPUAccelerator, CUDAAccelerator, MPSAccelerator
 from lightning.fabric.plugins.environments import LightningEnvironment
 from lightning.fabric.strategies import DDPStrategy, SingleDeviceStrategy
@@ -121,6 +123,10 @@ def test_collective_operations(devices, process):
     spawn_launch(process, devices)
 
 
+@pytest.mark.skipif(
+    RequirementCache("torch<2.4") and RequirementCache("numpy>=2.0"),
+    reason="torch.distributed not compatible with numpy>=2.0",
+)
 @pytest.mark.flaky(reruns=3)  # flaky with "process 0 terminated with signal SIGABRT" (GLOO)
 def test_is_shared_filesystem(tmp_path, monkeypatch):
     # In the non-distributed case, every location is interpreted as 'shared'


### PR DESCRIPTION
## What does this PR do?

PyTorch distributed (an potentially other modules) are not yet compatible with NumPy > 2.0. This PR skips tests that run with incompatible versions. Note, this will only affect tests run on master where numpy is unpinned.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20004.org.readthedocs.build/en/20004/

<!-- readthedocs-preview pytorch-lightning end -->

cc @carmocca @justusschock @awaelchli @borda