### PR TITLE
Convert tensors to bytes instead of numpy in multiprocessing result-queue

### DIFF
--- a/.github/workflows/ci-tests-pytorch.yml
+++ b/.github/workflows/ci-tests-pytorch.yml
@@ -193,6 +193,9 @@ jobs:
         # needs to run outside `pytest`
         run: python utilities/test_warnings.py
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Testing PyTorch
         working-directory: tests/tests_pytorch
         # NOTE: do not include coverage report here, see: https://github.com/nedbat/coveragepy/issues/1003

--- a/.github/workflows/ci-tests-pytorch.yml
+++ b/.github/workflows/ci-tests-pytorch.yml
@@ -193,9 +193,6 @@ jobs:
         # needs to run outside `pytest`
         run: python utilities/test_warnings.py
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Testing PyTorch
         working-directory: tests/tests_pytorch
         # NOTE: do not include coverage report here, see: https://github.com/nedbat/coveragepy/issues/1003

--- a/src/lightning/pytorch/strategies/launchers/multiprocessing.py
+++ b/src/lightning/pytorch/strategies/launchers/multiprocessing.py
@@ -236,7 +236,6 @@ class _MultiProcessingLauncher(_Launcher):
             process this output.
 
         """
-
         def tensor_to_bytes(tensor: Tensor) -> bytes:
             buffer = io.BytesIO()
             torch.save(tensor.cpu(), buffer)
@@ -256,13 +255,12 @@ class _MultiProcessingLauncher(_Launcher):
                 on the current trainer.
 
         """
-
         def bytes_to_tensor(tensor_bytes: bytes) -> Tensor:
             return torch.load(io.BytesIO(tensor_bytes))
 
         # NOTE: `get_extra_results` needs to be called before
         callback_metrics = extra["callback_metrics"]
-        trainer.callback_metrics.update(apply_to_collection(callback_metrics, bytes, bytes_to_tensor)
+        trainer.callback_metrics.update(apply_to_collection(callback_metrics, bytes, bytes_to_tensor))
 
     @override
     def kill(self, signum: _SIGNUM) -> None:

--- a/src/lightning/pytorch/strategies/launchers/multiprocessing.py
+++ b/src/lightning/pytorch/strategies/launchers/multiprocessing.py
@@ -236,6 +236,7 @@ class _MultiProcessingLauncher(_Launcher):
             process this output.
 
         """
+
         def tensor_to_bytes(tensor: Tensor) -> bytes:
             buffer = io.BytesIO()
             torch.save(tensor.cpu(), buffer)
@@ -255,6 +256,7 @@ class _MultiProcessingLauncher(_Launcher):
                 on the current trainer.
 
         """
+
         def bytes_to_tensor(tensor_bytes: bytes) -> Tensor:
             return torch.load(io.BytesIO(tensor_bytes))
 


### PR DESCRIPTION
## What does this PR do?

Fixes #19945
Part of #16649

An alternative implementation to sending tensors from the worker rank 0 to the main process. Using tensors directly is not possible, otherwise we run into a memory sharing issue from multiprocessing:

```
Traceback (most recent call last):
  File "/Users/adrian/repositories/lightning/queuet.py", line 20, in <module>
    main()
  File "/Users/adrian/repositories/lightning/queuet.py", line 9, in main
    result = return_queue.get()
             ^^^^^^^^^^^^^^^^^^
  File "/Users/adrian/miniconda3/envs/lightning/lib/python3.11/multiprocessing/queues.py", line 122, in get
    return _ForkingPickler.loads(res)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/adrian/miniconda3/envs/lightning/lib/python3.11/site-packages/torch/multiprocessing/reductions.py", line 514, in rebuild_storage_filename
    storage = torch.UntypedStorage._new_shared_filename_cpu(manager, handle, size)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: No such file or directory
```

which is why the current code converts tensors to numpy arrays. However, as suggested in #16649, we would like to avoid a dependency on numpy if not necessary. This PR converts the tensors to bytes instead of numpy arrays for transferring them.


We have tests that assert the current functionality:
https://github.com/Lightning-AI/pytorch-lightning/blob/e330da5870fae34339170b942095a2600fa7a95e/tests/tests_pytorch/strategies/test_ddp_integration.py#L259
https://github.com/Lightning-AI/pytorch-lightning/blob/e330da5870fae34339170b942095a2600fa7a95e/tests/tests_pytorch/strategies/launchers/test_multiprocessing.py#L92

cc @justusschock @awaelchli