### PR TITLE
Fix dependency issues with omegaconf and hydra

### DIFF
--- a/requirements/pytorch/extra.txt
+++ b/requirements/pytorch/extra.txt
@@ -3,8 +3,8 @@
 
 # extended list of package dependencies to reach full functionality
 matplotlib>3.1, <3.9.0
-omegaconf >=2.0.5, <2.4.0
-hydra-core >=1.0.5, <1.4.0
+omegaconf >=2.2.3, <2.4.0
+hydra-core >=1.2.0, <1.4.0
 jsonargparse[signatures] >=4.27.7, <4.28.0
 rich >=12.3.0, <13.6.0
 tensorboardX >=2.2, <2.7.0  # min version is set by torch.onnx missing attribute


### PR DESCRIPTION
## What does this PR do?

It's unclear what has triggered these issues to show up suddenly.

See for example: https://github.com/Lightning-AI/pytorch-lightning/actions/runs/9700837393/job/26773176862
```
...
Collecting bitsandbytes<1.0,==0.42.0 (from lightning==2.4.0.dev0)
  Downloading bitsandbytes-0.42.0-py3-none-any.whl.metadata (9.9 kB)
Collecting hydra-core<2.0,==1.0.5 (from lightning==2.4.0.dev0)
  Downloading hydra_core-1.0.5-py3-none-any.whl.metadata (3.7 kB)
Requirement already satisfied: jsonargparse<5.0,==4.27.7 in /opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages (from jsonargparse[signatures]<5.0,==4.27.7; extra == "pytorch-extra"->lightning==2.4.0.dev0) (4.27.7)
Collecting matplotlib<4.0,>3.1 (from lightning==2.4.0.dev0)
  Downloading matplotlib-3.7.5-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl.metadata (5.7 kB)
Collecting omegaconf<3.0,==2.0.5 (from lightning==2.4.0.dev0)
  Downloading omegaconf-2.0.5-py3-none-any.whl.metadata (3.0 kB)
WARNING: Ignoring version 2.0.5 of omegaconf since it has invalid metadata:
Requested omegaconf<3.0,==2.0.5 from https://files.pythonhosted.org/packages/e5/f6/043b6d255dd6fbf2025110cea35b87f4c5100a181681d8eab4[96](https://github.com/Lightning-AI/pytorch-lightning/actions/runs/9700837393/job/26773176862#step:10:97)269f0d5b/omegaconf-2.0.5-py3-none-any.whl (from lightning==2.4.0.dev0) has invalid metadata: .* suffix can only be used with `==` or `!=` operators
    PyYAML (>=5.1.*)
INFO: pip is looking at multiple versions of lightning[pytorch-extra,pytorch-strategies,pytorch-test] to determine which version is compatible with other requirements. This could take a while.
            ~~~~~~^
Please use pip<24.1 if you need to use this version.
ERROR: Ignored the following yanked versions: 1.0.0, 1.0.1, 1.0.2, 2.0.0rc1, 2.0.0rc2, 2.0.0rc22, 2.0.0rc23, 2.0.0rc24, 2.0.0rc25, 2.0.0rc26, 2.0.0rc27, 2.0.0rc28, 2.0.0rc29, 2.0.1rc1, 2.0.1rc2, 2.0.1rc3, 2.0.1rc4, 2.0.1rc5, 2.2.0
ERROR: Ignored the following versions that require a different python version: 1.25.0 Requires-Python >=3.9; 1.25.0rc1 Requires-Python >=3.9; 1.25.1 Requires-Python >=3.9; 1.25.2 Requires-Python >=3.9; 1.26.0 Requires-Python <3.13,>=3.9; 1.26.0b1 Requires-Python <3.13,>=3.9; 1.26.0rc1 Requires-Python <3.13,>=3.9; 1.26.1 Requires-Python <3.13,>=3.9; 1.26.2 Requires-Python >=3.9; 1.26.3 Requires-Python >=3.9; 1.26.4 Requires-Python >=3.9; 2.0.0 Requires-Python >=3.9; 2.0.0b1 Requires-Python >=3.9; 2.0.0rc1 Requires-Python >=3.9; 2.0.0rc2 Requires-Python >=3.9; 3.2 Requires-Python >=3.9; 3.2.1 Requires-Python >=3.9; 3.2rc0 Requires-Python >=3.9; 3.3 Requires-Python >=3.10; 3.3rc0 Requires-Python >=3.10; 3.8.0 Requires-Python >=3.9; 3.8.0rc1 Requires-Python >=3.9; 3.8.1 Requires-Python >=3.9; 3.8.2 Requires-Python >=3.9; 3.8.3 Requires-Python >=3.9; 3.8.4 Requires-Python >=3.9; 3.9.0 Requires-Python >=3.9; 3.9.0rc2 Requires-Python >=3.9
ERROR: Could not find a version that satisfies the requirement omegaconf<3.0,==2.0.5; extra == "pytorch-extra" (from lightning[pytorch-extra,pytorch-strategies,pytorch-test]) (from versions: 1.0.3, 1.0.4, 1.0.5, 1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.10, 1.0.11, 1.0.12, 1.0.13, 1.0.14, 1.0.16, 1.0.17, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.1.5, 1.1.6, 1.1.7, 1.1.8, 1.1.9, 1.1.10, 1.2.0, 1.2.1, 1.3.0rc1, 1.3.0rc2, 1.3.0rc3, 1.3.0rc4, 1.3.0rc5, 1.3.0rc6, 1.3.0rc7, 1.3.0rc8, 1.3.0rc9, 1.3.0rc10, 1.3.0, 1.4.0rc1, 1.4.0rc2, 1.4.0rc3, 1.4.0rc4, 1.4.0, 1.4.1rc1, 1.4.1, 2.0.0rc3, 2.0.0rc4, 2.0.0rc5, 2.0.0rc6, 2.0.0rc7, 2.0.0rc8, 2.0.0rc9, 2.0.0rc10, 2.0.0rc11, 2.0.0rc12, 2.0.0rc13, 2.0.0rc14, 2.0.0rc15, 2.0.0rc16, 2.0.0rc17, 2.0.0rc18, 2.0.0rc19, 2.0.0rc20, 2.0.0rc21, 2.0.0, 2.0.1rc6, 2.0.1rc7, 2.0.1rc8, 2.0.1rc9, 2.0.1rc10, 2.0.1rc11, 2.0.1rc12, 2.0.1rc13, 2.0.1, 2.0.2rc1, 2.0.2rc2, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.1.0.dev1, 2.1.0.dev2, 2.1.0.dev3, 2.1.0.dev4, 2.1.0.dev5, 2.1.0.dev6, 2.1.0.dev7, 2.1.0.dev8, 2.1.0.dev9, 2.1.0.dev10, 2.1.0.dev11, 2.1.0.dev12, 2.1.0.dev13, 2.1.0.dev14, 2.1.0.dev15, 2.1.0.dev16, 2.1.0.dev17, 2.1.0.dev18, 2.1.0.dev19, 2.1.0.dev20, 2.1.0.dev21, 2.1.0.dev22, 2.1.0.dev23, 2.1.0.dev24, 2.1.0.dev25, 2.1.0.dev26, 2.1.0.dev27, 2.1.0rc1, 2.1.0, 2.1.1, 2.1.2, 2.2.0.dev1, 2.2.0.dev2, 2.2.0.dev3, 2.2.0.dev4, 2.2.0.dev5, 2.2.1, 2.2.2, 2.2.3, 2.3.0.dev0, 2.3.0.dev1, 2.3.0.dev2, 2.3.0, 2.4.0.dev0, 2.4.0.dev1, 2.4.0.dev2, 2.4.0.dev3)
ERROR: No matching distribution found for omegaconf<3.0,==2.0.5; extra == "pytorch-extra"

Notice:  A new release of pip is available: 24.1 -> 24.1.1
Notice:  To update, run: pip install --upgrade pip
```


cc @carmocca @borda