### PR TITLE
docs: Bump HPU ref `1.6.0`

### DIFF
--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -91,7 +91,7 @@ _transform_changelog(
 assist_local.AssistantCLI.pull_docs_files(
     gh_user_repo="Lightning-AI/lightning-Habana",
     target_dir="docs/source-pytorch/integrations/hpu",
-    checkout="refs/tags/1.4.0",
+    checkout="1.6.0",
 )
 
 # Copy strategies docs as single pages

--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -95,7 +95,7 @@ assist_local.AssistantCLI.pull_docs_files(
     checkout="refs/tags/1.6.0",
 )
 # the HPU also need some images
-URL_RAW_DOCS_GRAPHCORE = "https://raw.githubusercontent.com/Lightning-AI/lightning-Habana/1.5.0/docs/source"
+URL_RAW_DOCS_HABANA = "https://raw.githubusercontent.com/Lightning-AI/lightning-Habana/1.5.0/docs/source"
 for img in ["_images/HPUProfiler.png", "_images/IGP.png"]:
     img_ = os.path.join(_PATH_HERE, "integrations", "hpu", img)
     os.makedirs(os.path.dirname(img_), exist_ok=True)

--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -99,7 +99,7 @@ URL_RAW_DOCS_HABANA = "https://raw.githubusercontent.com/Lightning-AI/lightning-
 for img in ["_images/HPUProfiler.png", "_images/IGP.png"]:
     img_ = os.path.join(_PATH_HERE, "integrations", "hpu", img)
     os.makedirs(os.path.dirname(img_), exist_ok=True)
-    urllib.request.urlretrieve(f"{URL_RAW_DOCS_GRAPHCORE}/{img}", img_)
+    urllib.request.urlretrieve(f"{URL_RAW_DOCS_HABANA}/{img}", img_)
 
 # Copy strategies docs as single pages
 assist_local.AssistantCLI.pull_docs_files(


### PR DESCRIPTION
**This is automated update with the latest HPU
  [release](https://github.com/Lightning-AI/lightning-habana/releases/tag/1.6.0)!**

Go to `docs/source-pytorch/conf.py` and find section `assist_local.AssistantCLI.pull_docs_files(...` for Habana and bump the reference to `1.6.0`
Please, proceed with this update in timely manner...

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20026.org.readthedocs.build/en/20026/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda