### PR TITLE
Update DeepSpeedOptimizer import for deepspeed >= 0.14.1

### DIFF
--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
 _DEEPSPEED_AVAILABLE = RequirementCache("deepspeed")
 _DEEPSPEED_GREATER_EQUAL_0_14_1 = RequirementCache("deepspeed>=0.14.1")
 
+
 # TODO(fabric): Links in the docstrings to PL-specific deepspeed user docs need to be replaced.
 class DeepSpeedStrategy(DDPStrategy, _Sharded):
     DEEPSPEED_ENV_VAR = "PL_DEEPSPEED_CONFIG_PATH"

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from deepspeed import DeepSpeedEngine
 
 _DEEPSPEED_AVAILABLE = RequirementCache("deepspeed")
-
+_DEEPSPEED_GREATER_EQUAL_0_14_1 = RequirementCache("deepspeed>=0.14.1")
 
 # TODO(fabric): Links in the docstrings to PL-specific deepspeed user docs need to be replaced.
 class DeepSpeedStrategy(DDPStrategy, _Sharded):
@@ -498,7 +498,10 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
             )
         engine = engines[0]
 
-        from deepspeed.runtime.base_optimizer import DeepSpeedOptimizer
+        if _DEEPSPEED_GREATER_EQUAL_0_14_1:
+            from deepspeed.runtime.base_optimizer import DeepSpeedOptimizer
+        else:
+            from deepspeed.runtime import DeepSpeedOptimizer
 
         optimzer_state_requested = any(isinstance(item, (Optimizer, DeepSpeedOptimizer)) for item in state.values())
 

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -498,7 +498,7 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
             )
         engine = engines[0]
 
-        from deepspeed.runtime import DeepSpeedOptimizer
+        from deepspeed.runtime.base_optimizer import DeepSpeedOptimizer
 
         optimzer_state_requested = any(isinstance(item, (Optimizer, DeepSpeedOptimizer)) for item in state.values())
 


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fix DeepSpeedOptimizer import error 

DeepSpeed team remove DeepSpeedOptimizer from the \_\_init\_\_.py 

https://github.com/microsoft/DeepSpeed/commit/c56a4b9e0db340dcb0f7e14495699ca5c90dd976

```
[rank1]: Traceback (most recent call last):
[rank1]:   File "/data/projects/livdet2025/train.py", line 140, in <module>
[rank1]:     main()
[rank1]:   File "/data/projects/livdet2025/train.py", line 134, in main
[rank1]:     train_helper.load_state(checkpoint, model, optimizer, lr_scheduler)
[rank1]:   File "/data/projects/livdet2025/utils.py", line 253, in load_state
[rank1]:     }
[rank1]:   File "/data/.pyenv/versions/livdet/lib/python3.10/site-packages/lightning/fabric/fabric.py", line 775, in load
[rank1]:     remainder = self._strategy.load_checkpoint(path=path, state=unwrapped_state, strict=strict)
[rank1]:   File "/data/.pyenv/versions/livdet/lib/python3.10/site-packages/lightning/fabric/strategies/deepspeed.py", line 501, in load_checkpoint
[rank1]:     from deepspeed.runtime import DeepSpeedOptimizer
[rank1]: ImportError: cannot import name 'DeepSpeedOptimizer' from 'deepspeed.runtime' (/data/.pyenv/versions/livdet/lib/python3.10/site-packages/deepspeed/runtime/__init__.py)
```

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20040.org.readthedocs.build/en/20040/

<!-- readthedocs-preview pytorch-lightning end -->