### PR TITLE
CI: Remove waiting logic in release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yaml
@@ -98,7 +98,6 @@ body:
         #- CUDA/cuDNN version:
         #- GPU models and configuration:
         #- How you installed Lightning(`conda`, `pip`, source):
-        #- Running environment of LightningApp (e.g. local, cloud):
         ```
 
         </details>

--- a/.github/workflows/release-pkg.yml
+++ b/.github/workflows/release-pkg.yml
@@ -130,34 +130,6 @@ jobs:
             ethanwharris
             borda
 
-  waiting:
-    runs-on: ubuntu-22.04
-    needs: [release-version, signaling]
-    env:
-      TAG: ${{ needs.release-version.outputs.tag }}
-    # due to PR process this may take longer
-    timeout-minutes: 180
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VER }}
-      - run: pip install gitpython
-      - name: Delay releasing
-        run: |
-          import git, os, time
-          repo = git.Repo('.')
-          branch = f"origin/builds/{os.getenv('TAG')}"
-          while True:
-            remote_refs = [b.name for b in repo.remote().refs]
-            print([n for n in remote_refs if "builds" in n])
-            if branch in remote_refs:
-              break
-            time.sleep(60)
-            for remote in repo.remotes:
-              remote.fetch()
-        shell: python
-
   pre-publish-packages:
     runs-on: ubuntu-22.04
     needs: build-packages
@@ -185,7 +157,7 @@ jobs:
 
   publish-packages:
     runs-on: ubuntu-22.04
-    needs: [build-packages, waiting]
+    needs: [build-packages]
     if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
     strategy:
       fail-fast: false

--- a/requirements/store/test.txt
+++ b/requirements/store/test.txt
@@ -1,6 +1,0 @@
-coverage ==7.3.1
-pytest ==7.4.0
-pytest-cov ==4.1.0
-pytest-timeout ==2.1.0
-pytest-rerunfailures ==12.0
-pytest-random-order ==1.1.0


### PR DESCRIPTION
## What does this PR do?

So far, the release process had a mechanism to wait for a builds/version branch to appear while waiting on the merging of an internal repo. But this was a deadlock for a long time, and now that this internal repo no longer depends on the lightning package, we should remove the waiting logic from the package release workflow.  


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20050.org.readthedocs.build/en/20050/

<!-- readthedocs-preview pytorch-lightning end -->