### PR TITLE
Set `weights_only` in tests to avoid warnings in PyTorch 2.4

### DIFF
--- a/tests/tests_fabric/strategies/test_deepspeed_integration.py
+++ b/tests/tests_fabric/strategies/test_deepspeed_integration.py
@@ -312,11 +312,11 @@ def _assert_saved_model_is_equal(fabric, model, checkpoint_path):
             single_ckpt_path = checkpoint_path / "single_model.pt"
             # the tag is hardcoded in DeepSpeedStrategy
             convert_zero_checkpoint_to_fp32_state_dict(checkpoint_path, single_ckpt_path, tag="checkpoint")
-            state_dict = torch.load(single_ckpt_path)
+            state_dict = torch.load(single_ckpt_path, weights_only=False)
         else:
             # 'checkpoint' is the tag, hardcoded in DeepSpeedStrategy
             single_ckpt_path = checkpoint_path / "checkpoint" / "mp_rank_00_model_states.pt"
-            state_dict = torch.load(single_ckpt_path)["module"]
+            state_dict = torch.load(single_ckpt_path, weights_only=False)["module"]
 
         model = model.cpu()
 

--- a/tests/tests_fabric/strategies/test_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_fsdp_integration.py
@@ -191,7 +191,7 @@ def test_save_full_state_dict(tmp_path):
     state = {"model": trainer.model, "optimizer": trainer.optimizer, "steps": 1}
     fabric.save(checkpoint_path, state)
 
-    checkpoint = torch.load(checkpoint_path)
+    checkpoint = torch.load(checkpoint_path, weights_only=True)
     assert checkpoint["steps"] == 1
     loaded_state_dict = checkpoint["model"]
 
@@ -248,7 +248,7 @@ def test_save_full_state_dict(tmp_path):
     # get optimizer state after loading
     normal_checkpoint_path = Path(fabric.broadcast(str(tmp_path / "normal-checkpoint.pt")))
     fabric.save(normal_checkpoint_path, {"model": trainer.model, "optimizer": trainer.optimizer, "steps": 2})
-    optimizer_state_after = torch.load(normal_checkpoint_path)["optimizer"]
+    optimizer_state_after = torch.load(normal_checkpoint_path, weights_only=True)["optimizer"]
     optimizer_state_after = FullyShardedDataParallel.rekey_optim_state_dict(
         optimizer_state_after, optim_state_key_type=OptimStateKeyType.PARAM_NAME, model=trainer.model
     )
@@ -330,7 +330,7 @@ def test_load_full_state_dict_into_sharded_model(tmp_path):
     # Create a raw state-dict checkpoint to test `Fabric.load_raw` too
     raw_checkpoint_path = checkpoint_path.with_name("model-state-dict")
     if fabric.global_rank == 0:
-        checkpoint = torch.load(checkpoint_path)
+        checkpoint = torch.load(checkpoint_path, weights_only=True)
         torch.save(checkpoint["model"], raw_checkpoint_path)
     fabric.barrier()
 
@@ -485,7 +485,7 @@ def test_save_filter(tmp_path):
 
     checkpoint_path = tmp_path / "full.pth"
     fabric.save(checkpoint_path, state, filter=filter)
-    checkpoint = torch.load(checkpoint_path)["model"]
+    checkpoint = torch.load(checkpoint_path, weights_only=True)["model"]
     assert set(checkpoint) == {"bias"}
     assert type(checkpoint["bias"]) is torch.Tensor
 

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -321,7 +321,7 @@ def test_save_full_state_dict(tmp_path):
     state = {"model": model, "optimizer": optimizer, "steps": 1}
     fabric.save(checkpoint_path, state)
 
-    checkpoint = torch.load(checkpoint_path)
+    checkpoint = torch.load(checkpoint_path, weights_only=True)
     assert checkpoint["steps"] == 1
     loaded_state_dict = checkpoint["model"]
 
@@ -369,7 +369,7 @@ def test_save_full_state_dict(tmp_path):
     normal_checkpoint_path = Path(fabric.broadcast(str(tmp_path / "normal-checkpoint.pt")))
     fabric.save(normal_checkpoint_path, {"model": model, "optimizer": optimizer, "steps": 2})
 
-    optimizer_state_after = torch.load(normal_checkpoint_path)["optimizer"]
+    optimizer_state_after = torch.load(normal_checkpoint_path, weights_only=True)["optimizer"]
     assert set(optimizer_state_after.keys()) == set(optimizer_state_before.keys()) == {"state", "param_groups"}
     assert torch.equal(
         optimizer_state_after["state"][0]["exp_avg"],
@@ -433,7 +433,7 @@ def test_load_full_state_dict_into_sharded_model(tmp_path):
     # Create a raw state-dict checkpoint to test `Fabric.load_raw` too
     raw_checkpoint_path = checkpoint_path.with_name("model-state-dict")
     if fabric.global_rank == 0:
-        checkpoint = torch.load(checkpoint_path)
+        checkpoint = torch.load(checkpoint_path, weights_only=True)
         torch.save(checkpoint["model"], raw_checkpoint_path)
     fabric.barrier()
 
@@ -519,7 +519,7 @@ def test_save_filter(tmp_path):
 
     checkpoint_path = tmp_path / "full.pth"
     fabric.save(checkpoint_path, state, filter=filter)
-    checkpoint = torch.load(checkpoint_path)["model"]
+    checkpoint = torch.load(checkpoint_path, weights_only=True)["model"]
     assert set(checkpoint) == {"w1.bias", "w2.bias", "w3.bias"}
     assert type(checkpoint["w1.bias"]) is torch.Tensor
 

--- a/tests/tests_pytorch/accelerators/test_xla.py
+++ b/tests/tests_pytorch/accelerators/test_xla.py
@@ -67,7 +67,7 @@ def test_resume_training_on_cpu(tmp_path):
     model_path = trainer.checkpoint_callback.best_model_path
 
     # Verify saved Tensors are on CPU
-    ckpt = torch.load(model_path)
+    ckpt = torch.load(model_path, weights_only=True)
     weight_tensor = list(ckpt["state_dict"].values())[0]
     assert weight_tensor.device == torch.device("cpu")
 

--- a/tests/tests_pytorch/callbacks/test_pruning.py
+++ b/tests/tests_pytorch/callbacks/test_pruning.py
@@ -273,7 +273,7 @@ def test_multiple_pruning_callbacks(tmp_path, caplog, make_pruning_permanent: bo
     filepath = str(tmp_path / "foo.ckpt")
     trainer.save_checkpoint(filepath)
 
-    model.load_state_dict(torch.load(filepath), strict=False)
+    model.load_state_dict(torch.load(filepath, weights_only=True), strict=False)
     has_pruning = hasattr(model.layer.mlp_1, "weight_orig")
     assert not has_pruning if make_pruning_permanent else has_pruning
 

--- a/tests/tests_pytorch/checkpointing/test_legacy_checkpoints.py
+++ b/tests/tests_pytorch/checkpointing/test_legacy_checkpoints.py
@@ -78,7 +78,7 @@ def test_legacy_ckpt_threading(pl_version: str):
         from lightning.pytorch.utilities.migration import pl_legacy_patch
 
         with pl_legacy_patch():
-            _ = torch.load(path_ckpt)
+            _ = torch.load(path_ckpt, weights_only=False)
 
     with patch("sys.path", [PATH_LEGACY] + sys.path):
         t1 = ThreadExceptionHandler(target=load_model)

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -17,6 +17,7 @@ import pickle
 import re
 import time
 from argparse import Namespace
+from contextlib import nullcontext
 from datetime import timedelta
 from inspect import signature
 from pathlib import Path
@@ -31,6 +32,7 @@ import torch
 import yaml
 from jsonargparse import ArgumentParser
 from lightning.fabric.utilities.cloud_io import _load as pl_load
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.demos.boring_classes import BoringModel
@@ -350,11 +352,13 @@ def test_pickling(tmp_path):
     ckpt = ModelCheckpoint(dirpath=tmp_path)
 
     ckpt_pickled = pickle.dumps(ckpt)
-    ckpt_loaded = pickle.loads(ckpt_pickled)
+    with pytest.warns(FutureWarning, match="`weights_only=False`") if _TORCH_GREATER_EQUAL_2_4 else nullcontext():
+        ckpt_loaded = pickle.loads(ckpt_pickled)
     assert vars(ckpt) == vars(ckpt_loaded)
 
     ckpt_pickled = cloudpickle.dumps(ckpt)
-    ckpt_loaded = cloudpickle.loads(ckpt_pickled)
+    with pytest.warns(FutureWarning, match="`weights_only=False`") if _TORCH_GREATER_EQUAL_2_4 else nullcontext():
+        ckpt_loaded = cloudpickle.loads(ckpt_pickled)
     assert vars(ckpt) == vars(ckpt_loaded)
 
 
@@ -920,8 +924,8 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmp_path):
     assert os.path.isfile(path_last_epoch)
     assert os.path.isfile(path_last)
 
-    ckpt_last_epoch = torch.load(path_last_epoch)
-    ckpt_last = torch.load(path_last)
+    ckpt_last_epoch = torch.load(path_last_epoch, weights_only=True)
+    ckpt_last = torch.load(path_last, weights_only=True)
 
     assert ckpt_last_epoch["epoch"] == ckpt_last["epoch"]
     assert ckpt_last_epoch["global_step"] == ckpt_last["global_step"]
@@ -1168,7 +1172,7 @@ def test_current_score(tmp_path):
     )
     trainer.fit(TestModel())
     assert model_checkpoint.current_score == 0.3
-    ckpts = [torch.load(ckpt) for ckpt in tmp_path.iterdir()]
+    ckpts = [torch.load(ckpt, weights_only=True) for ckpt in tmp_path.iterdir()]
     ckpts = [
         ckpt["callbacks"][
             "ModelCheckpoint{'monitor': 'foo', 'mode': 'min', 'every_n_train_steps': 0, 'every_n_epochs': 1,"
@@ -1452,7 +1456,7 @@ def test_save_last_saves_correct_last_model_path(tmp_path):
     expected = "foo=1-last.ckpt"
     assert os.listdir(tmp_path) == [expected]
     full_path = tmp_path / expected
-    ckpt = torch.load(full_path)
+    ckpt = torch.load(full_path, weights_only=True)
     assert ckpt["callbacks"][mc.state_key]["last_model_path"] == str(full_path)
 
 
@@ -1484,7 +1488,7 @@ def test_none_monitor_saves_correct_best_model_path(tmp_path):
     expected = "epoch=0-step=0.ckpt"
     assert os.listdir(tmp_path) == [expected]
     full_path = str(tmp_path / expected)
-    ckpt = torch.load(full_path)
+    ckpt = torch.load(full_path, weights_only=True)
     assert ckpt["callbacks"][mc.state_key]["best_model_path"] == full_path
 
 

--- a/tests/tests_pytorch/checkpointing/test_torch_saving.py
+++ b/tests/tests_pytorch/checkpointing/test_torch_saving.py
@@ -30,7 +30,7 @@ def test_model_torch_save(tmp_path):
     # Ensure these do not fail
     torch.save(trainer.model, temp_path)
     torch.save(trainer, temp_path)
-    trainer = torch.load(temp_path)
+    trainer = torch.load(temp_path, weights_only=False)
 
 
 @RunIf(skip_windows=True)

--- a/tests/tests_pytorch/core/test_datamodules.py
+++ b/tests/tests_pytorch/core/test_datamodules.py
@@ -208,7 +208,7 @@ def test_dm_checkpoint_save_and_load(tmp_path):
     # fit model
     trainer.fit(model, datamodule=dm)
     checkpoint_path = list(trainer.checkpoint_callback.best_k_models.keys())[0]
-    checkpoint = torch.load(checkpoint_path)
+    checkpoint = torch.load(checkpoint_path, weights_only=True)
     assert dm.__class__.__qualname__ in checkpoint
     assert checkpoint[dm.__class__.__qualname__] == {"my": "state_dict"}
 

--- a/tests/tests_pytorch/core/test_metric_result_integration.py
+++ b/tests/tests_pytorch/core/test_metric_result_integration.py
@@ -19,6 +19,7 @@ from unittest import mock
 import lightning.pytorch as pl
 import pytest
 import torch
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4
 from lightning.fabric.utilities.warnings import PossibleUserWarning
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import OnExceptionCheckpoint
@@ -253,11 +254,12 @@ def test_result_collection_restoration(tmp_path):
         }
 
         # make sure can be pickled
-        pickle.loads(pickle.dumps(result))
+        with pytest.warns(FutureWarning, match="`weights_only=False`") if _TORCH_GREATER_EQUAL_2_4 else nullcontext():
+            pickle.loads(pickle.dumps(result))
         # make sure can be torch.loaded
         filepath = str(tmp_path / "result")
         torch.save(result, filepath)
-        torch.load(filepath)
+        torch.load(filepath, weights_only=False)
 
         # assert metric state reset to default values
         result.reset()

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -39,7 +39,7 @@ def test_load_from_checkpoint_map_location_automatic(accelerator, tmp_path, monk
     create_boring_checkpoint(tmp_path, BoringModel(), accelerator=accelerator)
 
     # The checkpoint contains tensors with storage tag on the accelerator
-    checkpoint = torch.load(f"{tmp_path}/checkpoint.ckpt")
+    checkpoint = torch.load(f"{tmp_path}/checkpoint.ckpt", weights_only=True)
     assert checkpoint["state_dict"]["layer.weight"].device.type.startswith(accelerator)
 
     # Pretend that the accelerator is not available
@@ -113,7 +113,7 @@ def test_load_from_checkpoint_warn_on_empty_state_dict(tmp_path):
     """Test that checkpoints can be loaded with an empty state dict and that the appropriate warning is raised."""
     create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cpu")
     # Now edit so the state_dict is empty
-    checkpoint = torch.load(tmp_path / "checkpoint.ckpt")
+    checkpoint = torch.load(tmp_path / "checkpoint.ckpt", weights_only=True)
     checkpoint["state_dict"] = {}
     torch.save(checkpoint, tmp_path / "checkpoint.ckpt")
 

--- a/tests/tests_pytorch/helpers/datasets.py
+++ b/tests/tests_pytorch/helpers/datasets.py
@@ -106,7 +106,7 @@ class MNIST(Dataset):
         assert os.path.isfile(path_data), f"missing file: {path_data}"
         for _ in range(trials):
             try:
-                res = torch.load(path_data)
+                res = torch.load(path_data, weights_only=True)
             # todo: specify the possible exception
             except Exception as ex:
                 exception = ex

--- a/tests/tests_pytorch/helpers/test_datasets.py
+++ b/tests/tests_pytorch/helpers/test_datasets.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pickle
+from contextlib import nullcontext
 
 import cloudpickle
 import pytest
 import torch
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4
 
 from tests_pytorch import _PATH_DATASETS
 from tests_pytorch.helpers.datasets import MNIST, AverageDataset, TrialMNIST
@@ -42,9 +44,9 @@ def test_pickling_dataset_mnist(dataset_cls, args):
     mnist = dataset_cls(**args)
 
     mnist_pickled = pickle.dumps(mnist)
-    pickle.loads(mnist_pickled)
-    # assert vars(mnist) == vars(mnist_loaded)
+    with pytest.warns(FutureWarning, match="`weights_only=False`") if _TORCH_GREATER_EQUAL_2_4 else nullcontext():
+        pickle.loads(mnist_pickled)
 
     mnist_pickled = cloudpickle.dumps(mnist)
-    cloudpickle.loads(mnist_pickled)
-    # assert vars(mnist) == vars(mnist_loaded)
+    with pytest.warns(FutureWarning, match="`weights_only=False`") if _TORCH_GREATER_EQUAL_2_4 else nullcontext():
+        cloudpickle.loads(mnist_pickled)

--- a/tests/tests_pytorch/loggers/test_all.py
+++ b/tests/tests_pytorch/loggers/test_all.py
@@ -14,11 +14,13 @@
 import inspect
 import os
 import pickle
+from contextlib import nullcontext
 from unittest import mock
 from unittest.mock import ANY, Mock
 
 import pytest
 import torch
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4
 from lightning.pytorch import Callback, Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel
 from lightning.pytorch.loggers import (
@@ -182,7 +184,8 @@ def _test_loggers_pickle(tmp_path, monkeypatch, logger_class):
     trainer = Trainer(max_epochs=1, logger=logger)
     pkl_bytes = pickle.dumps(trainer)
 
-    trainer2 = pickle.loads(pkl_bytes)
+    with pytest.warns(FutureWarning, match="`weights_only=False`") if _TORCH_GREATER_EQUAL_2_4 else nullcontext():
+        trainer2 = pickle.loads(pkl_bytes)
     trainer2.logger.log_metrics({"acc": 1.0})
 
     # make sure we restored properly

--- a/tests/tests_pytorch/loggers/test_logger.py
+++ b/tests/tests_pytorch/loggers/test_logger.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import pickle
 from argparse import Namespace
+from contextlib import nullcontext
 from copy import deepcopy
 from typing import Any, Dict, Optional
 from unittest.mock import patch
@@ -20,6 +21,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import torch
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4
 from lightning.fabric.utilities.logger import _convert_params, _sanitize_params
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringDataModule, BoringModel
@@ -122,7 +124,8 @@ def test_multiple_loggers_pickle(tmp_path):
 
     trainer = Trainer(logger=[logger1, logger2])
     pkl_bytes = pickle.dumps(trainer)
-    trainer2 = pickle.loads(pkl_bytes)
+    with pytest.warns(FutureWarning, match="`weights_only=False`") if _TORCH_GREATER_EQUAL_2_4 else nullcontext():
+        trainer2 = pickle.loads(pkl_bytes)
     for logger in trainer2.loggers:
         logger.log_metrics({"acc": 1.0}, 0)
 

--- a/tests/tests_pytorch/loggers/test_wandb.py
+++ b/tests/tests_pytorch/loggers/test_wandb.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 import os
 import pickle
+from contextlib import nullcontext
 from pathlib import Path
 from unittest import mock
 
 import pytest
 import yaml
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.cli import LightningCLI
@@ -160,7 +162,8 @@ def test_wandb_pickle(wandb_mock, tmp_path):
     assert trainer.logger.experiment, "missing experiment"
     assert trainer.log_dir == logger.save_dir
     pkl_bytes = pickle.dumps(trainer)
-    trainer2 = pickle.loads(pkl_bytes)
+    with pytest.warns(FutureWarning, match="`weights_only=False`") if _TORCH_GREATER_EQUAL_2_4 else nullcontext():
+        trainer2 = pickle.loads(pkl_bytes)
 
     assert os.environ["WANDB_MODE"] == "dryrun"
     assert trainer2.logger.__class__.__name__ == WandbLogger.__name__

--- a/tests/tests_pytorch/loops/test_loops.py
+++ b/tests/tests_pytorch/loops/test_loops.py
@@ -226,7 +226,7 @@ def test_loop_restart_progress_multiple_dataloaders(tmp_path, n_dataloaders, sto
         trainer.fit(model)
 
     ckpt_path = str(tmp_path / "on_exception.ckpt")
-    checkpoint = torch.load(ckpt_path)["loops"]["fit_loop"]
+    checkpoint = torch.load(ckpt_path, weights_only=True)["loops"]["fit_loop"]
 
     trainer.fit_loop.load_state_dict(checkpoint)
 
@@ -285,7 +285,7 @@ def test_loop_state_on_exception(accumulate_grad_batches, stop_epoch, stop_batch
 
     ckpt_path = str(tmp_path / "on_exception.ckpt")
     assert os.path.exists(ckpt_path)
-    checkpoint = torch.load(ckpt_path)
+    checkpoint = torch.load(ckpt_path, weights_only=True)
 
     optim_progress = trainer.fit_loop.epoch_loop.automatic_optimization.optim_progress
     sch_progress = trainer.fit_loop.epoch_loop.scheduler_progress
@@ -446,7 +446,7 @@ def test_loop_state_on_complete_run(tmp_path):
 
     ckpt_path = trainer.checkpoint_callback.best_model_path
     assert os.path.exists(ckpt_path)
-    checkpoint = torch.load(ckpt_path)
+    checkpoint = torch.load(ckpt_path, weights_only=True)
 
     n_sch_steps_total = n_epochs
     n_sch_steps_current = 1
@@ -547,7 +547,7 @@ def test_fit_loop_reset(tmp_path):
     trainer.fit(model)
 
     # reset state loaded from a checkpoint from mid-epoch
-    mid_epoch_ckpt = torch.load(str(tmp_path / "epoch=0-step=2.ckpt"))
+    mid_epoch_ckpt = torch.load(str(tmp_path / "epoch=0-step=2.ckpt"), weights_only=True)
     fit_loop = trainer.fit_loop
     epoch_loop = fit_loop.epoch_loop
     optimizer_loop = epoch_loop.automatic_optimization
@@ -578,7 +578,7 @@ def test_fit_loop_reset(tmp_path):
     assert optimizer_loop.restarting
 
     # reset state loaded from a checkpoint from the end of an epoch
-    end_of_epoch_ckpt = torch.load(str(tmp_path / "epoch=0-step=4.ckpt"))
+    end_of_epoch_ckpt = torch.load(str(tmp_path / "epoch=0-step=4.ckpt"), weights_only=True)
     fit_loop = trainer.fit_loop
     epoch_loop = fit_loop.epoch_loop
     fit_loop.restarting = False
@@ -696,7 +696,7 @@ def test_fit_can_fail_during_validation(train_datasets, val_datasets, val_check_
         trainer.fit(model)
 
     assert os.path.exists(ckpt_path)
-    checkpoint = torch.load(ckpt_path)["loops"]["fit_loop"]
+    checkpoint = torch.load(ckpt_path, weights_only=True)["loops"]["fit_loop"]
 
     per_val_train_batches = int(n_batches * val_check_interval)
     assert checkpoint["epoch_loop.batch_progress"] == {
@@ -963,7 +963,7 @@ def test_fit_loop_save_and_restore_dataloaders(
 
     # Save a checkpoint
     trainer.save_checkpoint(tmp_path / "checkpoint.ckpt")
-    checkpoint = torch.load(tmp_path / "checkpoint.ckpt")
+    checkpoint = torch.load(tmp_path / "checkpoint.ckpt", weights_only=True)
     if has_state:
         assert checkpoint["loops"]["fit_loop"]["state_dict"]["combined_loader"]
     else:

--- a/tests/tests_pytorch/models/test_hparams.py
+++ b/tests/tests_pytorch/models/test_hparams.py
@@ -108,7 +108,7 @@ def _run_standard_hparams_test(tmp_path, model, cls, datamodule=None, try_overwr
 
     # make sure the raw checkpoint saved the properties
     raw_checkpoint_path = _raw_checkpoint_path(trainer)
-    raw_checkpoint = torch.load(raw_checkpoint_path)
+    raw_checkpoint = torch.load(raw_checkpoint_path, weights_only=False)
     assert cls.CHECKPOINT_HYPER_PARAMS_KEY in raw_checkpoint
     assert raw_checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY]["test_arg"] == 14
 
@@ -242,7 +242,7 @@ def test_explicit_missing_args_hparams(tmp_path):
 
     # make sure the raw checkpoint saved the properties
     raw_checkpoint_path = _raw_checkpoint_path(trainer)
-    raw_checkpoint = torch.load(raw_checkpoint_path)
+    raw_checkpoint = torch.load(raw_checkpoint_path, weights_only=True)
     assert LightningModule.CHECKPOINT_HYPER_PARAMS_KEY in raw_checkpoint
     assert raw_checkpoint[LightningModule.CHECKPOINT_HYPER_PARAMS_KEY]["test_arg"] == 14
 
@@ -393,7 +393,7 @@ def test_collect_init_arguments(tmp_path, cls):
 
     raw_checkpoint_path = _raw_checkpoint_path(trainer)
 
-    raw_checkpoint = torch.load(raw_checkpoint_path)
+    raw_checkpoint = torch.load(raw_checkpoint_path, weights_only=False)
     assert LightningModule.CHECKPOINT_HYPER_PARAMS_KEY in raw_checkpoint
     assert raw_checkpoint[LightningModule.CHECKPOINT_HYPER_PARAMS_KEY]["batch_size"] == 179
 
@@ -507,7 +507,7 @@ def test_load_past_checkpoint(tmp_path, past_key):
 
     # make sure the raw checkpoint saved the properties
     raw_checkpoint_path = _raw_checkpoint_path(trainer)
-    raw_checkpoint = torch.load(raw_checkpoint_path)
+    raw_checkpoint = torch.load(raw_checkpoint_path, weights_only=True)
     raw_checkpoint[past_key] = raw_checkpoint[LightningModule.CHECKPOINT_HYPER_PARAMS_KEY]
     raw_checkpoint["hparams_type"] = "Namespace"
     raw_checkpoint[past_key]["batch_size"] = -17
@@ -772,7 +772,7 @@ def test_ignore_args_list_hparams(tmp_path, ignore):
 
     # make sure the raw checkpoint saved the properties
     raw_checkpoint_path = _raw_checkpoint_path(trainer)
-    raw_checkpoint = torch.load(raw_checkpoint_path)
+    raw_checkpoint = torch.load(raw_checkpoint_path, weights_only=True)
     assert LightningModule.CHECKPOINT_HYPER_PARAMS_KEY in raw_checkpoint
     assert raw_checkpoint[LightningModule.CHECKPOINT_HYPER_PARAMS_KEY]["arg1"] == 14
 

--- a/tests/tests_pytorch/models/test_restore.py
+++ b/tests/tests_pytorch/models/test_restore.py
@@ -131,7 +131,7 @@ def test_trainer_properties_restore_ckpt_path(tmp_path):
     trainer.fit(model, datamodule=dm)
 
     resume_ckpt = str(tmp_path / "last.ckpt")
-    state_dict = torch.load(resume_ckpt)
+    state_dict = torch.load(resume_ckpt, weights_only=True)
 
     trainer_args.update({"max_epochs": 3, "enable_checkpointing": False, "callbacks": []})
 
@@ -208,7 +208,7 @@ def test_correct_step_and_epoch(tmp_path):
     ckpt_path = str(tmp_path / "model.ckpt")
     trainer.save_checkpoint(ckpt_path)
 
-    ckpt = torch.load(ckpt_path)
+    ckpt = torch.load(ckpt_path, weights_only=True)
     assert ckpt["epoch"] == first_max_epochs
     assert ckpt["global_step"] == first_max_epochs * train_batches
 
@@ -461,7 +461,7 @@ def test_load_model_from_checkpoint(tmp_path, model_template):
     last_checkpoint = sorted(glob.glob(os.path.join(trainer.checkpoint_callback.dirpath, "*.ckpt")))[-1]
 
     # Since `BoringModel` has `_save_hparams = True` by default, check that ckpt has hparams
-    ckpt = torch.load(last_checkpoint)
+    ckpt = torch.load(last_checkpoint, weights_only=True)
     assert model_template.CHECKPOINT_HYPER_PARAMS_KEY in ckpt, "hyper_parameters missing from checkpoints"
 
     # Ensure that model can be correctly restored from checkpoint

--- a/tests/tests_pytorch/plugins/test_checkpoint_io_plugin.py
+++ b/tests/tests_pytorch/plugins/test_checkpoint_io_plugin.py
@@ -31,7 +31,7 @@ class CustomCheckpointIO(CheckpointIO):
         torch.save(checkpoint, path)
 
     def load_checkpoint(self, path: _PATH, storage_options: Optional[Any] = None) -> Dict[str, Any]:
-        return torch.load(path)
+        return torch.load(path, weights_only=True)
 
     def remove_checkpoint(self, path: _PATH) -> None:
         os.remove(path)

--- a/tests/tests_pytorch/strategies/test_deepspeed.py
+++ b/tests/tests_pytorch/strategies/test_deepspeed.py
@@ -986,7 +986,7 @@ def _assert_save_model_is_equal(model, tmp_path, trainer):
     if trainer.is_global_zero:
         single_ckpt_path = os.path.join(tmp_path, "single_model.pt")
         convert_zero_checkpoint_to_fp32_state_dict(checkpoint_path, single_ckpt_path)
-        state_dict = torch.load(single_ckpt_path)
+        state_dict = torch.load(single_ckpt_path, weights_only=False)
 
         model = model.cpu()
         # Assert model parameters are identical after loading

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -831,7 +831,7 @@ def test_save_load_sharded_state_dict(tmp_path):
     checkpoint_path = Path(trainer.strategy.broadcast(trainer.checkpoint_callback.best_model_path))
     assert set(os.listdir(checkpoint_path)) == {"meta.pt", ".metadata", "__0_0.distcp", "__1_0.distcp"}
 
-    metadata = torch.load(checkpoint_path / "meta.pt")
+    metadata = torch.load(checkpoint_path / "meta.pt", weights_only=True)
     assert "pytorch-lightning_version" in metadata
     assert len(metadata["callbacks"]) == 1  # model checkpoint callback
     assert "state_dict" not in metadata

--- a/tests/tests_pytorch/strategies/test_model_parallel_integration.py
+++ b/tests/tests_pytorch/strategies/test_model_parallel_integration.py
@@ -495,7 +495,7 @@ def test_save_load_sharded_state_dict(tmp_path):
     checkpoint_path = Path(trainer.strategy.broadcast(trainer.checkpoint_callback.best_model_path))
     assert set(os.listdir(checkpoint_path)) == {"meta.pt", ".metadata", "__0_0.distcp", "__1_0.distcp"}
 
-    metadata = torch.load(checkpoint_path / "meta.pt")
+    metadata = torch.load(checkpoint_path / "meta.pt", weights_only=True)
     assert "pytorch-lightning_version" in metadata
     assert len(metadata["callbacks"]) == 1  # model checkpoint callback
     assert "state_dict" not in metadata

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -881,7 +881,7 @@ def test_lightning_cli_load_from_checkpoint_dependency_injection(cleandir):
 
     checkpoint_path = next(Path(cli.trainer.log_dir, "checkpoints").glob("*.ckpt"), None)
     assert checkpoint_path.is_file()
-    ckpt = torch.load(checkpoint_path)
+    ckpt = torch.load(checkpoint_path, weights_only=True)
     assert ckpt["hyper_parameters"] == expected
 
     model = TestModelSaveHparams.load_from_checkpoint(checkpoint_path)
@@ -910,7 +910,7 @@ def test_lightning_cli_load_from_checkpoint_dependency_injection_subclass_mode(c
 
     checkpoint_path = next(Path(cli.trainer.log_dir, "checkpoints").glob("*.ckpt"), None)
     assert checkpoint_path.is_file()
-    ckpt = torch.load(checkpoint_path)
+    ckpt = torch.load(checkpoint_path, weights_only=True)
     assert ckpt["hyper_parameters"] == expected
 
     model = LightningModule.load_from_checkpoint(checkpoint_path)

--- a/tests/tests_pytorch/trainer/connectors/test_callback_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_callback_connector.py
@@ -144,7 +144,7 @@ def test_all_callback_states_saved_before_checkpoint_callback(tmp_path):
     )
     trainer.fit(model)
 
-    ckpt = torch.load(str(tmp_path / "all_states.ckpt"))
+    ckpt = torch.load(str(tmp_path / "all_states.ckpt"), weights_only=True)
     state0 = ckpt["callbacks"]["StatefulCallback0"]
     state1 = ckpt["callbacks"]["StatefulCallback1{'unique': 'one'}"]
     state2 = ckpt["callbacks"]["StatefulCallback1{'unique': 'two'}"]

--- a/tests/tests_pytorch/trainer/test_trainer.py
+++ b/tests/tests_pytorch/trainer/test_trainer.py
@@ -103,7 +103,7 @@ def test_no_val_module(monkeypatch, tmp_path, tmpdir_server, url_ckpt):
     trainer.save_checkpoint(new_weights_path)
 
     # assert ckpt has hparams
-    ckpt = torch.load(new_weights_path)
+    ckpt = torch.load(new_weights_path, weights_only=True)
     assert LightningModule.CHECKPOINT_HYPER_PARAMS_KEY in ckpt, "hyper_parameters missing from checkpoints"
 
     # load new model
@@ -364,7 +364,7 @@ def test_model_checkpoint_only_weights(tmp_path):
     checkpoint_path = trainer.checkpoint_callback.best_model_path
 
     # assert saved checkpoint has no trainer data
-    checkpoint = torch.load(checkpoint_path)
+    checkpoint = torch.load(checkpoint_path, weights_only=True)
     assert "optimizer_states" not in checkpoint, "checkpoint should contain only model weights"
     assert "lr_schedulers" not in checkpoint, "checkpoint should contain only model weights"
 
@@ -375,7 +375,7 @@ def test_model_checkpoint_only_weights(tmp_path):
     new_weights_path = os.path.join(tmp_path, "save_test.ckpt")
     trainer.save_checkpoint(new_weights_path, weights_only=True)
     # assert saved checkpoint has no trainer data
-    checkpoint = torch.load(new_weights_path)
+    checkpoint = torch.load(new_weights_path, weights_only=True)
     assert "optimizer_states" not in checkpoint, "checkpoint should contain only model weights"
     assert "lr_schedulers" not in checkpoint, "checkpoint should contain only model weights"
 

--- a/tests/tests_pytorch/utilities/migration/test_migration.py
+++ b/tests/tests_pytorch/utilities/migration/test_migration.py
@@ -93,7 +93,7 @@ def test_migrate_loop_batches_that_stepped(tmp_path, model_class):
     ckpt_path = trainer.checkpoint_callback.best_model_path
 
     # pretend we have a checkpoint produced in < v1.6.5; the key "_batches_that_stepped" didn't exist back then
-    ckpt = torch.load(ckpt_path)
+    ckpt = torch.load(ckpt_path, weights_only=True)
     del ckpt["loops"]["fit_loop"]["epoch_loop.state_dict"]["_batches_that_stepped"]
     _set_version(ckpt, "1.6.4")
     torch.save(ckpt, ckpt_path)

--- a/tests/tests_pytorch/utilities/migration/test_utils.py
+++ b/tests/tests_pytorch/utilities/migration/test_utils.py
@@ -84,7 +84,7 @@ def test_test_patch_legacy_imports_standalone(pl_version):
     path_ckpt = path_ckpts[-1]
 
     with no_warning_call(match="Redirecting import of*"), pl_legacy_patch():
-        torch.load(path_ckpt)
+        torch.load(path_ckpt, weights_only=False)
 
     assert any(
         key.startswith("pytorch_lightning") for key in sys.modules
@@ -117,7 +117,7 @@ def test_patch_legacy_imports_unified(pl_version):
     else:
         context = no_warning_call(match="Redirecting import of*")
     with context, pl_legacy_patch():
-        torch.load(path_ckpt)
+        torch.load(path_ckpt, weights_only=False)
 
     assert any(
         key.startswith("lightning." + "pytorch") for key in sys.modules

--- a/tests/tests_pytorch/utilities/test_deepspeed_collate_checkpoint.py
+++ b/tests/tests_pytorch/utilities/test_deepspeed_collate_checkpoint.py
@@ -49,7 +49,7 @@ def test_deepspeed_collate_checkpoint(tmp_path):
 
 def _assert_checkpoint_equal(model, output_path):
     assert os.path.exists(output_path)
-    single_output = torch.load(output_path)
+    single_output = torch.load(output_path, weights_only=False)
     state_dict = model.state_dict()
     for orig_param, saved_model_param in zip(state_dict.values(), single_output["state_dict"].values()):
         if model.dtype == torch.half:


### PR DESCRIPTION
## What does this PR do?

PyTorch wants to flip the default of `torch.load(..., weights_only=)` to True in the future. In 2.4, they start [raising a FutureWarning](https://github.com/pytorch/pytorch/pull/129239) if you're not explicitly setting this argument to either True or False. This is the case in some of our tests. Since we have a strict setting that FutureWarning will fail tests, we have to set this flag now everywhere we call `torch.load()`.

Part of #20010.


cc @borda