### PR TITLE
Fixed positional encoding not used in Demo Transformer

### DIFF
--- a/src/lightning/pytorch/demos/transformer.py
+++ b/src/lightning/pytorch/demos/transformer.py
@@ -88,7 +88,7 @@ class PositionalEncoding(nn.Module):
             # TODO: Could make this a `nn.Parameter` with `requires_grad=False`
             self.pe = self._init_pos_encoding(device=x.device)
 
-        x + self.pe[: x.size(0), :]
+        x = x + self.pe[: x.size(0), :]
         return self.dropout(x)
 
     def _init_pos_encoding(self, device: torch.device) -> Tensor:


### PR DESCRIPTION


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20099.org.readthedocs.build/en/20099/

<!-- readthedocs-preview pytorch-lightning end -->