### PR TITLE
Remove outdated warnings filter for `reduce_op`

### DIFF
--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -23,7 +23,6 @@
 import logging
 import math
 import os
-import warnings
 from contextlib import contextmanager
 from datetime import timedelta
 from typing import Any, Dict, Generator, Iterable, List, Optional, Union

--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -82,10 +82,6 @@ from lightning.pytorch.utilities.types import (
 from lightning.pytorch.utilities.warnings import PossibleUserWarning
 
 log = logging.getLogger(__name__)
-# warnings to ignore in trainer
-warnings.filterwarnings(
-    "ignore", message="torch.distributed.reduce_op is deprecated, please use torch.distributed.ReduceOp instead"
-)
 
 
 class Trainer:


### PR DESCRIPTION
## What does this PR do?

Removes an old warnings filter that is no longer needed (since PyTorch 1.13). See https://github.com/pytorch/pytorch/issues/87191


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20102.org.readthedocs.build/en/20102/

<!-- readthedocs-preview pytorch-lightning end -->