### PR TITLE
Remove confusing warning "Missing logger folder"

### DIFF
--- a/src/lightning/fabric/loggers/csv_logs.py
+++ b/src/lightning/fabric/loggers/csv_logs.py
@@ -172,7 +172,6 @@ class CSVLogger(Logger):
         versions_root = os.path.join(self._root_dir, self.name)
 
         if not _is_dir(self._fs, versions_root, strict=True):
-            log.warning("Missing logger folder: %s", versions_root)
             return 0
 
         existing_versions = []

--- a/src/lightning/fabric/loggers/tensorboard.py
+++ b/src/lightning/fabric/loggers/tensorboard.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 from argparse import Namespace
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Union
@@ -26,11 +25,10 @@ from lightning.fabric.loggers.logger import Logger, rank_zero_experiment
 from lightning.fabric.utilities.cloud_io import _is_dir, get_filesystem
 from lightning.fabric.utilities.logger import _add_prefix, _convert_params, _flatten_dict
 from lightning.fabric.utilities.logger import _sanitize_params as _utils_sanitize_params
-from lightning.fabric.utilities.rank_zero import rank_zero_only, rank_zero_warn
+from lightning.fabric.utilities.rank_zero import rank_zero_only, rank_zero_warn, rank_zero_info
 from lightning.fabric.utilities.types import _PATH
 from lightning.fabric.wrappers import _unwrap_objects
 
-log = logging.getLogger(__name__)
 
 _TENSORBOARD_AVAILABLE = RequirementCache("tensorboard")
 _TENSORBOARDX_AVAILABLE = RequirementCache("tensorboardX")
@@ -305,8 +303,6 @@ class TensorBoardLogger(Logger):
         try:
             listdir_info = self._fs.listdir(save_dir)
         except OSError:
-            # TODO(fabric): This message can be confusing (did user do something wrong?). Improve it or remove it.
-            log.warning("Missing logger folder: %s", save_dir)
             return 0
 
         existing_versions = []

--- a/src/lightning/fabric/loggers/tensorboard.py
+++ b/src/lightning/fabric/loggers/tensorboard.py
@@ -25,10 +25,9 @@ from lightning.fabric.loggers.logger import Logger, rank_zero_experiment
 from lightning.fabric.utilities.cloud_io import _is_dir, get_filesystem
 from lightning.fabric.utilities.logger import _add_prefix, _convert_params, _flatten_dict
 from lightning.fabric.utilities.logger import _sanitize_params as _utils_sanitize_params
-from lightning.fabric.utilities.rank_zero import rank_zero_only, rank_zero_warn, rank_zero_info
+from lightning.fabric.utilities.rank_zero import rank_zero_only, rank_zero_warn
 from lightning.fabric.utilities.types import _PATH
 from lightning.fabric.wrappers import _unwrap_objects
-
 
 _TENSORBOARD_AVAILABLE = RequirementCache("tensorboard")
 _TENSORBOARDX_AVAILABLE = RequirementCache("tensorboardX")

--- a/src/lightning/pytorch/loggers/csv_logs.py
+++ b/src/lightning/pytorch/loggers/csv_logs.py
@@ -19,7 +19,6 @@ CSV logger for basic experiment logging that does not require opening ports
 
 """
 
-import logging
 import os
 from argparse import Namespace
 from typing import Any, Dict, Optional, Union
@@ -34,8 +33,6 @@ from lightning.fabric.utilities.types import _PATH
 from lightning.pytorch.core.saving import save_hparams_to_yaml
 from lightning.pytorch.loggers.logger import Logger
 from lightning.pytorch.utilities.rank_zero import rank_zero_only
-
-log = logging.getLogger(__name__)
 
 
 class ExperimentWriter(_FabricExperimentWriter):

--- a/src/lightning/pytorch/loggers/tensorboard.py
+++ b/src/lightning/pytorch/loggers/tensorboard.py
@@ -16,7 +16,6 @@ TensorBoard Logger
 ------------------
 """
 
-import logging
 import os
 from argparse import Namespace
 from typing import Any, Dict, Optional, Union
@@ -35,8 +34,6 @@ from lightning.pytorch.core.saving import save_hparams_to_yaml
 from lightning.pytorch.loggers.logger import Logger
 from lightning.pytorch.utilities.imports import _OMEGACONF_AVAILABLE
 from lightning.pytorch.utilities.rank_zero import rank_zero_only, rank_zero_warn
-
-log = logging.getLogger(__name__)
 
 
 class TensorBoardLogger(Logger, FabricTensorBoardLogger):
@@ -245,7 +242,6 @@ class TensorBoardLogger(Logger, FabricTensorBoardLogger):
         try:
             listdir_info = self._fs.listdir(root_dir)
         except OSError:
-            log.warning("Missing logger folder: %s", root_dir)
             return 0
 
         existing_versions = []

--- a/tests/tests_fabric/loggers/test_tensorboard.py
+++ b/tests/tests_fabric/loggers/test_tensorboard.py
@@ -213,8 +213,7 @@ def test_tensorboard_finalize(monkeypatch, tmp_path):
     logger.experiment.close.assert_called()
 
 
-@mock.patch("lightning.fabric.loggers.tensorboard.log")
-def test_tensorboard_with_symlink(log, tmp_path, monkeypatch):
+def test_tensorboard_with_symlink(tmp_path, monkeypatch):
     """Tests a specific failure case when tensorboard logger is used with empty name, symbolic link ``save_dir``, and
     relative paths."""
     monkeypatch.chdir(tmp_path)  # need to use relative paths
@@ -226,5 +225,3 @@ def test_tensorboard_with_symlink(log, tmp_path, monkeypatch):
 
     logger = TensorBoardLogger(root_dir=dest, name="")
     _ = logger.version
-
-    log.warning.assert_not_called()

--- a/tests/tests_fabric/loggers/test_tensorboard.py
+++ b/tests/tests_fabric/loggers/test_tensorboard.py
@@ -228,14 +228,3 @@ def test_tensorboard_with_symlink(log, tmp_path, monkeypatch):
     _ = logger.version
 
     log.warning.assert_not_called()
-
-
-def test_tensorboard_missing_folder_warning(tmp_path, caplog):
-    """Verify that the logger throws a warning for invalid directory."""
-    name = "fake_dir"
-    logger = TensorBoardLogger(root_dir=tmp_path, name=name)
-
-    with caplog.at_level(logging.WARNING):
-        assert logger.version == 0
-
-    assert "Missing logger folder:" in caplog.text

--- a/tests/tests_pytorch/loggers/test_tensorboard.py
+++ b/tests/tests_pytorch/loggers/test_tensorboard.py
@@ -312,8 +312,7 @@ def test_tensorboard_save_hparams_to_yaml_once(tmp_path):
     assert not os.path.isfile(os.path.join(tmp_path, hparams_file))
 
 
-@mock.patch("lightning.pytorch.loggers.tensorboard.log")
-def test_tensorboard_with_symlink(log, tmp_path, monkeypatch):
+def test_tensorboard_with_symlink(tmp_path, monkeypatch):
     """Tests a specific failure case when tensorboard logger is used with empty name, symbolic link ``save_dir``, and
     relative paths."""
     monkeypatch.chdir(tmp_path)  # need to use relative paths
@@ -325,5 +324,3 @@ def test_tensorboard_with_symlink(log, tmp_path, monkeypatch):
 
     logger = TensorBoardLogger(save_dir=dest, name="")
     _ = logger.version
-
-    log.warning.assert_not_called()

--- a/tests/tests_pytorch/loggers/test_tensorboard.py
+++ b/tests/tests_pytorch/loggers/test_tensorboard.py
@@ -327,14 +327,3 @@ def test_tensorboard_with_symlink(log, tmp_path, monkeypatch):
     _ = logger.version
 
     log.warning.assert_not_called()
-
-
-def test_tensorboard_missing_folder_warning(tmp_path, caplog):
-    """Verify that the logger throws a warning for invalid directory."""
-    name = "fake_dir"
-    logger = TensorBoardLogger(save_dir=tmp_path, name=name)
-
-    with caplog.at_level(logging.WARNING):
-        assert logger.version == 0
-
-    assert "Missing logger folder:" in caplog.text


### PR DESCRIPTION
## What does this PR do?

The TensorBoardLogger checks if an existing folder already exists in order to determine the version. For example, if `lightning_logs/version_1` already exists, it would create version 2. However, the very first time you run an experiment, the `lightning_logs` folder won't exist. Currently, the logger will output a warning
```
Missing logger folder: /teamspace/studios/this_studio/lightning_logs
```
to inform the folder does not exist yet. This implies the version will be set to 0. This is completely normal, but to the user this sounds like something is wrong. I currently don't see a reason why we should keep this warning message.


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20109.org.readthedocs.build/en/20109/

<!-- readthedocs-preview pytorch-lightning end -->