### PR TITLE
Fix DDP strategy registration with override

### DIFF
--- a/src/lightning/pytorch/strategies/ddp.py
+++ b/src/lightning/pytorch/strategies/ddp.py
@@ -377,6 +377,15 @@ class DDPStrategy(ParallelStrategy):
                 find_unused_parameters=fup,
                 start_method=start_method,
             )
+            
+        strategy_registry.register(
+            "ddp_find_unused_parameters_true",
+            cls,
+            description="Alias for DDP strategy with `find_unused_parameters=True` and `start_method='popen'`",
+            find_unused_parameters = True,
+            start_method = "popen"
+            
+        )
 
     @override
     def on_exception(self, exception: BaseException) -> None:


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Part of #\<20037>

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review
Following changes were made:
1. In ```pytorch-lightning\src\lightning\pytorch\strategies\ddp.py```: 
 ```
strategy_registry.register(
            "ddp_find_unused_parameters_true",
            cls,
            description="Alias for DDP strategy with `find_unused_parameters=True` and `start_method='popen'`",
            find_unused_parameters = True,
            start_method = "open"
            
        )
```

Tagging @awaelchli for better visibility.

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
