### PR TITLE
docs: update ref to latest tutorials

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -68,9 +68,18 @@ jobs:
           ref: ${{ inputs.checkout }}
           # only Pytorch has/uses notebooks
           submodules: ${{ matrix.pkg-name == 'pytorch' }}
+          lfs: ${{ matrix.pkg-name == 'pytorch' }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
+
+      - name: List notebooks
+        if: ${{ matrix.pkg-name == 'pytorch' }}
+        working-directory: _notebooks/
+        run: |
+          pip install -q py-tree
+          py-tree .notebooks/
+          ls -lhR .notebooks/
 
       - name: Pull sphinx template
         run: |

--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -70,11 +70,9 @@ if _COPY_NOTEBOOKS:
         _PATH_HERE,
         "notebooks",
         patterns=[".", "course_UvA-DL", "lightning_examples"],
-        # TODO(@aniketmaurya): Complete converting the missing items and add them back
-        ignore=[
-            # "course_UvA-DL/13-contrastive-learning",
-            "lightning_examples/warp-drive",
-        ],
+        # ignore=[
+        #     "lightning_examples/warp-drive",
+        # ],
     )
 
 

--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -642,5 +642,6 @@ linkcheck_ignore = [
     "https://www.microsoft.com/en-us/research/blog/zero-infinity-and-deepspeed-unlocking-unprecedented-model-scale-for-deep-learning-training/",  # noqa: E501
     "https://stackoverflow.com/questions/66640705/how-can-i-install-grpcio-on-an-apple-m1-silicon-laptop",
     "https://openai.com/blog/.*",
+    "https://openai.com/index/*"
     "https://tinyurl.com/.*",  # has a human verification check on redirect
 ]


### PR DESCRIPTION
**This is automated update with the latest lighting tutorials!**
The target commit in the [publication](https://github.com/Lightning-AI/tutorials/tree/publication)
 branch is [565f61a9](https://github.com/Lightning-AI/tutorials/commit/565f61a9).

Before proceeding further double check that the PR include only submodule's head update. Eventually some additional adjustments in lightning docs may be needed.

cc @borda

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20132.org.readthedocs.build/en/20132/

<!-- readthedocs-preview pytorch-lightning end -->