### PR TITLE
Avoid deprecated distutils for docs build

### DIFF
--- a/.actions/assistant.py
+++ b/.actions/assistant.py
@@ -18,13 +18,13 @@ import re
 import shutil
 import tempfile
 import urllib.request
-from packaging.version import Version
 from itertools import chain
 from os.path import dirname, isfile
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
 
 from packaging.requirements import Requirement
+from packaging.version import Version
 
 REQUIREMENT_FILES = {
     "pytorch": (

--- a/.actions/assistant.py
+++ b/.actions/assistant.py
@@ -18,7 +18,7 @@ import re
 import shutil
 import tempfile
 import urllib.request
-from distutils.version import LooseVersion
+from packaging.version import Version
 from itertools import chain
 from os.path import dirname, isfile
 from pathlib import Path
@@ -84,7 +84,7 @@ class _RequirementWithComment(Requirement):
         if unfreeze == "major":
             for operator, version in specs:
                 if operator in ("<", "<="):
-                    major = LooseVersion(version).version[0]
+                    major = Version(version).major
                     # replace upper bound with major version increased by one
                     return out.replace(f"{operator}{version}", f"<{major + 1}.0")
         elif unfreeze == "all":


### PR DESCRIPTION
## What does this PR do?

Fixes a docs build error on Python 3.12. The `make docs` command errors out with `module not found: distutils` because it was deprecated in Python 3.10 and removed in Python 3.12. 


cc @borda