### PR TITLE
Remove outdated `process_position` reference in progress bar docs.

### DIFF
--- a/src/lightning/pytorch/callbacks/progress/tqdm_progress.py
+++ b/src/lightning/pytorch/callbacks/progress/tqdm_progress.py
@@ -96,9 +96,7 @@ class TQDMProgressBar(ProgressBar):
             Set it to ``0`` to disable the display.
         process_position: Set this to a value greater than ``0`` to offset the progress bars by this many lines.
             This is useful when you have progress bars defined elsewhere and want to show all of them
-            together. This corresponds to
-            :paramref:`~lightning.pytorch.trainer.trainer.Trainer.process_position` in the
-            :class:`~lightning.pytorch.trainer.trainer.Trainer`.
+            together.
         leave: If set to ``True``, leaves the finished progress bar in the terminal at the end of the epoch.
             Default: ``False``
 


### PR DESCRIPTION
## What does this PR do?

Removes a reference to `Trainer.process_position` in the docs of TQDMProgressBar that no longer exists.


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20158.org.readthedocs.build/en/20158/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @awaelchli