### PR TITLE
Count number of modules in train/eval mode in ModelSummary

### DIFF
--- a/docs/source-pytorch/advanced/transfer_learning.rst
+++ b/docs/source-pytorch/advanced/transfer_learning.rst
@@ -116,6 +116,7 @@ Here's a model that uses `Huggingface transformers <https://github.com/huggingfa
             super().__init__()
 
             self.bert = BertModel.from_pretrained("bert-base-cased", output_attentions=True)
+            self.bert.train()
             self.W = nn.Linear(bert.config.hidden_size, 3)
             self.num_classes = 3
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - The `TQDMProgressBar` now provides an option to retain prior training epoch bars ([#19578](https://github.com/Lightning-AI/pytorch-lightning/pull/19578))
 
+- Added the count of modules in train and eval mode to the printed `ModelSummary` table ([#20159](https://github.com/Lightning-AI/pytorch-lightning/pull/20159))
+
 ### Changed
 
 - Triggering KeyboardInterrupt (Ctrl+C) during `.fit()`, `.evaluate()`, `.test()` or `.predict()` now terminates all processes launched by the Trainer and exits the program ([#19976](https://github.com/Lightning-AI/pytorch-lightning/pull/19976))

--- a/src/lightning/pytorch/callbacks/model_summary.py
+++ b/src/lightning/pytorch/callbacks/model_summary.py
@@ -66,10 +66,17 @@ class ModelSummary(Callback):
         total_parameters = model_summary.total_parameters
         trainable_parameters = model_summary.trainable_parameters
         model_size = model_summary.model_size
-        training_modes = model_summary.training_modes
+        total_training_modes = model_summary.total_training_modes
 
         if trainer.is_global_zero:
-            self.summarize(summary_data, total_parameters, trainable_parameters, model_size, training_modes, **self._summarize_kwargs)
+            self.summarize(
+                summary_data,
+                total_parameters,
+                trainable_parameters,
+                model_size,
+                total_training_modes,
+                **self._summarize_kwargs
+            )
 
     def _summary(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> Union[DeepSpeedSummary, Summary]:
         from lightning.pytorch.strategies.deepspeed import DeepSpeedStrategy
@@ -84,14 +91,14 @@ class ModelSummary(Callback):
         total_parameters: int,
         trainable_parameters: int,
         model_size: float,
-        training_modes: List[bool],
+        total_training_modes: Dict[str, int],
         **summarize_kwargs: Any,
     ) -> None:
         summary_table = _format_summary_table(
             total_parameters,
             trainable_parameters,
             model_size,
-            training_modes,
+            total_training_modes,
             *summary_data,
         )
         log.info("\n" + summary_table)

--- a/src/lightning/pytorch/callbacks/model_summary.py
+++ b/src/lightning/pytorch/callbacks/model_summary.py
@@ -75,7 +75,7 @@ class ModelSummary(Callback):
                 trainable_parameters,
                 model_size,
                 total_training_modes,
-                **self._summarize_kwargs
+                **self._summarize_kwargs,
             )
 
     def _summary(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> Union[DeepSpeedSummary, Summary]:

--- a/src/lightning/pytorch/callbacks/model_summary.py
+++ b/src/lightning/pytorch/callbacks/model_summary.py
@@ -66,9 +66,10 @@ class ModelSummary(Callback):
         total_parameters = model_summary.total_parameters
         trainable_parameters = model_summary.trainable_parameters
         model_size = model_summary.model_size
+        training_modes = model_summary.training_modes
 
         if trainer.is_global_zero:
-            self.summarize(summary_data, total_parameters, trainable_parameters, model_size, **self._summarize_kwargs)
+            self.summarize(summary_data, total_parameters, trainable_parameters, model_size, training_modes, **self._summarize_kwargs)
 
     def _summary(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> Union[DeepSpeedSummary, Summary]:
         from lightning.pytorch.strategies.deepspeed import DeepSpeedStrategy
@@ -83,12 +84,14 @@ class ModelSummary(Callback):
         total_parameters: int,
         trainable_parameters: int,
         model_size: float,
+        training_modes: List[bool],
         **summarize_kwargs: Any,
     ) -> None:
         summary_table = _format_summary_table(
             total_parameters,
             trainable_parameters,
             model_size,
+            training_modes,
             *summary_data,
         )
         log.info("\n" + summary_table)

--- a/src/lightning/pytorch/callbacks/rich_model_summary.py
+++ b/src/lightning/pytorch/callbacks/rich_model_summary.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, List, Tuple, Dict
+from typing import Any, Dict, List, Tuple
 
 from typing_extensions import override
 

--- a/src/lightning/pytorch/callbacks/rich_model_summary.py
+++ b/src/lightning/pytorch/callbacks/rich_model_summary.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Dict
 
 from typing_extensions import override
 
@@ -71,7 +71,7 @@ class RichModelSummary(ModelSummary):
         total_parameters: int,
         trainable_parameters: int,
         model_size: float,
-        training_modes: List[bool],
+        total_training_modes: Dict[str, int],
         **summarize_kwargs: Any,
     ) -> None:
         from rich import get_console
@@ -111,7 +111,7 @@ class RichModelSummary(ModelSummary):
         grid.add_row(f"[bold]Non-trainable params[/]: {parameters[1]}")
         grid.add_row(f"[bold]Total params[/]: {parameters[2]}")
         grid.add_row(f"[bold]Total estimated model params size (MB)[/]: {parameters[3]}")
-        grid.add_row(f"[bold]Modules in train mode[/]: {training_modes.count(True)}")
-        grid.add_row(f"[bold]Modules in eval mode[/]: {training_modes.count(False)}")
+        grid.add_row(f"[bold]Modules in train mode[/]: {total_training_modes['train']}")
+        grid.add_row(f"[bold]Modules in eval mode[/]: {total_training_modes['eval']}")
 
         console.print(grid)

--- a/src/lightning/pytorch/callbacks/rich_model_summary.py
+++ b/src/lightning/pytorch/callbacks/rich_model_summary.py
@@ -71,6 +71,7 @@ class RichModelSummary(ModelSummary):
         total_parameters: int,
         trainable_parameters: int,
         model_size: float,
+        training_modes: List[bool],
         **summarize_kwargs: Any,
     ) -> None:
         from rich import get_console
@@ -110,5 +111,7 @@ class RichModelSummary(ModelSummary):
         grid.add_row(f"[bold]Non-trainable params[/]: {parameters[1]}")
         grid.add_row(f"[bold]Total params[/]: {parameters[2]}")
         grid.add_row(f"[bold]Total estimated model params size (MB)[/]: {parameters[3]}")
+        grid.add_row(f"[bold]Modules in train mode[/]: {training_modes.count(True)}")
+        grid.add_row(f"[bold]Modules in eval mode[/]: {training_modes.count(False)}")
 
         console.print(grid)

--- a/src/lightning/pytorch/utilities/model_summary/model_summary.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary.py
@@ -187,7 +187,7 @@ class ModelSummary:
         0         Non-trainable params
         132 K     Total params
         0.530     Total estimated model params size (MB)
-        1         Modules in train mode
+        3         Modules in train mode
         0         Modules in eval mode
         >>> ModelSummary(model, max_depth=-1)  # doctest: +NORMALIZE_WHITESPACE
           | Name  | Type        | Params | Mode  | In sizes  | Out sizes

--- a/src/lightning/pytorch/utilities/model_summary/model_summary.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary.py
@@ -361,9 +361,9 @@ class ModelSummary:
         total_parameters = self.total_parameters
         trainable_parameters = self.trainable_parameters
         model_size = self.model_size
-        training_modes = self.training_modes
+        total_training_modes = self.total_training_modes
 
-        return _format_summary_table(total_parameters, trainable_parameters, model_size, training_modes, *arrays)
+        return _format_summary_table(total_parameters, trainable_parameters, model_size, total_training_modes, *arrays)
 
     def __repr__(self) -> str:
         return str(self)

--- a/src/lightning/pytorch/utilities/model_summary/model_summary.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary.py
@@ -351,8 +351,9 @@ class ModelSummary:
         total_parameters = self.total_parameters
         trainable_parameters = self.trainable_parameters
         model_size = self.model_size
+        training_modes = self.training_modes
 
-        return _format_summary_table(total_parameters, trainable_parameters, model_size, *arrays)
+        return _format_summary_table(total_parameters, trainable_parameters, model_size, training_modes, *arrays)
 
     def __repr__(self) -> str:
         return str(self)
@@ -372,6 +373,7 @@ def _format_summary_table(
     total_parameters: int,
     trainable_parameters: int,
     model_size: float,
+    training_modes: List[bool],
     *cols: Tuple[str, List[str]],
 ) -> str:
     """Takes in a number of arrays, each specifying a column in the summary table, and combines them all into one big
@@ -408,6 +410,10 @@ def _format_summary_table(
     summary += "Total params"
     summary += "\n" + s.format(get_formatted_model_size(model_size), 10)
     summary += "Total estimated model params size (MB)"
+    summary += "\n" + s.format(training_modes.count(True), 10)
+    summary += "Submodules in train mode"
+    summary += "\n" + s.format(training_modes.count(False), 10)
+    summary += "Submodules in eval mode"
 
     return summary
 

--- a/src/lightning/pytorch/utilities/model_summary/model_summary.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary.py
@@ -411,9 +411,9 @@ def _format_summary_table(
     summary += "\n" + s.format(get_formatted_model_size(model_size), 10)
     summary += "Total estimated model params size (MB)"
     summary += "\n" + s.format(training_modes.count(True), 10)
-    summary += "Submodules in train mode"
+    summary += "Modules in train mode"
     summary += "\n" + s.format(training_modes.count(False), 10)
-    summary += "Submodules in eval mode"
+    summary += "Modules in eval mode"
 
     return summary
 

--- a/src/lightning/pytorch/utilities/model_summary/model_summary.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary.py
@@ -187,6 +187,8 @@ class ModelSummary:
         0         Non-trainable params
         132 K     Total params
         0.530     Total estimated model params size (MB)
+        1         Modules in train mode
+        0         Modules in eval mode
         >>> ModelSummary(model, max_depth=-1)  # doctest: +NORMALIZE_WHITESPACE
           | Name  | Type        | Params | Mode  | In sizes  | Out sizes
         ----------------------------------------------------------------------
@@ -198,7 +200,8 @@ class ModelSummary:
         0         Non-trainable params
         132 K     Total params
         0.530     Total estimated model params size (MB)
-
+        3         Modules in train mode
+        0         Modules in eval mode
     """
 
     def __init__(self, model: "pl.LightningModule", max_depth: int = 1) -> None:

--- a/src/lightning/pytorch/utilities/model_summary/model_summary.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary.py
@@ -202,6 +202,7 @@ class ModelSummary:
         0.530     Total estimated model params size (MB)
         3         Modules in train mode
         0         Modules in eval mode
+
     """
 
     def __init__(self, model: "pl.LightningModule", max_depth: int = 1) -> None:

--- a/src/lightning/pytorch/utilities/model_summary/model_summary.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary.py
@@ -253,6 +253,12 @@ class ModelSummary:
         return [layer.training for layer in self._layer_summary.values()]
 
     @property
+    def total_training_modes(self) -> Dict[str, int]:
+        modes = [layer.training for layer in self._model.modules()]
+        modes = modes[1:]  # exclude the root module
+        return {"train": modes.count(True), "eval": modes.count(False)}
+
+    @property
     def total_parameters(self) -> int:
         return sum(p.numel() if not _is_lazy_weight_tensor(p) else 0 for p in self._model.parameters())
 
@@ -373,7 +379,7 @@ def _format_summary_table(
     total_parameters: int,
     trainable_parameters: int,
     model_size: float,
-    training_modes: List[bool],
+    total_training_modes: Dict[str, int],
     *cols: Tuple[str, List[str]],
 ) -> str:
     """Takes in a number of arrays, each specifying a column in the summary table, and combines them all into one big
@@ -410,9 +416,9 @@ def _format_summary_table(
     summary += "Total params"
     summary += "\n" + s.format(get_formatted_model_size(model_size), 10)
     summary += "Total estimated model params size (MB)"
-    summary += "\n" + s.format(training_modes.count(True), 10)
+    summary += "\n" + s.format(total_training_modes["train"], 10)
     summary += "Modules in train mode"
-    summary += "\n" + s.format(training_modes.count(False), 10)
+    summary += "\n" + s.format(total_training_modes["eval"], 10)
     summary += "Modules in eval mode"
 
     return summary

--- a/tests/tests_pytorch/callbacks/test_early_stopping.py
+++ b/tests/tests_pytorch/callbacks/test_early_stopping.py
@@ -58,7 +58,7 @@ class EarlyStoppingTestRestore(EarlyStopping):
         self.saved_states.append(self.state_dict().copy())
 
 
-@RunIf(sklearn=True)
+@RunIf(sklearn=True, skip_windows=True)  # Flaky test on Windows for unknown reasons
 @mock.patch.dict(os.environ, os.environ.copy(), clear=True)
 def test_resume_early_stopping_from_checkpoint(tmp_path):
     """Prevent regressions to bugs:

--- a/tests/tests_pytorch/callbacks/test_model_summary.py
+++ b/tests/tests_pytorch/callbacks/test_model_summary.py
@@ -49,7 +49,7 @@ def test_custom_model_summary_callback_summarize(tmp_path):
             total_parameters: int,
             trainable_parameters: int,
             model_size: float,
-            training_modes,
+            total_training_modes,
             **summarize_kwargs: Any,
         ) -> None:
             assert summary_data[1][0] == "Name"
@@ -65,7 +65,7 @@ def test_custom_model_summary_callback_summarize(tmp_path):
             assert summary_data[4][0] == "Mode"
             assert summary_data[4][1][0] == "train"
 
-            assert training_modes == [True]
+            assert total_training_modes == {"train": 1, "eval": 0}
 
     model = BoringModel()
     trainer = Trainer(default_root_dir=tmp_path, callbacks=CustomModelSummary(), max_steps=1)

--- a/tests/tests_pytorch/callbacks/test_model_summary.py
+++ b/tests/tests_pytorch/callbacks/test_model_summary.py
@@ -49,6 +49,7 @@ def test_custom_model_summary_callback_summarize(tmp_path):
             total_parameters: int,
             trainable_parameters: int,
             model_size: float,
+            training_modes,
             **summarize_kwargs: Any,
         ) -> None:
             assert summary_data[1][0] == "Name"
@@ -63,6 +64,8 @@ def test_custom_model_summary_callback_summarize(tmp_path):
 
             assert summary_data[4][0] == "Mode"
             assert summary_data[4][1][0] == "train"
+
+            assert training_modes == [True]
 
     model = BoringModel()
     trainer = Trainer(default_root_dir=tmp_path, callbacks=CustomModelSummary(), max_steps=1)

--- a/tests/tests_pytorch/callbacks/test_rich_model_summary.py
+++ b/tests/tests_pytorch/callbacks/test_rich_model_summary.py
@@ -56,7 +56,9 @@ def test_rich_summary_tuples(mock_table_add_row, mock_console):
     summary = summarize(model)
     summary_data = summary._get_summary_data()
 
-    model_summary.summarize(summary_data=summary_data, total_parameters=1, trainable_parameters=1, model_size=1)
+    model_summary.summarize(
+        summary_data=summary_data, total_parameters=1, trainable_parameters=1, model_size=1, training_modes=[True]
+    )
 
     # ensure that summary was logged + the breakdown of model parameters
     assert mock_console.call_count == 2

--- a/tests/tests_pytorch/callbacks/test_rich_model_summary.py
+++ b/tests/tests_pytorch/callbacks/test_rich_model_summary.py
@@ -57,7 +57,11 @@ def test_rich_summary_tuples(mock_table_add_row, mock_console):
     summary_data = summary._get_summary_data()
 
     model_summary.summarize(
-        summary_data=summary_data, total_parameters=1, trainable_parameters=1, model_size=1, training_modes=[True]
+        summary_data=summary_data,
+        total_parameters=1,
+        trainable_parameters=1,
+        model_size=1,
+        total_training_modes=summary.total_training_modes,
     )
 
     # ensure that summary was logged + the breakdown of model parameters

--- a/tests/tests_pytorch/core/test_datamodules.py
+++ b/tests/tests_pytorch/core/test_datamodules.py
@@ -218,7 +218,7 @@ def test_dm_checkpoint_save_and_load(tmp_path):
         assert dm.my_state_dict == {"my": "state_dict"}
 
 
-@RunIf(sklearn=True)
+@RunIf(sklearn=True, skip_windows=True)  # Flaky test on Windows for unknown reasons
 def test_full_loop(tmp_path):
     seed_everything(7)
 

--- a/tests/tests_pytorch/utilities/test_model_summary.py
+++ b/tests/tests_pytorch/utilities/test_model_summary.py
@@ -424,7 +424,9 @@ def test_summary_restores_module_mode():
 
 
 def test_total_training_modes():
-    """Test that the `total_training_modes` counts the modules in 'train' and 'eval' mode, excluding the root module."""
+    """Test that the `total_training_modes` counts the modules in 'train' and 'eval' mode, excluding the root
+    module."""
+
     class ModelWithoutChildren(LightningModule):
         pass
 

--- a/tests/tests_pytorch/utilities/test_model_summary.py
+++ b/tests/tests_pytorch/utilities/test_model_summary.py
@@ -423,6 +423,27 @@ def test_summary_restores_module_mode():
     assert not model.layer2.training
 
 
+def test_total_training_modes():
+    """Test that the `total_training_modes` counts the modules in 'train' and 'eval' mode, excluding the root module."""
+    class ModelWithoutChildren(LightningModule):
+        pass
+
+    summary = ModelSummary(ModelWithoutChildren())
+    assert summary.total_training_modes == {"train": 0, "eval": 0}
+
+    model = DeepNestedModel()
+    summary = ModelSummary(model)
+    assert summary.total_training_modes == {"train": 19, "eval": 0}
+    assert sum(summary.total_training_modes.values()) == len(list(model.modules())) - 1
+
+    model = DeepNestedModel()
+    summary = ModelSummary(model)
+    model.branch1[1][0].eval()
+    model.branch2.eval()
+    assert summary.total_training_modes == {"train": 17, "eval": 2}
+    assert sum(summary.total_training_modes.values()) == len(list(model.modules())) - 1
+
+
 def test_summary_training_mode():
     """Test that the model summary captures the training mode on all submodules."""
     model = DeepNestedModel()
@@ -436,6 +457,7 @@ def test_summary_training_mode():
         "eval",  # branch2
         "train",  # head
     ]
+    assert summary.total_training_modes == {"train": 17, "eval": 2}
 
     summary = summarize(model, max_depth=-1)
     expected_eval = {"branch1.1.0", "branch2"}
@@ -445,5 +467,7 @@ def test_summary_training_mode():
     # A model with params not belonging to a layer
     model = NonLayerParamsModel()
     model.layer.eval()
-    summary_data = OrderedDict(summarize(model)._get_summary_data())
+    summary = summarize(model)
+    summary_data = OrderedDict(summary._get_summary_data())
     assert summary_data["Mode"] == ["eval", "n/a"]
+    assert summary.total_training_modes == {"train": 0, "eval": 1}


### PR DESCRIPTION
## What does this PR do?

Fixes #19820
Fixes #20128

This PR adds two rows to the model summary that count how many modules are in train and how many are in eval model. The issues linked above raised concern that it is not visible enough when models are in eval mode (accidentally). Printing the explicit count for each mode should raise awareness:
1. For pretraining, you want it to show 0 for the total eval modules, and the rest in train mode
2. For finetuning, either 0 eval modules or a mix of train and eval (some modules frozen). 

To see which modules are in train/eval mode, the user can look at the summary table or expand it to show all modules using `ModelSummary(max_depth=-1)`.

Example:
```py
import torch
from transformers import BertModel

from lightning.pytorch import LightningModule, Trainer
from torch.utils.data import DataLoader, Dataset


class RandomDataset(Dataset):
    def __init__(self, size, length):
        self.len = length
        self.data = torch.randn(length, size)

    def __getitem__(self, index):
        return self.data[index]

    def __len__(self):
        return self.len


class BoringModel(LightningModule):
    def __init__(self):
        super().__init__()
        self.layer = torch.nn.Linear(32, 2).train()
        self.bert = BertModel.from_pretrained("bert-base-cased", output_attentions=True)
        # self.bert.train()

    def training_step(self, batch, batch_idx):
        return self.layer(batch).sum()

    def configure_optimizers(self):
        return torch.optim.SGD(self.layer.parameters(), lr=0.1)


model = BoringModel()
trainer = Trainer(max_epochs=1)
trainer.fit(model, train_dataloaders=DataLoader(RandomDataset(32, 64)))

```

Output:
```
  | Name  | Type      | Params | Mode 
--------------------------------------------
0 | layer | Linear    | 66     | train
1 | bert  | BertModel | 108 M  | eval 
--------------------------------------------
108 M     Trainable params
0         Non-trainable params
108 M     Total params
433.241   Total estimated model params size (MB)
1         Modules in train mode                               <--- New
228       Modules in eval mode                                <--- New

```
New are the two rows at the bottom that count the modules in train/eval mode.


## Alternatives

#19820 initially proposed to print a warning. However, that would lead to false positives when doing finetuning, and so I opted for the info in the model summary (which is on by default in the Trainer). 


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20159.org.readthedocs.build/en/20159/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @awaelchli