### PR TITLE
Fix parameter count in ModelSummary when parameters are DTensors

### DIFF
--- a/src/lightning/fabric/utilities/distributed.py
+++ b/src/lightning/fabric/utilities/distributed.py
@@ -7,7 +7,7 @@ import time
 from contextlib import nullcontext
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, List, Optional, Sized, Union
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, List, Optional, Sized, Union, TypeGuard
 
 import torch
 import torch.nn.functional as F
@@ -20,6 +20,7 @@ from lightning.fabric.utilities.cloud_io import _is_local_file_protocol
 from lightning.fabric.utilities.data import _num_cpus_available
 from lightning.fabric.utilities.rank_zero import rank_zero_info
 from lightning.fabric.utilities.types import _PATH, ReduceOp
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4
 
 if torch.distributed.is_available():
     from torch.distributed import group
@@ -32,6 +33,7 @@ else:
 if TYPE_CHECKING:
     from lightning.fabric.plugins import ClusterEnvironment
     from lightning.fabric.strategies import Strategy
+    from torch.distributed._tensor import DTensor
 
 
 log = logging.getLogger(__name__)
@@ -427,3 +429,11 @@ class _InfiniteBarrier:
         self.barrier()
         if self.group is not None:
             torch.distributed.destroy_process_group(self.group)
+
+
+def _is_dtensor(tensor: Tensor) -> TypeGuard["DTensor"]:
+    if _TORCH_GREATER_EQUAL_2_4:
+        from torch.distributed._tensor import DTensor
+
+        return isinstance(tensor, DTensor)
+    return False

--- a/src/lightning/fabric/utilities/distributed.py
+++ b/src/lightning/fabric/utilities/distributed.py
@@ -7,14 +7,14 @@ import time
 from contextlib import nullcontext
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, List, Optional, Sized, TypeGuard, Union
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, List, Optional, Sized, Union
 
 import torch
 import torch.nn.functional as F
 from lightning_utilities.core.imports import package_available
 from torch import Tensor
 from torch.utils.data import Dataset, DistributedSampler, Sampler
-from typing_extensions import Self, override
+from typing_extensions import Self, TypeGuard, override
 
 from lightning.fabric.utilities.cloud_io import _is_local_file_protocol
 from lightning.fabric.utilities.data import _num_cpus_available

--- a/src/lightning/fabric/utilities/distributed.py
+++ b/src/lightning/fabric/utilities/distributed.py
@@ -7,7 +7,7 @@ import time
 from contextlib import nullcontext
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, List, Optional, Sized, Union, TypeGuard
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, List, Optional, Sized, TypeGuard, Union
 
 import torch
 import torch.nn.functional as F
@@ -18,9 +18,9 @@ from typing_extensions import Self, override
 
 from lightning.fabric.utilities.cloud_io import _is_local_file_protocol
 from lightning.fabric.utilities.data import _num_cpus_available
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4
 from lightning.fabric.utilities.rank_zero import rank_zero_info
 from lightning.fabric.utilities.types import _PATH, ReduceOp
-from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4
 
 if torch.distributed.is_available():
     from torch.distributed import group
@@ -31,9 +31,10 @@ else:
 
 
 if TYPE_CHECKING:
+    from torch.distributed._tensor import DTensor
+
     from lightning.fabric.plugins import ClusterEnvironment
     from lightning.fabric.strategies import Strategy
-    from torch.distributed._tensor import DTensor
 
 
 log = logging.getLogger(__name__)

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `_LoggerConnector`'s `_ResultMetric` to move all registered keys to the device of the logged value if needed ([#19814](https://github.com/Lightning-AI/pytorch-lightning/issues/19814))
 
+- Fixed parameter counts in `ModelSummary` when model has distributed parameters (DTensor) ([#20163](https://github.com/Lightning-AI/pytorch-lightning/pull/20163))
 
 
 ## [2.3.0] - 2024-06-13

--- a/src/lightning/pytorch/utilities/model_summary/model_summary.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary.py
@@ -472,6 +472,7 @@ def get_human_readable_count(number: int) -> str:
 def _tensor_has_shape(p: Tensor) -> bool:
     from torch.nn.parameter import UninitializedParameter
 
+    # DTensor is a subtype of `UninitializedParameter`, but the shape is known
     if isinstance(p, UninitializedParameter) and not _is_dtensor(p):
         warning_cache.warn(
             "The total number of parameters detected may be inaccurate because the model contains"

--- a/src/lightning/pytorch/utilities/model_summary/model_summary.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary.py
@@ -27,6 +27,7 @@ from torch.utils.hooks import RemovableHandle
 import lightning.pytorch as pl
 from lightning.pytorch.utilities.model_helpers import _ModuleMode
 from lightning.pytorch.utilities.rank_zero import WarningCache
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4
 
 log = logging.getLogger(__name__)
 warning_cache = WarningCache()
@@ -472,6 +473,12 @@ def get_human_readable_count(number: int) -> str:
 
 def _is_lazy_weight_tensor(p: Tensor) -> bool:
     from torch.nn.parameter import UninitializedParameter
+
+    if _TORCH_GREATER_EQUAL_2_4:
+        from torch.distributed._tensor import DTensor
+
+        if isinstance(p, DTensor):
+            return False
 
     if isinstance(p, UninitializedParameter):
         warning_cache.warn(

--- a/src/lightning/pytorch/utilities/model_summary/model_summary_deepspeed.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary_deepspeed.py
@@ -25,7 +25,7 @@ from lightning.pytorch.utilities.model_summary.model_summary import (
     NOT_APPLICABLE,
     LayerSummary,
     ModelSummary,
-    _is_lazy_weight_tensor,
+    _tensor_has_shape,
     get_human_readable_count,
 )
 
@@ -40,7 +40,7 @@ class DeepSpeedLayerSummary(LayerSummary):
     @override
     def num_parameters(self) -> int:
         """Returns the number of parameters in this module."""
-        return sum(deepspeed_param_size(p) if not _is_lazy_weight_tensor(p) else 0 for p in self._module.parameters())
+        return sum(deepspeed_param_size(p) if not _tensor_has_shape(p) else 0 for p in self._module.parameters())
 
     @property
     def average_shard_parameters(self) -> int:
@@ -49,7 +49,7 @@ class DeepSpeedLayerSummary(LayerSummary):
         def partitioned_size(p: Parameter) -> int:
             return p.partitioned_size() if RequirementCache("deepspeed<0.6.6") else p.partition_numel()
 
-        return sum(partitioned_size(p) if not _is_lazy_weight_tensor(p) else 0 for p in self._module.parameters())
+        return sum(partitioned_size(p) if not _tensor_has_shape(p) else 0 for p in self._module.parameters())
 
 
 class DeepSpeedSummary(ModelSummary):
@@ -71,13 +71,13 @@ class DeepSpeedSummary(ModelSummary):
     @property
     @override
     def total_parameters(self) -> int:
-        return sum(deepspeed_param_size(p) if not _is_lazy_weight_tensor(p) else 0 for p in self._model.parameters())
+        return sum(deepspeed_param_size(p) if not _tensor_has_shape(p) else 0 for p in self._model.parameters())
 
     @property
     @override
     def trainable_parameters(self) -> int:
         return sum(
-            deepspeed_param_size(p) if not _is_lazy_weight_tensor(p) else 0
+            deepspeed_param_size(p) if not _tensor_has_shape(p) else 0
             for p in self._model.parameters()
             if p.requires_grad
         )

--- a/tests/tests_fabric/utilities/test_distributed.py
+++ b/tests/tests_fabric/utilities/test_distributed.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock
 
+import lightning.fabric
 import pytest
 import torch
-import lightning.fabric
 from lightning.fabric.accelerators import CPUAccelerator, CUDAAccelerator, MPSAccelerator
 from lightning.fabric.plugins.environments import LightningEnvironment
 from lightning.fabric.strategies import DDPStrategy, SingleDeviceStrategy
@@ -17,11 +17,11 @@ from lightning.fabric.utilities.distributed import (
     _gather_all_tensors,
     _InfiniteBarrier,
     _init_dist_connection,
+    _is_dtensor,
     _set_num_threads_if_needed,
     _suggested_max_num_threads,
     _sync_ddp,
     is_shared_filesystem,
-    _is_dtensor,
 )
 from lightning_utilities.core.imports import RequirementCache
 

--- a/tests/tests_pytorch/utilities/test_model_summary.py
+++ b/tests/tests_pytorch/utilities/test_model_summary.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from collections import OrderedDict
 from typing import Any
+from unittest import mock
+from unittest.mock import Mock, MagicMock
 
 import pytest
 import torch
@@ -119,6 +121,18 @@ class LazyModel(LightningModule):
 
     def forward(self, inp):
         return self.layer2(self.layer1(inp))
+
+
+# class FakeDTensorModel(LightningModule):
+#     """A model which contains DTensor parameters."""
+#
+#     def __init__(self):
+#         super().__init__()
+#         from torch.distributed._tensor import DTensor
+#         # self.parameter = nn.Parameter(DTensor.from_local(torch.rand(2, 2)))
+#
+#         self.parameter = MagicMock(wraps=nn.Parameter, spec=DTensor)(torch.rand(2, 2))
+#         assert isinstance(self.parameter, DTensor)
 
 
 class DeepNestedModel(LightningModule):
@@ -343,6 +357,18 @@ def test_lazy_model_summary():
     with pytest.warns(UserWarning, match="The total number of parameters detected may be inaccurate."):
         assert summary.total_parameters == 0
         assert summary.trainable_parameters == 0
+
+
+@mock.patch("lightning.pytorch.utilities.model_summary.model_summary._is_dtensor", return_value=True)
+def test_dtensor_model_summary(_):
+    """Test that the model summary can work with layers that have DTensor parameters."""
+    # We mock the `_is_dtensor` to pretend parameters are DTensors, because testing with real DTensors
+    # would require setting up distributed
+    dtensor_model = UnorderedModel()
+    summary = ModelSummary(dtensor_model)
+    assert summary.total_layer_params > 0
+    assert summary.total_parameters > 0
+    assert summary.trainable_parameters > 0
 
 
 @pytest.mark.parametrize("max_depth", [-1, 0, 1, 3, 999])

--- a/tests/tests_pytorch/utilities/test_model_summary.py
+++ b/tests/tests_pytorch/utilities/test_model_summary.py
@@ -14,7 +14,6 @@
 from collections import OrderedDict
 from typing import Any
 from unittest import mock
-from unittest.mock import Mock, MagicMock
 
 import pytest
 import torch

--- a/tests/tests_pytorch/utilities/test_model_summary.py
+++ b/tests/tests_pytorch/utilities/test_model_summary.py
@@ -122,18 +122,6 @@ class LazyModel(LightningModule):
         return self.layer2(self.layer1(inp))
 
 
-# class FakeDTensorModel(LightningModule):
-#     """A model which contains DTensor parameters."""
-#
-#     def __init__(self):
-#         super().__init__()
-#         from torch.distributed._tensor import DTensor
-#         # self.parameter = nn.Parameter(DTensor.from_local(torch.rand(2, 2)))
-#
-#         self.parameter = MagicMock(wraps=nn.Parameter, spec=DTensor)(torch.rand(2, 2))
-#         assert isinstance(self.parameter, DTensor)
-
-
 class DeepNestedModel(LightningModule):
     """A model with deep nested layers."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes #20151

Running 
```bash
python examples/pytorch/tensor_parallel/train.py
```

Before:
```
  | Name  | Type            | Params | Mode 
--------------------------------------------------
0 | model | FSDPTransformer | 0      | train
--------------------------------------------------
0         Trainable params
0         Non-trainable params
0         Total params
0.000     Total estimated model params size (MB)
421       Modules in train mode
0         Modules in eval mode
```
(shows 0 parameters)

After:
```
  | Name  | Type            | Params | Mode 
--------------------------------------------------
0 | model | FSDPTransformer | 6.7 B  | train
--------------------------------------------------
6.7 B     Trainable params
0         Non-trainable params
6.7 B     Total params
26,953.662Total estimated model params size (MB)
421       Modules in train mode
0         Modules in eval mode
```
(shows correct counts)

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20163.org.readthedocs.build/en/20163/

<!-- readthedocs-preview pytorch-lightning end -->

cc @carmocca @justusschock @awaelchli