### PR TITLE
a bit more lazy load functionality

### DIFF
--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -141,7 +141,7 @@ class _NotYetLoadedTensor:
         return func(*loaded_args, **kwargs)
 
     @property
-    def device(self):
+    def device(self) -> torch.device:
         return torch.device(self.storageinfo[3])
 
     def __getattr__(self, name: str) -> Any:

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -140,6 +140,10 @@ class _NotYetLoadedTensor:
         loaded_args = [(arg._load_tensor() if isinstance(arg, _NotYetLoadedTensor) else arg) for arg in args]
         return func(*loaded_args, **kwargs)
 
+    @property
+    def device(self):
+        return torch.device(self.storageinfo[3])
+
     def __getattr__(self, name: str) -> Any:
         # These properties don't require materialization and can be accessed through the meta tensor directly
         if name in {
@@ -160,7 +164,7 @@ class _NotYetLoadedTensor:
             return getattr(self.metatensor, name)
 
         # materializing these is needed for quantization (see lit-gpt)
-        if name in {"contiguous", "cuda", "half", "data"}:
+        if name in {"contiguous", "cuda", "half", "data", "to"}:
             return getattr(self._load_tensor(), name)
 
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")

--- a/tests/tests_fabric/utilities/test_load.py
+++ b/tests/tests_fabric/utilities/test_load.py
@@ -31,6 +31,8 @@ def test_lazy_load_module(tmp_path):
     model1.load_state_dict(checkpoint)
 
     assert isinstance(checkpoint["weight"], _NotYetLoadedTensor)
+    assert checkpoint["weight"].device == torch.device("cpu")
+    assert type(checkpoint["weight"].to("cpu")) is torch.Tensor
     assert type(model0.weight.data) is torch.Tensor
     assert torch.equal(model0.weight, model1.weight)
     assert torch.equal(model0.bias, model1.bias)


### PR DESCRIPTION
This adds the .device property and the method .to to NotYetLoaded tensors produced by lazy loading.

The  two would be convenient to have for Thunder.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20183.org.readthedocs.build/en/20183/

<!-- readthedocs-preview pytorch-lightning end -->