### PR TITLE
Add documentation note for TQDMProgressBar

### DIFF
--- a/docs/source-pytorch/common/progress_bar.rst
+++ b/docs/source-pytorch/common/progress_bar.rst
@@ -36,6 +36,10 @@ You can update ``refresh_rate`` (rate (number of batches) at which the progress 
 
     trainer = Trainer(callbacks=[TQDMProgressBar(refresh_rate=10)])
 
+.. note:: 
+
+    The ``smoothing`` option has no effect when using the default implementation of :class:`~lightning.pytorch.callbacks.TQDMProgressBar`, as the progress bar is updated using the ``bar.refresh()`` method instead of ``bar.update()``. This can cause the progress bar to become desynchronized with the actual progress. To avoid this issue, you can use the ``bar.update()`` method instead, but this may require customizing the :class:`~lightning.pytorch.callbacks.TQDMProgressBar` class.
+    
 By default the training progress bar is reset (overwritten) at each new epoch.
 If you wish for a new progress bar to be displayed at the end of every epoch, set
 :paramref:`TQDMProgressBar.leave <lightning.pytorch.callbacks.TQDMProgressBar.leave>` to ``True``.


### PR DESCRIPTION
## What does this PR do?

This PR adds a note to the documentation of TQDMProgressBar to clarify the behavior of the smoothing option. The note explains that the smoothing option has no effect when using the default implementation of TQDMProgressBar and suggests a possible solution.

Fixes #20003 


- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs) -> Yes, discussed in issue #20003 
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?    
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?  
- Did you make sure to **update the documentation** with your changes? (if necessary).  -> Yes
- Did you write any **new necessary tests**? (not for typos and docs).  -> No
- [x] Did you verify new and **existing tests pass** locally with your changes?    
- Did you list all the **breaking changes** introduced by this pull request?   -> No
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors). -> Yes

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
