### PR TITLE
docs: fix pytorch version typo in upgrade/from_2_0

### DIFF
--- a/docs/source-pytorch/upgrade/sections/2_0_regular.rst
+++ b/docs/source-pytorch/upgrade/sections/2_0_regular.rst
@@ -6,7 +6,7 @@
      - Then
      - Ref
 
-   * - used PyTorch 3.11
+   * - used PyTorch 1.11
      - upgrade to PyTorch 2.1 or higher
      - `PR18691`_
 


### PR DESCRIPTION
## What does this PR do?

Fix pytorch version typo: PyTorch 3.11 -> PyTorch 1.11


<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20333.org.readthedocs.build/en/20333/

<!-- readthedocs-preview pytorch-lightning end -->