### PR TITLE
docs: Bump HPU ref `1.7.0.rc0`

### DIFF
--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -90,7 +90,7 @@ _transform_changelog(
 assist_local.AssistantCLI.pull_docs_files(
     gh_user_repo="Lightning-AI/lightning-Habana",
     target_dir="docs/source-pytorch/integrations/hpu",
-    checkout="refs/tags/1.6.0",
+    checkout="1.7.0.rc0",
 )
 # the HPU also need some images
 URL_RAW_DOCS_HABANA = "https://raw.githubusercontent.com/Lightning-AI/lightning-Habana/1.5.0/docs/source"


### PR DESCRIPTION
**This is automated update with the latest HPU
  [release](https://github.com/Lightning-AI/lightning-habana/releases/tag/1.7.0.rc0)!**

Go to `docs/source-pytorch/conf.py` and find section `assist_local.AssistantCLI.pull_docs_files(...` for Habana and bump the reference to `1.7.0.rc0`
Please, proceed with this update in timely manner...

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20345.org.readthedocs.build/en/20345/

<!-- readthedocs-preview pytorch-lightning end -->