### PR TITLE
Reference `PL_GLOBAL_SEED` in `pl_worker_init_function()` to correctly seed dataloader workers

### DIFF
--- a/src/lightning/fabric/utilities/seed.py
+++ b/src/lightning/fabric/utilities/seed.py
@@ -91,8 +91,9 @@ def pl_worker_init_function(worker_id: int, rank: Optional[int] = None) -> None:
 
     """
     # implementation notes: https://github.com/pytorch/pytorch/issues/5059#issuecomment-817392562
+    assert "PL_GLOBAL_SEED" in os.environ, "`seed_everything(seed, workers=True)` must be called before training to use this function."
     global_rank = rank if rank is not None else rank_zero_only.rank
-    process_seed = torch.initial_seed()
+    process_seed = int(os.environ["PL_GLOBAL_SEED"])
     # back out the base seed so we can use all the bits
     base_seed = process_seed - worker_id
     log.debug(


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the value for `PL_GLOBAL_SEED` set by `seed_everything()` would not be referenced in `pl_worker_init_function()`. This could cause multi-process dataloader workers to not change their random state based on a user's desired seed set via `seed_everything()` before training. In other words, if users were relying on `seed_everything()` to change e.g., the order of the indices sampled by each dataloader worker, this would not work until now.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
