### PR TITLE
Register batch complete progress before batch_end hooks

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [2.5.0] - 
+
+### Added
+
+### Changed
+
+- `batch_progress.increment_completed()` is now called right prior to `on_train_batch_end`, `on_validation_batch_end`, and `on_predict_batch_end` to ensure hooks see up-to-date progress information about the completed batch and avoid skews during restarts ([]())
+
+### Removed
+
+### Fixed
+
 
 ## [2.4.0] - 2024-08-06
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [2.5.0] - 
+## [2.5.0] -
 
 ### Added
 

--- a/src/lightning/pytorch/loops/evaluation_loop.py
+++ b/src/lightning/pytorch/loops/evaluation_loop.py
@@ -410,9 +410,9 @@ class _EvaluationLoop(_Loop):
         call._call_callback_hooks(trainer, hook_name, output, *hook_kwargs.values())
         call._call_lightning_module_hook(trainer, hook_name, output, *hook_kwargs.values())
 
-        trainer._logger_connector.on_batch_end()
-
         self.batch_progress.increment_completed()
+
+        trainer._logger_connector.on_batch_end()
 
         if not trainer.sanity_checking:
             # indicate the loop has run

--- a/src/lightning/pytorch/loops/prediction_loop.py
+++ b/src/lightning/pytorch/loops/prediction_loop.py
@@ -263,10 +263,10 @@ class _PredictionLoop(_Loop):
             dataloader_idx = data_fetcher._dataloader_idx
             hook_kwargs = self._build_kwargs(batch, batch_idx, dataloader_idx if self.num_dataloaders > 1 else None)
 
+        self.batch_progress.increment_completed()
+
         call._call_callback_hooks(trainer, "on_predict_batch_end", predictions, *hook_kwargs.values())
         call._call_lightning_module_hook(trainer, "on_predict_batch_end", predictions, *hook_kwargs.values())
-
-        self.batch_progress.increment_completed()
 
         if self._return_predictions or any_on_epoch:
             self._predictions[dataloader_idx].append(move_data_to_device(predictions, torch.device("cpu")))

--- a/src/lightning/pytorch/loops/training_epoch_loop.py
+++ b/src/lightning/pytorch/loops/training_epoch_loop.py
@@ -270,6 +270,10 @@ class _TrainingEpochLoop(loops._Loop):
         # failure to do this will lead to incorrect total batch completed progress counts
         self.batch_progress.increment_completed()
 
+        if not self._should_accumulate():
+            # this is increased once per batch disregarding multiple optimizers on purpose for loggers
+            self._batches_that_stepped += 1
+
         call._call_callback_hooks(trainer, "on_train_batch_end", batch_output, batch, batch_idx)
         call._call_lightning_module_hook(trainer, "on_train_batch_end", batch_output, batch, batch_idx)
         trainer._logger_connector.on_batch_end()
@@ -301,9 +305,6 @@ class _TrainingEpochLoop(loops._Loop):
         # update plateau LR scheduler after metrics are logged
         self.update_lr_schedulers("step", update_plateau_schedulers=True)
 
-        if not self._should_accumulate():
-            # this is increased once per batch disregarding multiple optimizers on purpose for loggers
-            self._batches_that_stepped += 1
         # this will save based on the `batches_that_stepped` value
         self._save_loggers_on_train_batch_end()
 

--- a/src/lightning/pytorch/loops/training_epoch_loop.py
+++ b/src/lightning/pytorch/loops/training_epoch_loop.py
@@ -266,11 +266,13 @@ class _TrainingEpochLoop(loops._Loop):
             # update `is_last_batch` again after dataloader_iter was fetched in `training_step()`
             self.batch_progress.is_last_batch = data_fetcher.done
 
+        # we increment prior to on_batch_end so checkpoints can see progress correctly
+        # failure to do this will lead to incorrect restarts
+        self.batch_progress.increment_completed()
+
         call._call_callback_hooks(trainer, "on_train_batch_end", batch_output, batch, batch_idx)
         call._call_lightning_module_hook(trainer, "on_train_batch_end", batch_output, batch, batch_idx)
         trainer._logger_connector.on_batch_end()
-
-        self.batch_progress.increment_completed()
 
         # -----------------------------------------
         # SAVE METRICS TO LOGGERS AND PROGRESS_BAR

--- a/src/lightning/pytorch/loops/training_epoch_loop.py
+++ b/src/lightning/pytorch/loops/training_epoch_loop.py
@@ -267,7 +267,7 @@ class _TrainingEpochLoop(loops._Loop):
             self.batch_progress.is_last_batch = data_fetcher.done
 
         # we increment prior to on_batch_end so checkpoints can see progress correctly
-        # failure to do this will lead to incorrect restarts
+        # failure to do this will lead to incorrect total batch completed progress counts
         self.batch_progress.increment_completed()
 
         call._call_callback_hooks(trainer, "on_train_batch_end", batch_output, batch, batch_idx)

--- a/tests/tests_pytorch/loops/test_loops.py
+++ b/tests/tests_pytorch/loops/test_loops.py
@@ -571,7 +571,6 @@ def test_fit_loop_reset(tmp_path):
     assert epoch_loop.batch_progress.total.ready == 2
     assert epoch_loop.batch_progress.total.processed == 2
     assert epoch_loop.batch_progress.total.completed == 2  # the checkpoint was saved on train_batch_end
-                                                           # this used to be 1 but progress is now recorded before train_batch_end
     assert epoch_loop.batch_progress.current.ready == 2  # currents get set to the completed value
     assert epoch_loop.batch_progress.current.processed == 2
     assert epoch_loop.batch_progress.current.completed == 2

--- a/tests/tests_pytorch/loops/test_loops.py
+++ b/tests/tests_pytorch/loops/test_loops.py
@@ -575,6 +575,8 @@ def test_fit_loop_reset(tmp_path):
     assert epoch_loop.batch_progress.current.processed == 2
     assert epoch_loop.batch_progress.current.completed == 2
 
+    assert epoch_loop._batches_that_stepped == 2
+
     assert optimizer_loop.restarting
 
     # reset state loaded from a checkpoint from the end of an epoch
@@ -604,6 +606,8 @@ def test_fit_loop_reset(tmp_path):
     assert epoch_loop.batch_progress.current.ready == 4  # currents get set to the completed value
     assert epoch_loop.batch_progress.current.processed == 4
     assert epoch_loop.batch_progress.current.completed == 4
+
+    assert epoch_loop._batches_that_stepped == 4
 
 
 @pytest.mark.parametrize(

--- a/tests/tests_pytorch/loops/test_loops.py
+++ b/tests/tests_pytorch/loops/test_loops.py
@@ -570,10 +570,11 @@ def test_fit_loop_reset(tmp_path):
     assert epoch_loop.restarting
     assert epoch_loop.batch_progress.total.ready == 2
     assert epoch_loop.batch_progress.total.processed == 2
-    assert epoch_loop.batch_progress.total.completed == 1  # the checkpoint was saved on train_batch_end
-    assert epoch_loop.batch_progress.current.ready == 1  # currents get set to the completed value
-    assert epoch_loop.batch_progress.current.processed == 1
-    assert epoch_loop.batch_progress.current.completed == 1
+    assert epoch_loop.batch_progress.total.completed == 2  # the checkpoint was saved on train_batch_end
+                                                           # this used to be 1 but progress is now recorded before train_batch_end
+    assert epoch_loop.batch_progress.current.ready == 2  # currents get set to the completed value
+    assert epoch_loop.batch_progress.current.processed == 2
+    assert epoch_loop.batch_progress.current.completed == 2
 
     assert optimizer_loop.restarting
 
@@ -600,10 +601,10 @@ def test_fit_loop_reset(tmp_path):
     assert epoch_loop.restarting
     assert epoch_loop.batch_progress.total.ready == 4
     assert epoch_loop.batch_progress.total.processed == 4
-    assert epoch_loop.batch_progress.total.completed == 3  # the checkpoint was saved on train_batch_end
-    assert epoch_loop.batch_progress.current.ready == 3  # currents get set to the completed value
-    assert epoch_loop.batch_progress.current.processed == 3
-    assert epoch_loop.batch_progress.current.completed == 3
+    assert epoch_loop.batch_progress.total.completed == 4  # the checkpoint was saved on train_batch_end
+    assert epoch_loop.batch_progress.current.ready == 4  # currents get set to the completed value
+    assert epoch_loop.batch_progress.current.processed == 4
+    assert epoch_loop.batch_progress.current.completed == 4
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Fixes #14579

The following code

```python
import torch
from torch.utils.data import DataLoader, Dataset
 
import lightning as L
from lightning.pytorch.callbacks import ModelCheckpoint

 
class RandomDataset(Dataset):
   def __init__(self, size, length):
       self.len = length
       self.data = torch.randn(length, size)
 
   def __getitem__(self, index):
       return self.data[index]
 
   def __len__(self):
       return self.len
 
 
class BoringModel(L.LightningModule):
   def __init__(self):
       super().__init__()
       self.layer = torch.nn.Linear(32, 2)
 
   def forward(self, x):
       return self.layer(x)
 
   def training_step(self, batch, batch_idx):
       loss = self(batch).sum()
       return {"loss": loss}
 
   def configure_optimizers(self):
       return torch.optim.SGD(self.layer.parameters(), lr=0.1)

 
train_data = DataLoader(RandomDataset(32, 24), batch_size=2)
 
model = BoringModel()

trainer = L.Trainer(
   default_root_dir=".",
   max_steps=10,
   enable_model_summary=False,
   accelerator="cpu",
   callbacks=ModelCheckpoint(dirpath="./lightning_logs/checkpoints", save_last=True, save_top_k=-1, every_n_train_steps=10),
)
trainer.fit(model, train_data)

trainer = L.Trainer(
   default_root_dir=".",
   max_steps=20,
   enable_model_summary=False,
   accelerator="cpu",
   callbacks=ModelCheckpoint(dirpath="./lightning_logs/checkpoints", save_last=True, save_top_k=-1, every_n_train_steps=10),
)
trainer.fit(model, train_data, ckpt_path='last')
```

will produce skewed progress information in the checkpoints, compared to the case where there is no restart.

This is due to the fact that when `ModelCheckpoint` is triggered on `on_train_batch_end`, it won't see `batch_progress.total.completed` updated to the latest batch that was processed, because progress is updated right after the hook is called.

However, upon restart, there won't be any opportunity to register the actual completion of the batch, causing a skew that is proportional to the number of restarts. This impacts the time at which validation is called, which itself becomes dependent from restarts.

This PR addresses this issue by first updating batch progress and then calling batch_end hooks. 

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20376.org.readthedocs.build/en/20376/

<!-- readthedocs-preview pytorch-lightning end -->