### PR TITLE
Pin setuptools in release container

### DIFF
--- a/dockers/release/Dockerfile
+++ b/dockers/release/Dockerfile
@@ -39,7 +39,7 @@ RUN \
     fi && \
     # otherwise there is collision with folder name and pkg name on Pypi
     cd pytorch-lightning && \
-    pip install setuptools && \
+    pip install setuptools==75.6.0 && \
     PACKAGE_NAME=lightning pip install '.[extra,loggers,strategies]' --no-cache-dir && \
     PACKAGE_NAME=pytorch pip install '.[extra,loggers,strategies]' --no-cache-dir && \
     cd .. && \


### PR DESCRIPTION
Module `pkg_resources` has been removed in Python 3.12, this produces

```
Traceback (most recent call last):
  File "/__w/13/s/requirements/collect_env_details.py", line 24, in <module>
    import pkg_resources
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2172, in <module>
    register_finder(pkgutil.ImpImporter, find_on_path)
                    ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
```

This PR pins `setuptools` in the release Docker image, which now provides `pkg_resources`.
Moving forward we'll need to migrate away from it but not today.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20488.org.readthedocs.build/en/20488/

<!-- readthedocs-preview pytorch-lightning end -->