### PR TITLE
Pin setuptools in GPU tests

### DIFF
--- a/.azure/gpu-benchmarks.yml
+++ b/.azure/gpu-benchmarks.yml
@@ -75,7 +75,9 @@ jobs:
           pip list
         displayName: "Image info & NVIDIA"
 
-      - bash: pip install -e .[dev] --find-links ${TORCH_URL}
+      - bash: |
+          pip install -e .[dev] --find-links ${TORCH_URL}
+          pip install setuptools==75.6.0
         env:
           FREEZE_REQUIREMENTS: "1"
         displayName: "Install package"

--- a/.azure/gpu-tests-fabric.yml
+++ b/.azure/gpu-tests-fabric.yml
@@ -107,6 +107,7 @@ jobs:
       - bash: |
           extra=$(python -c "print({'lightning': 'fabric-'}.get('$(PACKAGE_NAME)', ''))")
           pip install -e ".[${extra}dev]" pytest-timeout -U --find-links="${TORCH_URL}" --find-links="${TORCHVISION_URL}"
+          pip install setuptools==75.6.0
         displayName: "Install package & dependencies"
 
       - bash: |

--- a/.azure/gpu-tests-pytorch.yml
+++ b/.azure/gpu-tests-pytorch.yml
@@ -111,6 +111,7 @@ jobs:
       - bash: |
           extra=$(python -c "print({'lightning': 'pytorch-'}.get('$(PACKAGE_NAME)', ''))")
           pip install -e ".[${extra}dev]" pytest-timeout -U --find-links="${TORCH_URL}" --find-links="${TORCHVISION_URL}"
+          pip install setuptools==75.6.0
         displayName: "Install package & dependencies"
 
       - bash: pip uninstall -y lightning

--- a/docs/source-pytorch/common/index.rst
+++ b/docs/source-pytorch/common/index.rst
@@ -23,6 +23,7 @@
    ../data/data
    ../model/own_your_loop
    ../advanced/model_init
+   ../common/tbptt
 
 
 #############
@@ -205,7 +206,7 @@ How-to Guides
 .. displayitem::
     :header: Truncated Back-Propagation Through Time
     :description: Efficiently step through time when training recurrent models
-    :button_link: ../common/tbtt.html
+    :button_link: ../common/tbptt.html
     :col_css: col-md-4
     :height: 180
 


### PR DESCRIPTION
## What does this PR do?

This PR makes CI green by:

- pinning `setuptools` in GPU tests, similar to #20488
- fixing doc references

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20489.org.readthedocs.build/en/20489/

<!-- readthedocs-preview pytorch-lightning end -->