### PR TITLE
Allow batch sampler to not have a .sampler attribute

### DIFF
--- a/src/lightning/pytorch/utilities/data.py
+++ b/src/lightning/pytorch/utilities/data.py
@@ -351,7 +351,11 @@ def _is_dataloader_shuffled(dataloader: object) -> bool:
         # shuffling is enabled via a sampler. No sampler, no shuffling
         return False
     batch_sampler = dataloader.batch_sampler
-    sampler = batch_sampler.sampler if batch_sampler is not None else dataloader.sampler
+    if batch_sampler is not None:
+        # custom batch samplers may not have an internal .sampler
+        sampler = batch_sampler.sampler if hasattr(batch_sampler, "sampler") else batch_sampler
+    else:
+        sampler = dataloader.sampler
     if isinstance(sampler, SequentialSampler):
         return False
     return isinstance(sampler, RandomSampler)


### PR DESCRIPTION
## What does this PR do?

This PR fixes potential compatibility issues of the fix in #20327 with codebases like NeMo that use batch samplers that are not derived from PyTorch's `BatchSampler` and do not have a `.sampler` attriubute

https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/multimodal/models/multimodal_llm/neva/neva_model.py#L1438


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20514.org.readthedocs.build/en/20514/

<!-- readthedocs-preview pytorch-lightning end -->