### PR TITLE
Error when logging to MLFlow deleted experiment

### DIFF
--- a/src/lightning/pytorch/loggers/mlflow.py
+++ b/src/lightning/pytorch/loggers/mlflow.py
@@ -178,7 +178,7 @@ class MLFlowLogger(Logger):
 
         if self._experiment_id is None:
             expt = self._mlflow_client.get_experiment_by_name(self._experiment_name)
-            if expt is not None:
+            if expt is not None and expt.lifecycle_stage != 'deleted':
                 self._experiment_id = expt.experiment_id
             else:
                 log.warning(f"Experiment with name {self._experiment_name} not found. Creating it.")

--- a/src/lightning/pytorch/loggers/mlflow.py
+++ b/src/lightning/pytorch/loggers/mlflow.py
@@ -178,7 +178,7 @@ class MLFlowLogger(Logger):
 
         if self._experiment_id is None:
             expt = self._mlflow_client.get_experiment_by_name(self._experiment_name)
-            if expt is not None and expt.lifecycle_stage != 'deleted':
+            if expt is not None and expt.lifecycle_stage != "deleted":
                 self._experiment_id = expt.experiment_id
             else:
                 log.warning(f"Experiment with name {self._experiment_name} not found. Creating it.")


### PR DESCRIPTION
## What does this PR do?


Addresses issue #20555.

When logging to an MLFlow experiment name that has been deleted (e.g. deleted from the MLFlow UI), the MLFlow experiment still exists in the backend, so `expt = self._mlflow_client.get_experiment_by_name(self._experiment_name)` retrieves it and Lightning proceeds as if the experiment already exists.  When Lightning actually tries to log to the experiment, it stalls as MLFlow returns many 500 errors. Eventually it times out and the program crashes.

This PR simply modifies the check to ensure that the run exists **and also is not deleted**. This will cause the experiment creation to fail, but with an error message that explicitly states that it cannot be created because there is a deleted experiment with the same name.

This could be handled differently to not crash the run (e.g. increment the experiment name by post-pending _1, _2, etc.) but I think the explicit failure with a clear message is my preferred behaviour.

Fixes #20555>




<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20556.org.readthedocs.build/en/20556/

<!-- readthedocs-preview pytorch-lightning end -->