### PR TITLE
Update twine to 6.0.1 for Python 3.13

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,7 +1,7 @@
 setuptools <70.1.1
 wheel <0.44.0
 awscli >=1.30.0, <1.31.0
-twine ==4.0.1
+twine ==6.1.0
 importlib-metadata <8.0.0
 wget
 packaging <24.2

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,7 +1,7 @@
 setuptools <70.1.1
 wheel <0.44.0
 awscli >=1.30.0, <1.31.0
-twine ==6.1.0
+twine ==6.0.1
 importlib-metadata <8.0.0
 wget
 pkginfo ==1.12.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,4 +4,5 @@ awscli >=1.30.0, <1.31.0
 twine ==6.1.0
 importlib-metadata <8.0.0
 wget
+pkginfo ==1.12.0
 packaging <24.2


### PR DESCRIPTION
## What does this PR do?

Python 3.13 removed `cgi` from its modules, `twine` `4.0.1` depended on it, which broke CI for 3.13.

This PR upgrades `twine` to `6.0.1` which dropped its dependence on `cgi`.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20570.org.readthedocs.build/en/20570/

<!-- readthedocs-preview pytorch-lightning end -->