### PR TITLE
test: flaky terminated with signal SIGABRT

### DIFF
--- a/tests/tests_pytorch/core/test_results.py
+++ b/tests/tests_pytorch/core/test_results.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from functools import partial
 
+import pytest
 import torch
 import torch.distributed as dist
 
@@ -48,6 +49,8 @@ def result_reduce_ddp_fn(strategy):
     assert actual.item() == dist.get_world_size()
 
 
+# flaky with "process 0 terminated with signal SIGABRT"
+@pytest.mark.flaky(reruns=3, only_rerun="torch.multiprocessing.spawn.ProcessExitedException")
 @RunIf(skip_windows=True)
 def test_result_reduce_ddp():
     spawn_launch(result_reduce_ddp_fn, [torch.device("cpu")] * 2)


### PR DESCRIPTION
## What does this PR do?


Fixes #20620 


The test **`tests/tests_pytorch/core/test_results.py::test_result_reduce_ddp`** fails intermittently, similar to the test addressed in [#20537](https://github.com/Lightning-AI/pytorch-lightning/pull/20537), with the error:  

> `torch.multiprocessing.spawn.ProcessExitedException: process 0 terminated with signal SIGABRT`  


To address this, the test could be marked **flaky**.  

### **Background**  
We are evaluating how our tool for **test prioritization** could find test failures faster in your project. During a CI rerun for commit `7322d63bef2cf1a0439f8b19b545cd4a89da62b0`, we encountered the failure of this test, which you can see in this log: [GitHub Actions Log](https://github.com/syncpr-user1/pytorch-lightning-random_order/actions/runs/13600237309/job/38024923746).


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this **discussed/agreed** via a GitHub issue?
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you verify new and **existing tests pass** locally with your changes?

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20621.org.readthedocs.build/en/20621/

<!-- readthedocs-preview pytorch-lightning end -->