### PR TITLE
Improve performance of available_accelerators by returning a set

### DIFF
--- a/src/lightning/fabric/accelerators/registry.py
+++ b/src/lightning/fabric/accelerators/registry.py
@@ -107,9 +107,9 @@ class _AcceleratorRegistry(dict):
         """Removes the registered accelerator by name."""
         self.pop(name)
 
-    def available_accelerators(self) -> list[str]:
-        """Returns a list of registered accelerators."""
-        return list(self.keys())
+    def available_accelerators(self) -> set[str]:
+        """Returns a set of registered accelerators."""
+        return set(self.keys())
 
     def __str__(self) -> str:
         return "Registered Accelerators: {}".format(", ".join(self.available_accelerators()))

--- a/tests/tests_fabric/accelerators/test_registry.py
+++ b/tests/tests_fabric/accelerators/test_registry.py
@@ -70,4 +70,4 @@ def test_accelerator_registry_with_new_accelerator():
 
 
 def test_available_accelerators_in_registry():
-    assert ACCELERATOR_REGISTRY.available_accelerators() == ["cpu", "cuda", "mps", "tpu"]
+    assert ACCELERATOR_REGISTRY.available_accelerators() == {"cpu", "cuda", "mps", "tpu"}

--- a/tests/tests_pytorch/accelerators/test_registry.py
+++ b/tests/tests_pytorch/accelerators/test_registry.py
@@ -16,7 +16,7 @@ from lightning.pytorch.accelerators import AcceleratorRegistry
 
 def test_available_accelerators_in_registry():
     """Tests the accelerators available by default, not including external, third-party accelerators."""
-    available = set(AcceleratorRegistry.available_accelerators())
+    available = AcceleratorRegistry.available_accelerators()
     expected = {"cpu", "cuda", "mps", "tpu"}
     # Note: the registry is global, other tests may register new strategies as a side effect
     assert expected.issubset(available)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

This PR updates available_accelerators to return a set instead of a list, improving performance for membership checks.

Using a `set` makes membership checks more efficient, reducing time complexity from O(n) to O(1) on average. This change enhances performance while maintaining functionality.

Fixes #20671

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20672.org.readthedocs.build/en/20672/

<!-- readthedocs-preview pytorch-lightning end -->