### PR TITLE
drop duplicated `torchmetrics` requirement from Fabric's testing

### DIFF
--- a/requirements/fabric/test.txt
+++ b/requirements/fabric/test.txt
@@ -7,4 +7,3 @@ pytest-rerunfailures ==12.0
 pytest-random-order ==1.1.0
 click ==8.1.7
 tensorboardX >=2.2, <2.7.0  # min version is set by torch.onnx missing attribute
-torchmetrics >=0.7.0, <1.5.0 # needed for using fixed compare_version

--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -5,7 +5,7 @@ torch >=2.1.0, <2.6.0
 tqdm >=4.57.0, <4.67.0
 PyYAML >=5.4, <6.1.0
 fsspec[http] >=2022.5.0, <2024.4.0
-torchmetrics >=0.7.0, <1.5.0  # needed for using fixed compare_version
+torchmetrics >=0.7.0, <1.5.0
 packaging >=20.0, <=23.1
 typing-extensions >=4.4.0, <4.11.0
 lightning-utilities >=0.10.0, <0.12.0

--- a/src/lightning/fabric/utilities/spike.py
+++ b/src/lightning/fabric/utilities/spike.py
@@ -52,7 +52,7 @@ class SpikeDetection:
             from torchmetrics.aggregation import MeanMetric
             from torchmetrics.wrappers import Running
         else:
-            raise RuntimeError("SpikeDetection requires torchmetrics>=1.0.0! Please upgrade your version!")
+            raise RuntimeError("SpikeDetection requires `torchmetrics>=1.0.0` Please upgrade your version.")
         super().__init__()
 
         self.last_val: Union[torch.Tensor, float] = 0.0


### PR DESCRIPTION
## What does this PR do?

make the Fabric lighter

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20675.org.readthedocs.build/en/20675/

<!-- readthedocs-preview pytorch-lightning end -->