### PR TITLE
docs(LightningModule): update docs for `.training` mode in loops

### DIFF
--- a/docs/source-pytorch/common/lightning_module.rst
+++ b/docs/source-pytorch/common/lightning_module.rst
@@ -286,6 +286,9 @@ Under the hood, Lightning does the following (pseudocode):
         # ...
 
         if validate_at_some_point:
+            # capture .training mode of every submodule
+            capture_training_mode()
+
             # disable grads + batchnorm + dropout
             torch.set_grad_enabled(False)
             model.eval()
@@ -295,9 +298,11 @@ Under the hood, Lightning does the following (pseudocode):
                 val_out = model.validation_step(val_batch, val_batch_idx)
             # ----------------- VAL LOOP ---------------
 
-            # enable grads + batchnorm + dropout
+            # enable grads
             torch.set_grad_enabled(True)
-            model.train()
+
+            # restore .training mode of every submodule
+            restore_training_mode()
 
 You can also run just the validation loop on your validation dataloaders by overriding :meth:`~lightning.pytorch.core.LightningModule.validation_step`
 and calling :meth:`~lightning.pytorch.trainer.trainer.Trainer.validate`.
@@ -368,7 +373,7 @@ The only difference is that the test loop is only called when :meth:`~lightning.
     trainer = L.Trainer()
     trainer.fit(model=model, train_dataloaders=dataloader)
 
-    # automatically loads the best weights for you
+    # use the current weights
     trainer.test(model)
 
 There are two ways to call ``test()``:

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -814,9 +814,10 @@ class LightningModule(
             If you don't need to validate you don't need to implement this method.
 
         Note:
-            When the :meth:`validation_step` is called, the model has been put in eval mode
-            and PyTorch gradients have been disabled. At the end of validation,
-            the model goes back to training mode and gradients are enabled.
+            When the :meth:`validation_step` is called, the model has been put
+            in eval mode and PyTorch gradients have been disabled. At the end
+            of the validation epoch, the ``.training`` mode of every submodule
+            is restored to what it was before and gradients are enabled.
 
         """
 
@@ -881,9 +882,10 @@ class LightningModule(
             If you don't need to test you don't need to implement this method.
 
         Note:
-            When the :meth:`test_step` is called, the model has been put in eval mode and
-            PyTorch gradients have been disabled. At the end of the test epoch, the model goes back
-            to training mode and gradients are enabled.
+            When the :meth:`test_step` is called, the model has been put in
+            eval mode and PyTorch gradients have been disabled. At the end of
+            the test epoch, the ``.training`` mode of every submodule is
+            restored to what it was before and gradients are enabled.
 
         """
 
@@ -921,6 +923,12 @@ class LightningModule(
             model = MyModel()
             trainer = Trainer(accelerator="gpu", devices=2)
             predictions = trainer.predict(model, dm)
+
+        Note:
+            When the :meth:`predict_step` is called, the model has been put in
+            eval mode and PyTorch gradients have been disabled. At the end of
+            the predict epoch, the ``.training`` mode of every submodule is
+            restored to what it was before and gradients are enabled.
 
         """
         # For backwards compatibility


### PR DESCRIPTION
Related to https://github.com/Lightning-AI/pytorch-lightning/pull/18951#issuecomment-2633423417.

Update the pseudocode of validation loop according to #18951:

> When the validation loop ends, and before switching to training, it restores the `.training mode` on all submodules to what it was before.

and add a corresponding note to `{validation,test,predict}_step` since they exhibit this behavior as can be seen in the following snippet:
```python
from lightning.pytorch.demos.boring_classes import BoringModel
import lightning as L
import warnings

warnings.filterwarnings('ignore')

trainer = L.Trainer(max_epochs=1)
loop = trainer.test

litmodel = BoringModel()
litmodel.train()
print('Before loop', litmodel.training)
loop(litmodel)
print('After loop', litmodel.training)

litmodel = BoringModel()
litmodel.eval()
print('Before loop', litmodel.training)
loop(litmodel)
print('After loop', litmodel.training)
```

```
GPU available: False, used: False
TPU available: False, using: 0 TPU cores
HPU available: False, using: 0 HPUs
Before loop True
Testing DataLoader 0: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 64/64 [00:00<00:00, 1299.38it/s]
After loop True
Before loop False
Testing DataLoader 0: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 64/64 [00:00<00:00, 1332.01it/s]
After loop False
```
@awaelchli Can you please confirm that this is the intended (default) behavior of the loops?

Additional changes:
* Fix incorrect comment in `lightning_module.rst` that `trainer.test(model)` loads the best weights. According to the [docs](https://lightning.ai/docs/pytorch/stable/common/trainer.html#test), If `ckpt_path=None` and the model instance was passed, use the current weights.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #\<issue_number>

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
