### PR TITLE
Allow one to skip training steps during distributed training

### DIFF
--- a/src/lightning/pytorch/loops/optimization/automatic.py
+++ b/src/lightning/pytorch/loops/optimization/automatic.py
@@ -324,7 +324,7 @@ class _AutomaticOptimization(_Loop):
             rank_zero_warn(
                 "Skipping the `training_step` by returning None in distributed training is not supported."
                 " It is recommended that you rewrite your training logic to avoid having to skip the step in the first"
-                " place."
+                " place.",
                 category=PossibleUserWarning,
             )
 

--- a/tests/tests_pytorch/loops/optimization/test_automatic_loop.py
+++ b/tests/tests_pytorch/loops/optimization/test_automatic_loop.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections.abc import Iterator, Mapping
-from contextlib import nullcontext
 from typing import Generic, TypeVar
 
 import pytest
@@ -83,28 +82,4 @@ def test_warning_invalid_trainstep_output(tmp_path, case):
     trainer = Trainer(default_root_dir=tmp_path, fast_dev_run=1)
 
     with pytest.raises(MisconfigurationException, match=match):
-        trainer.fit(model)
-
-
-@pytest.mark.parametrize("world_size", [1, 2])
-def test_skip_training_step_not_allowed(world_size, tmp_path):
-    """Test that skipping the training_step in distributed training is not allowed."""
-
-    class TestModel(BoringModel):
-        def training_step(self, batch, batch_idx):
-            return None
-
-    model = TestModel()
-    trainer = Trainer(
-        default_root_dir=tmp_path,
-        max_steps=1,
-        barebones=True,
-    )
-    trainer.strategy.world_size = world_size  # mock world size without launching processes
-    error_context = (
-        pytest.raises(RuntimeError, match="Skipping the `training_step` .* is not supported")
-        if world_size > 1
-        else nullcontext()
-    )
-    with error_context:
         trainer.fit(model)


### PR DESCRIPTION
## What does this PR do?

* Allows one to skip training steps during distributed training once again, this time issuing a warning instead of raising an exception.

Adjusts https://github.com/Lightning-AI/pytorch-lightning/pull/19918.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20729.org.readthedocs.build/en/20729/

<!-- readthedocs-preview pytorch-lightning end -->