### PR TITLE
Fix: Respect required=False in add_lightning_class_args when subclass_mode=False

### DIFF
--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -126,27 +126,36 @@ class LightningArgumentParser(ArgumentParser):
         required: bool = True,
     ) -> list[str]:
         """Adds arguments from a lightning class to a nested key of the parser.
-
+    
         Args:
             lightning_class: A callable or any subclass of {Trainer, LightningModule, LightningDataModule, Callback}.
             nested_key: Name of the nested namespace to store arguments.
-            subclass_mode: Whether allow any subclass of the given class.
+            subclass_mode: Whether to allow any subclass of the given class.
             required: Whether the argument group is required.
-
+    
         Returns:
             A list with the names of the class arguments added.
-
         """
         if callable(lightning_class) and not isinstance(lightning_class, type):
             lightning_class = class_from_function(lightning_class)
-
+    
         if isinstance(lightning_class, type) and issubclass(
             lightning_class, (Trainer, LightningModule, LightningDataModule, Callback)
         ):
             if issubclass(lightning_class, Callback):
                 self.callback_keys.append(nested_key)
+    
+            # NEW LOGIC: If subclass_mode=False and required=False, only add if config provides this key
+            if not subclass_mode and not required:
+                config_path = f"{self.subcommand}.{nested_key}" if getattr(self, "subcommand", None) else nested_key
+                config = getattr(self, "config", {})
+                if not any(k.startswith(config_path) for k in config.keys()):
+                    # Skip adding class arguments
+                    return []
+    
             if subclass_mode:
                 return self.add_subclass_arguments(lightning_class, nested_key, fail_untyped=False, required=required)
+    
             return self.add_class_arguments(
                 lightning_class,
                 nested_key,
@@ -154,10 +163,12 @@ class LightningArgumentParser(ArgumentParser):
                 instantiate=not issubclass(lightning_class, Trainer),
                 sub_configs=True,
             )
+    
         raise MisconfigurationException(
             f"Cannot add arguments from: {lightning_class}. You should provide either a callable or a subclass of: "
             "Trainer, LightningModule, LightningDataModule, or Callback."
         )
+
 
     def add_optimizer_args(
         self,

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -1789,3 +1789,33 @@ def test_lightning_cli_with_args_given(args):
 def test_lightning_cli_args_and_sys_argv_warning():
     with mock.patch("sys.argv", ["", "--model.foo=456"]), pytest.warns(Warning, match="LightningCLI's args parameter "):
         LightningCLI(TestModel, run=False, args=["--model.foo=789"])
+
+
+def test_add_class_args_required_false_skips_addition(tmp_path):
+    from lightning.pytorch import cli, callbacks
+
+    class FooCheckpoint(callbacks.ModelCheckpoint):
+        def __init__(self, dirpath, *args, **kwargs):
+            super().__init__(dirpath, *args, **kwargs)
+
+    class SimpleModel:
+        def __init__(self): pass
+
+    class SimpleDataModule:
+        def __init__(self): pass
+
+    class FooCLI(cli.LightningCLI):
+        def __init__(self):
+            super().__init__(
+                model_class=SimpleModel,
+                datamodule_class=SimpleDataModule,
+                run=False,
+                save_config_callback=None
+            )
+
+        def add_arguments_to_parser(self, parser):
+            parser.add_lightning_class_args(FooCheckpoint, "checkpoint", required=False)
+
+    # Expectation: No error raised even though FooCheckpoint requires `dirpath`
+    FooCLI()
+


### PR DESCRIPTION
What does this PR do?

This PR fixes an inconsistency in LightningCLI.add_lightning_class_args() where the required=False flag was being ignored when subclass_mode=False (which is the default).
According to the documentation, setting required=False should make providing the corresponding config optional — but in practice, argument registration was enforced regardless, leading to errors if required constructor parameters (e.g., dirpath in ModelCheckpoint) were not provided.

This change adds a conditional check that skips argument registration when:

    subclass_mode=False

    required=False

    and the config key (nested_key) is not provided by the user

Additionally, a test case was added to verify that this behavior works as expected.

Fixes #20851 https://github.com/Lightning-AI/pytorch-lightning/issues/20851
<details> <summary><b>Before submitting</b></summary>

Was this discussed/agreed via a GitHub issue? yes

Did you read the contributor guideline, Pull Request section? yes

Did you make sure your PR does only one thing, instead of bundling different changes together? yes

Did you write any new necessary tests? yes

Did you verify new and existing tests pass locally with your changes? yes

Did you update the documentation if necessary?

Did you list all the breaking changes introduced by this pull request?

Did you update the CHANGELOG? (not for typos, docs, test updates, or minor internal changes/refactors)

</details>
PR review

Anyone in the community is welcome to review the PR.


</details>
 <!-- Did you have fun? Make sure you had fun coding 🙃 --> Yes :)