### PR TITLE
Ensure correct device is used for autocast when mps is selected as Fabric accelerator

### DIFF
--- a/src/lightning/fabric/connector.py
+++ b/src/lightning/fabric/connector.py
@@ -492,7 +492,7 @@ class _Connector:
                 if self._precision_input == "16-mixed"
                 else "Using bfloat16 Automatic Mixed Precision (AMP)"
             )
-            device = "cpu" if self._accelerator_flag == "cpu" else "cuda"
+            device = self._accelerator_flag if self._accelerator_flag in ("cpu", "mps") else "cuda"
             return MixedPrecision(precision=self._precision_input, device=device)  # type: ignore[arg-type]
 
         raise RuntimeError("No precision set")

--- a/tests/tests_fabric/test_connector.py
+++ b/tests/tests_fabric/test_connector.py
@@ -404,6 +404,7 @@ def test_unsupported_strategy_types_on_cpu_and_fallback():
         connector = _Connector(accelerator="cpu", strategy="dp", devices=2)
     assert isinstance(connector.strategy, DDPStrategy)
 
+
 @RunIf(mps=True)
 @pytest.mark.parametrize("precision", ["16-mixed", "bf16-mixed"])
 def test_mps_enabled_with_float16_or_bfloat16_precision(precision):

--- a/tests/tests_fabric/test_connector.py
+++ b/tests/tests_fabric/test_connector.py
@@ -404,6 +404,12 @@ def test_unsupported_strategy_types_on_cpu_and_fallback():
         connector = _Connector(accelerator="cpu", strategy="dp", devices=2)
     assert isinstance(connector.strategy, DDPStrategy)
 
+@RunIf(mps=True)
+@pytest.mark.parametrize("precision", ["16-mixed", "bf16-mixed"])
+def test_mps_enabled_with_float16_or_bfloat16_precision(precision):
+    connector = _Connector(accelerator="mps", precision=precision)
+    assert connector.precision.device == "mps"
+
 
 def test_invalid_accelerator_choice():
     with pytest.raises(ValueError, match="You selected an invalid accelerator name: `accelerator='cocofruit'`"):

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -735,6 +735,7 @@ def test_autocast():
         fabric._precision.forward_context().__enter__.assert_called()
     fabric._precision.forward_context().__exit__.assert_called()
 
+
 @RunIf(mps=True)
 @pytest.mark.parametrize("precision", ["16-mixed", "bf16-mixed"])
 def test_autocast_does_not_use_cuda_on_mps(precision):
@@ -749,6 +750,7 @@ def test_autocast_does_not_use_cuda_on_mps(precision):
 
     for warning in w:
         assert "device_type of 'cuda'" not in str(warning.message)
+
 
 def test_no_backward_sync():
     """Test that `Fabric.no_backward_sync()` validates the strategy and model is compatible."""

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import warnings
 from contextlib import nullcontext
 from re import escape
 from unittest import mock
@@ -734,6 +735,20 @@ def test_autocast():
         fabric._precision.forward_context().__enter__.assert_called()
     fabric._precision.forward_context().__exit__.assert_called()
 
+@RunIf(mps=True)
+@pytest.mark.parametrize("precision", ["16-mixed", "bf16-mixed"])
+def test_autocast_does_not_use_cuda_on_mps(precision):
+    """Ensure Fabric.autocast on MPS does not fall back to CUDA when using (bf)16-mixed precision."""
+    fabric = Fabric(accelerator="mps", precision=precision)
+    fabric.launch()
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        with fabric.autocast():
+            pass
+
+    for warning in w:
+        assert "device_type of 'cuda'" not in str(warning.message)
 
 def test_no_backward_sync():
     """Test that `Fabric.no_backward_sync()` validates the strategy and model is compatible."""


### PR DESCRIPTION
### Problem

When selecting `mps` (tested on MacBook Pro M4) as the accelerator in `Fabric` with `precision="bf16-mixed"` or `"16-mixed"`, the device passed to `torch.autocast` is incorrectly hardcoded as `"cuda"`. This results in the following warning and disables automatic mixed precision:

```
.../torch/amp/autocast_mode.py:266: UserWarning: User provided device_type of 'cuda', but CUDA is not available. Disabling.
```

###  Minimal Reproducible Example

```python
import warnings
from lightning.fabric import Fabric

fabric = Fabric(accelerator="mps", precision="bf16-mixed")
fabric.launch()

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    with fabric.autocast():
        pass

    for warning in w:
        assert "device_type of 'cuda'" not in str(warning.message), \
            "Fabric autocast used incorrect device_type='cuda' on MPS"
```

---

###  Proposed Solution

In [`lightning/fabric/connector.py`](https://github.com/Lightning-AI/pytorch-lightning/blob/6675932a6037aac15081279b0c24f94bfa17b8b4/src/lightning/fabric/connector.py#L495), the device is currently selected using:

```python
device = "cpu" if self._accelerator_flag == "cpu" else "cuda"
```

This can be corrected to:

```python
device = self._accelerator_flag if self._accelerator_flag in ("cpu", "mps") else "cuda"
```

This should ensure that `torch.autocast` receives the correct device type when enabling Automatic Mixed Precision in Fabric.

Open to feedback on test (placement) or implementation details.


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20876.org.readthedocs.build/en/20876/

<!-- readthedocs-preview pytorch-lightning end -->