### PR TITLE
refactor: use __all__ in accelerators/__init__.py

### DIFF
--- a/src/lightning/pytorch/accelerators/__init__.py
+++ b/src/lightning/pytorch/accelerators/__init__.py
@@ -10,16 +10,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__all__ = [
+    "Accelerator",
+    "CPUAccelerator",
+    "CUDAAccelerator",
+    "MPSAccelerator",
+    "XLAAccelerator",
+    "find_usable_cuda_devices",
+]
+
 import sys
 
-from lightning.fabric.accelerators import find_usable_cuda_devices  # noqa: F401
+from lightning.fabric.accelerators import find_usable_cuda_devices
 from lightning.fabric.accelerators.registry import _AcceleratorRegistry
 from lightning.fabric.utilities.registry import _register_classes
 from lightning.pytorch.accelerators.accelerator import Accelerator
-from lightning.pytorch.accelerators.cpu import CPUAccelerator  # noqa: F401
-from lightning.pytorch.accelerators.cuda import CUDAAccelerator  # noqa: F401
-from lightning.pytorch.accelerators.mps import MPSAccelerator  # noqa: F401
-from lightning.pytorch.accelerators.xla import XLAAccelerator  # noqa: F401
+from lightning.pytorch.accelerators.cpu import CPUAccelerator
+from lightning.pytorch.accelerators.cuda import CUDAAccelerator
+from lightning.pytorch.accelerators.mps import MPSAccelerator
+from lightning.pytorch.accelerators.xla import XLAAccelerator
 
 AcceleratorRegistry = _AcceleratorRegistry()
 _register_classes(AcceleratorRegistry, "register_accelerators", sys.modules[__name__], Accelerator)


### PR DESCRIPTION
## What does this PR do?

This PR refactors the [accelerators/__init__.py]file to use Python's `__all__` for explicit exports instead of using `# noqa: F401` comments. This change makes the public API more explicit and follows Python best practices.

### Key Changes:
- Added `__all__` list at the top of the file to explicitly define exported symbols
- Removed `# noqa: F401` comments from imports
- Maintained all existing functionality while improving code quality

### Motivation:
- Makes the public API more explicit and self-documenting
- Follows Python best practices for module exports
- Improves code maintainability and IDE support
- Removes linter workarounds

Fixes #11592

### Before submitting
- [x] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (not needed)
- [ ] Did you write any **new necessary tests**? (not needed)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request? (none)
- [x] Did you **update the CHANGELOG**? (not needed for this refactor)

### Notes:
- This is a non-breaking change that only affects internal imports
- No functionality has been changed
- All existing tests pass with these changes