### PR TITLE
Fix typos: "reparametrization" → "reparameterization" and "recommed" → "recommend"

### DIFF
--- a/src/lightning/fabric/connector.py
+++ b/src/lightning/fabric/connector.py
@@ -428,7 +428,7 @@ class _Connector:
         if strategy_flag in _DDP_FORK_ALIASES and "fork" not in torch.multiprocessing.get_all_start_methods():
             raise ValueError(
                 f"You selected `Fabric(strategy='{strategy_flag}')` but process forking is not supported on this"
-                f" platform. We recommed `Fabric(strategy='ddp_spawn')` instead."
+                f" platform. We recommend `Fabric(strategy='ddp_spawn')` instead."
             )
         if (
             strategy_flag in _FSDP_ALIASES or type(self._strategy_flag) is FSDPStrategy

--- a/src/lightning/pytorch/callbacks/pruning.py
+++ b/src/lightning/pytorch/callbacks/pruning.py
@@ -129,7 +129,7 @@ class ModelPruning(Callback):
                 - ``bool``. Always apply it or not.
                 - ``Callable[[epoch], bool]``. For dynamic values. Will be called every epoch.
 
-            make_pruning_permanent: Whether to remove all reparametrization pre-hooks and apply masks
+            make_pruning_permanent: Whether to remove all reparameterization pre-hooks and apply masks
                 when training ends or the model is saved.
 
             use_lottery_ticket_hypothesis: See `The lottery ticket hypothesis <https://arxiv.org/abs/1803.03635>`_:


### PR DESCRIPTION


Description:
This pull request corrects two typos in the codebase:
- Updates the spelling of "reparametrization" to "reparameterization" in the pruning callback documentation.
- Fixes the typo "recommed" to "recommend" in the strategy selection error message.

These changes improve code clarity and maintain consistency with standard terminology. No functional changes are introduced.


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20892.org.readthedocs.build/en/20892/

<!-- readthedocs-preview pytorch-lightning end -->