### PR TITLE
test: addressing flaky spawn in subprocesses

### DIFF
--- a/tests/tests_fabric/utilities/test_distributed.py
+++ b/tests/tests_fabric/utilities/test_distributed.py
@@ -105,8 +105,8 @@ def _test_all_reduce(strategy):
         assert result is tensor  # inplace
 
 
-# flaky with "process 0 terminated with signal SIGABRT" (GLOO)
-@pytest.mark.flaky(reruns=3, only_rerun="torch.multiprocessing.spawn.ProcessExitedException")
+# flaky with "torch.multiprocessing.spawn.ProcessExitedException: process 0 terminated with signal SIGABRT" (GLOO)
+@pytest.mark.flaky(reruns=3)
 @RunIf(skip_windows=True)
 @pytest.mark.parametrize(
     "process",

--- a/tests/tests_pytorch/callbacks/test_stochastic_weight_avg.py
+++ b/tests/tests_pytorch/callbacks/test_stochastic_weight_avg.py
@@ -354,8 +354,8 @@ def test_swa_resume_training_from_checkpoint_custom_scheduler(tmp_path, crash_on
 
 
 @RunIf(skip_windows=True)
-# flaky with "process 0 terminated with signal SIGABRT" (GLOO)
-@pytest.mark.flaky(reruns=3, only_rerun="torch.multiprocessing.spawn.ProcessExitedException")
+# flaky with "torch.multiprocessing.spawn.ProcessExitedException: process 0 terminated with signal SIGABRT" (GLOO)
+@pytest.mark.flaky(reruns=3)
 def test_swa_resume_training_from_checkpoint_ddp(tmp_path):
     model = SwaTestModel(crash_on_epoch=3)
     resume_model = SwaTestModel()

--- a/tests/tests_pytorch/core/test_results.py
+++ b/tests/tests_pytorch/core/test_results.py
@@ -49,8 +49,8 @@ def result_reduce_ddp_fn(strategy):
     assert actual.item() == dist.get_world_size()
 
 
-# flaky with "process 0 terminated with signal SIGABRT"
-@pytest.mark.flaky(reruns=3, only_rerun="torch.multiprocessing.spawn.ProcessExitedException")
+# flaky with "torch.multiprocessing.spawn.ProcessExitedException: process 0 terminated with signal SIGABRT"
+@pytest.mark.flaky(reruns=3)
 @RunIf(skip_windows=True)
 def test_result_reduce_ddp():
     spawn_launch(result_reduce_ddp_fn, [torch.device("cpu")] * 2)


### PR DESCRIPTION
## What does this PR do?

The exception is not properly surfaced from subprocess so the rerun was never used as a check in logs even though the exception was properly linked, since this sample was correctly rerun:

```py
@pytest.mark.flaky(reruns=3, only_rerun="ProcessExitedException")
def test_rerun():
    from torch.multiprocessing import ProcessExitedException
```


<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
