### PR TITLE
Make asyncio checkpointing work if validate/fit is called more than o…

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
--
+- Fixed `AsyncCheckpointIO` threadpool exception if calling fit or validate more than one.
 
 
 ---

--- a/tests/tests_pytorch/plugins/test_checkpoint_io_plugin.py
+++ b/tests/tests_pytorch/plugins/test_checkpoint_io_plugin.py
@@ -127,6 +127,10 @@ def test_async_checkpoint_plugin(tmp_path):
         enable_progress_bar=False,
         enable_model_summary=False,
     )
+
+    # We add a validate step to test that async works when fit or validate is called multiple times.
+    trainer.validate(model)
+
     trainer.fit(model)
 
     assert checkpoint_plugin.save_checkpoint.call_count == 3


### PR DESCRIPTION
…nce.

## What does this PR do?

Currently if using async checkpointing if fit or validate is called than once it will crash (because the threadpool is shutdown and never re-created).

This PR modifies the test to induce the crash and fixes it.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

No.

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)

No, this is just a bugfix, not a behavior change. Should I create an issue?

- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?

Yes

- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?

Yes
- Did you make sure to **update the documentation** with your changes? (if necessary)

na

- Did you write any **new necessary tests**? (not for typos and docs)

yes

- [ ] Did you verify new and **existing tests pass** locally with your changes?

as best I could, I'm not very clear the recommended setup for testing pytorch lightning locally, I was only able to run the test I modified.

- Did you list all the **breaking changes** introduced by this pull request?

na

- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

Yes
