### PR TITLE
Fix: Allow trainer to accept CUDAAccelerator instance as accelerator with FSDP strategy

### DIFF
--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -453,7 +453,9 @@ class _AcceleratorConnector:
 
         if (
             strategy_flag in FSDPStrategy.get_registered_strategies() or type(self._strategy_flag) is FSDPStrategy
-        ) and self._accelerator_flag not in ("cuda", "gpu"):
+        ) and not (
+            self._accelerator_flag in ("cuda", "gpu") or isinstance(self._accelerator_flag, CUDAAccelerator)
+        ):
             raise ValueError(
                 f"The strategy `{FSDPStrategy.strategy_name}` requires a GPU accelerator, but got:"
                 f" {self._accelerator_flag}"

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -453,9 +453,7 @@ class _AcceleratorConnector:
 
         if (
             strategy_flag in FSDPStrategy.get_registered_strategies() or type(self._strategy_flag) is FSDPStrategy
-        ) and not (
-            self._accelerator_flag in ("cuda", "gpu") or isinstance(self._accelerator_flag, CUDAAccelerator)
-        ):
+        ) and not (self._accelerator_flag in ("cuda", "gpu") or isinstance(self._accelerator_flag, CUDAAccelerator)):
             raise ValueError(
                 f"The strategy `{FSDPStrategy.strategy_name}` requires a GPU accelerator, but got:"
                 f" {self._accelerator_flag}"

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -455,8 +455,9 @@ class _AcceleratorConnector:
             strategy_flag in FSDPStrategy.get_registered_strategies() or type(self._strategy_flag) is FSDPStrategy
         ) and not (self._accelerator_flag in ("cuda", "gpu") or isinstance(self._accelerator_flag, CUDAAccelerator)):
             raise ValueError(
-                f"The strategy `{FSDPStrategy.strategy_name}` requires a GPU accelerator, but got:"
-                f" {self._accelerator_flag}"
+                f"The strategy `{FSDPStrategy.strategy_name}` requires a GPU accelerator, but received "
+                f"`accelerator={self._accelerator_flag!r}`. Please set `accelerator='cuda'`, `accelerator='gpu'`,"
+                " or pass a `CUDAAccelerator()` instance to use FSDP."
             )
         if strategy_flag in _DDP_FORK_ALIASES and "fork" not in torch.multiprocessing.get_all_start_methods():
             raise ValueError(

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -1084,4 +1084,3 @@ def test_precision_selection_model_parallel(precision, raises, mps_count_0):
     error_context = pytest.raises(ValueError, match=f"does not support .*{precision}") if raises else nullcontext()
     with error_context:
         _AcceleratorConnector(precision=precision, strategy=ModelParallelStrategy())
-

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -1085,6 +1085,7 @@ def test_precision_selection_model_parallel(precision, raises, mps_count_0):
 def test_fsdp_with_cudaaccelerator_instance(tmp_path):
     # Minimal test to ensure FSDP works with CUDAAccelerator instance
     from lightning.pytorch.demos.boring_classes import BoringModel
+
     model = BoringModel()
     trainer = Trainer(
         default_root_dir=tmp_path,

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -582,6 +582,11 @@ def test_check_fsdp_strategy_and_fallback():
     Trainer(accelerator=AcceleratorSubclass(), strategy=FSDPStrategySubclass())
 
 
+@RunIf(min_cuda_gpus=1)
+def test_check_fsdp_strategy_and_fallback_with_cudaaccelerator():
+    Trainer(strategy="fsdp", accelerator=CUDAAccelerator(), devices=1, fast_dev_run=True)
+
+
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_unsupported_tpu_choice(xla_available, tpu_available):
     # if user didn't set strategy, _Connector will choose the SingleDeviceXLAStrategy or XLAStrategy
@@ -1080,20 +1085,3 @@ def test_precision_selection_model_parallel(precision, raises, mps_count_0):
     with error_context:
         _AcceleratorConnector(precision=precision, strategy=ModelParallelStrategy())
 
-
-@RunIf(min_cuda_gpus=1)
-def test_fsdp_with_cudaaccelerator_instance(tmp_path):
-    # Minimal test to ensure FSDP works with CUDAAccelerator instance
-    from lightning.pytorch.demos.boring_classes import BoringModel
-
-    model = BoringModel()
-    trainer = Trainer(
-        default_root_dir=tmp_path,
-        max_epochs=1,
-        strategy="fsdp",
-        accelerator=CUDAAccelerator(),
-        devices=1,
-        fast_dev_run=True,
-    )
-    # Should not raise ValueError
-    trainer.fit(model)

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -1079,3 +1079,20 @@ def test_precision_selection_model_parallel(precision, raises, mps_count_0):
     error_context = pytest.raises(ValueError, match=f"does not support .*{precision}") if raises else nullcontext()
     with error_context:
         _AcceleratorConnector(precision=precision, strategy=ModelParallelStrategy())
+
+
+@RunIf(min_cuda_gpus=1)
+def test_fsdp_with_cudaaccelerator_instance(tmp_path):
+    # Minimal test to ensure FSDP works with CUDAAccelerator instance
+    from lightning.pytorch.demos.boring_classes import BoringModel
+    model = BoringModel()
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        max_epochs=1,
+        strategy="fsdp",
+        accelerator=CUDAAccelerator(),
+        devices=1,
+        fast_dev_run=True,
+    )
+    # Should not raise ValueError
+    trainer.fit(model)

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -584,7 +584,7 @@ def test_check_fsdp_strategy_and_fallback():
 
 @RunIf(min_cuda_gpus=1)
 def test_check_fsdp_strategy_and_fallback_with_cudaaccelerator():
-    Trainer(strategy="fsdp", accelerator=CUDAAccelerator(), devices=1, fast_dev_run=True)
+    Trainer(strategy="fsdp", accelerator=CUDAAccelerator())
 
 
 @mock.patch.dict(os.environ, {}, clear=True)


### PR DESCRIPTION
## What does this PR do?

Fixes #20957

This PR fixes a bug where passing a `CUDAAccelerator()` instance with `strategy="fsdp"` in `trainer` raised an error, as reported in #20957.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20964.org.readthedocs.build/en/20964/

<!-- readthedocs-preview pytorch-lightning end -->