### PR TITLE
Fix MLFlowLogger.save_dir Windows file URI handling

### DIFF
--- a/src/lightning/pytorch/loggers/mlflow.py
+++ b/src/lightning/pytorch/loggers/mlflow.py
@@ -300,11 +300,18 @@ class MLFlowLogger(Logger):
 
         """
         if self._tracking_uri.startswith(LOCAL_FILE_URI_PREFIX):
-            from urllib.parse import urlparse
-            from urllib.request import url2pathname
+            # Handle both proper file URIs (file:///path) and legacy format (file:/path)
+            uri_without_prefix = self._tracking_uri[len(LOCAL_FILE_URI_PREFIX) :]
 
-            parsed_uri = urlparse(self._tracking_uri)
-            return url2pathname(parsed_uri.path)
+            # If it starts with ///, it's a proper file URI, use urlparse
+            if uri_without_prefix.startswith("///"):
+                from urllib.parse import urlparse
+                from urllib.request import url2pathname
+
+                parsed_uri = urlparse(self._tracking_uri)
+                return url2pathname(parsed_uri.path)
+            # Legacy format: file:/path or file:./path - return as-is
+            return uri_without_prefix
         return None
 
     @property

--- a/src/lightning/pytorch/loggers/mlflow.py
+++ b/src/lightning/pytorch/loggers/mlflow.py
@@ -300,7 +300,11 @@ class MLFlowLogger(Logger):
 
         """
         if self._tracking_uri.startswith(LOCAL_FILE_URI_PREFIX):
-            return self._tracking_uri[len(LOCAL_FILE_URI_PREFIX) :]
+            from urllib.parse import urlparse
+            from urllib.request import url2pathname
+
+            parsed_uri = urlparse(self._tracking_uri)
+            return url2pathname(parsed_uri.path)
         return None
 
     @property


### PR DESCRIPTION
## Fix MLFlowLogger.save_dir Windows file URI handling

### What does this PR do?

Fixes #20972

This PR fixes a bug in `MLFlowLogger.save_dir` where Windows absolute file URIs were being incorrectly parsed, resulting in malformed local paths that caused `FileNotFoundError` on Windows systems.

**Problem:**
When using [MLFlowLogger] with Windows absolute file URIs (e.g., `file:///C:/Dev/example/mlruns`), the [save_dir] property would return malformed paths like `///C:/Dev/example/mlruns` instead of the expected `C:/Dev/example/mlruns`, causing file system operations to fail.

**Solution:**
- Replace simple string slicing with proper URI parsing using `urllib.parse.urlparse` and `urllib.request.url2pathname`
- Properly handle Windows absolute file URIs (e.g., `file:///C:/path`)
- Add comprehensive tests for various file URI formats
- Fix malformed paths like `///C:/path` becoming `C:/path` on Windows

**Changes:**
1. **Core Fix**: Updated `MLFlowLogger.save_dir` property to use standard library URI parsing methods
2. **Test Coverage**: Added comprehensive test [test_mlflow_logger_save_dir_file_uri_handling] covering:
   - Unix-style absolute file URIs
   - Windows-style absolute file URIs  
   - Relative file URIs
   - Non-file URIs (should return None)
   - URIs with URL-encoded special characters

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20988.org.readthedocs.build/en/20988/

<!-- readthedocs-preview pytorch-lightning end -->