### PR TITLE
Fix integration of `LearningRateFinder` with `EarlyStopping`

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -41,6 +41,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix `save_last` behavior in the absence of validation ([#20960](https://github.com/Lightning-AI/pytorch-lightning/pull/20960))
 
 
+- Fixed integration between `LearningRateFinder` and `EarlyStopping` ([#21056](https://github.com/Lightning-AI/pytorch-lightning/pull/21056))
+
 ---
 
 ## [2.5.2] - 2025-06-20

--- a/src/lightning/pytorch/callbacks/lr_finder.py
+++ b/src/lightning/pytorch/callbacks/lr_finder.py
@@ -106,7 +106,7 @@ class LearningRateFinder(Callback):
         self._attr_name = attr_name
 
         self._early_exit = False
-        self.lr_finder: Optional[_LRFinder] = None
+        self.optimal_lr: Optional[_LRFinder] = None
 
     def lr_find(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
         with isolate_rng():

--- a/src/lightning/pytorch/tuner/lr_finder.py
+++ b/src/lightning/pytorch/tuner/lr_finder.py
@@ -306,7 +306,7 @@ def _lr_find(
     trainer.fit_loop.restarting = False  # reset restarting flag as checkpoint restoring sets it to True
     trainer.fit_loop.epoch_loop.restarting = False  # reset restarting flag as checkpoint restoring sets it to True
     trainer.fit_loop.epoch_loop.val_loop._combined_loader = None
-
+    trainer.fit_loop._combined_loader = None  # reset data fetcher to avoid issues with the next fit
     return lr_finder
 
 

--- a/src/lightning/pytorch/tuner/lr_finder.py
+++ b/src/lightning/pytorch/tuner/lr_finder.py
@@ -307,6 +307,7 @@ def _lr_find(
     trainer.fit_loop.epoch_loop.restarting = False  # reset restarting flag as checkpoint restoring sets it to True
     trainer.fit_loop.epoch_loop.val_loop._combined_loader = None
     trainer.fit_loop._combined_loader = None  # reset data fetcher to avoid issues with the next fit
+    trainer.fit_loop.setup_data()
     return lr_finder
 
 

--- a/tests/tests_pytorch/tuner/test_lr_finder.py
+++ b/tests/tests_pytorch/tuner/test_lr_finder.py
@@ -588,7 +588,6 @@ def test_lr_finder_with_early_stopping(tmp_path):
     # Verify that both callbacks were active
     lr_finder_callback = None
     early_stopping_callback = None
-    breakpoint()
     for callback in trainer.callbacks:
         if isinstance(callback, LearningRateFinder):
             lr_finder_callback = callback


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #19575
Fixes #20355

When using `LearningRateFinder` there is currently a bug that makes is so that `on_train_epoch_end` hooks are executed as one of the first things when starting fitting afterwards. The reason for this seems to be that the `data_fetcher` returns `StopIteration` after the learning rate finding, which makes the `self.advance()` method in fit loop return immediately

https://github.com/Lightning-AI/pytorch-lightning/blob/f0676260bad01967f3bebb2c5ebbb9890ad15050/src/lightning/pytorch/loops/fit_loop.py#L207-L223

afterwards the `self.on_advance_end` is executed which then calls the `on_train_epoch_end` hook from `EarlyStopping` which then fails if we are monitoring a validation metric, because the validation loop have not been called yet (which is expected).

Solution is to reset `data_fetcher` to `None` such that it is re-initialized during the actual fit loop.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21056.org.readthedocs.build/en/21056/

<!-- readthedocs-preview pytorch-lightning end -->