### PR TITLE
Add adapt_checkpoint_hparams hook for customizing checkpoint hyperparameter loading

### DIFF
--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -579,7 +579,9 @@ class LightningCLI:
         Example::
 
             class MyCLI(LightningCLI):
-                def adapt_checkpoint_hparams(self, subcommand: str, checkpoint_hparams: dict[str, Any]) -> dict[str, Any]:
+                def adapt_checkpoint_hparams(
+                    self, subcommand: str, checkpoint_hparams: dict[str, Any]
+                ) -> dict[str, Any]:
                     # Only remove training-specific hyperparameters for non-fit subcommands
                     if subcommand != "fit":
                         checkpoint_hparams.pop("lr", None)

--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -601,12 +601,12 @@ class LightningCLI:
             hparams.pop("_instantiator", None)
             if not hparams:
                 return
-            
+
             # Allow customization of checkpoint hyperparameters via adapt_checkpoint_hparams hook
             hparams = self.adapt_checkpoint_hparams(hparams)
             if not hparams:
                 return
-            
+
             if "_class_path" in hparams:
                 hparams = {
                     "class_path": hparams.pop("_class_path"),

--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -560,7 +560,7 @@ class LightningCLI:
         else:
             self.config = parser.parse_args(args)
 
-    def adapt_checkpoint_hparams(self, checkpoint_hparams: Dict[str, Any]) -> Dict[str, Any]:
+    def adapt_checkpoint_hparams(self, subcommand: str, checkpoint_hparams: dict[str, Any]) -> dict[str, Any]:
         """Adapt checkpoint hyperparameters before instantiating the model class.
 
         This method allows for customization of hyperparameters loaded from a checkpoint when
@@ -569,6 +569,8 @@ class LightningCLI:
         ``__init__`` parameters, you can remove or modify incompatible hyperparameters.
 
         Args:
+            subcommand: The subcommand being executed (e.g., 'fit', 'validate', 'test', 'predict').
+                This allows you to apply different hyperparameter adaptations depending on the context.
             checkpoint_hparams: Dictionary of hyperparameters loaded from the checkpoint.
 
         Returns:
@@ -577,10 +579,11 @@ class LightningCLI:
         Example::
 
             class MyCLI(LightningCLI):
-                def adapt_checkpoint_hparams(self, checkpoint_hparams: Dict[str, Any]) -> Dict[str, Any]:
-                    # Remove training-specific hyperparameters not needed for inference
-                    checkpoint_hparams.pop("lr", None)
-                    checkpoint_hparams.pop("weight_decay", None)
+                def adapt_checkpoint_hparams(self, subcommand: str, checkpoint_hparams: dict[str, Any]) -> dict[str, Any]:
+                    # Only remove training-specific hyperparameters for non-fit subcommands
+                    if subcommand != "fit":
+                        checkpoint_hparams.pop("lr", None)
+                        checkpoint_hparams.pop("weight_decay", None)
                     return checkpoint_hparams
 
         Note:
@@ -603,7 +606,7 @@ class LightningCLI:
                 return
 
             # Allow customization of checkpoint hyperparameters via adapt_checkpoint_hparams hook
-            hparams = self.adapt_checkpoint_hparams(hparams)
+            hparams = self.adapt_checkpoint_hparams(self.config.subcommand, hparams)
             if not hparams:
                 return
 

--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -560,6 +560,36 @@ class LightningCLI:
         else:
             self.config = parser.parse_args(args)
 
+    def adapt_checkpoint_hparams(self, checkpoint_hparams: Dict[str, Any]) -> Dict[str, Any]:
+        """Adapt checkpoint hyperparameters before instantiating the model class.
+
+        This method allows for customization of hyperparameters loaded from a checkpoint when
+        using a different model class than the one used for training. For example, when loading
+        a checkpoint from a TrainingModule to use with an InferenceModule that has different
+        ``__init__`` parameters, you can remove or modify incompatible hyperparameters.
+
+        Args:
+            checkpoint_hparams: Dictionary of hyperparameters loaded from the checkpoint.
+
+        Returns:
+            Dictionary of adapted hyperparameters to be used for model instantiation.
+
+        Example::
+
+            class MyCLI(LightningCLI):
+                def adapt_checkpoint_hparams(self, checkpoint_hparams: Dict[str, Any]) -> Dict[str, Any]:
+                    # Remove training-specific hyperparameters not needed for inference
+                    checkpoint_hparams.pop("lr", None)
+                    checkpoint_hparams.pop("weight_decay", None)
+                    return checkpoint_hparams
+
+        Note:
+            If subclass module mode is enabled and ``_class_path`` is present in the checkpoint
+            hyperparameters, you may need to modify it as well to point to your new module class.
+
+        """
+        return checkpoint_hparams
+
     def _parse_ckpt_path(self) -> None:
         """If a checkpoint path is given, parse the hyperparameters from the checkpoint and update the config."""
         if not self.config.get("subcommand"):
@@ -571,6 +601,12 @@ class LightningCLI:
             hparams.pop("_instantiator", None)
             if not hparams:
                 return
+            
+            # Allow customization of checkpoint hyperparameters via adapt_checkpoint_hparams hook
+            hparams = self.adapt_checkpoint_hparams(hparams)
+            if not hparams:
+                return
+            
             if "_class_path" in hparams:
                 hparams = {
                     "class_path": hparams.pop("_class_path"),

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -564,6 +564,7 @@ def test_lightning_cli_ckpt_path_argument_hparams_subclass_mode(cleandir):
 
 def test_adapt_checkpoint_hparams_hook(cleandir):
     """Test that the adapt_checkpoint_hparams hook is called and modifications are applied."""
+
     class AdaptHparamsCLI(LightningCLI):
         def add_arguments_to_parser(self, parser):
             parser.link_arguments("model.out_dim", "model.hidden_dim", compute_fn=lambda x: x * 2)
@@ -597,6 +598,7 @@ def test_adapt_checkpoint_hparams_hook(cleandir):
 
 def test_adapt_checkpoint_hparams_hook_empty_dict(cleandir):
     """Test that returning empty dict from adapt_checkpoint_hparams disables checkpoint hyperparameter loading."""
+
     class AdaptHparamsEmptyCLI(LightningCLI):
         def add_arguments_to_parser(self, parser):
             parser.link_arguments("model.out_dim", "model.hidden_dim", compute_fn=lambda x: x * 2)

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -495,6 +495,33 @@ class BoringCkptPathModel(BoringModel):
         self.layer = torch.nn.Linear(32, out_dim)
 
 
+class AdaptHparamsModel(LightningModule):
+    """Simple model for testing adapt_checkpoint_hparams hook without dynamic neural network layers.
+    
+    This model stores hyperparameters as attributes without creating layers that would cause
+    size mismatches when hyperparameters are changed between fit and predict phases.
+    """
+
+    def __init__(self, out_dim: int = 8, hidden_dim: int = 16) -> None:
+        super().__init__()
+        self.save_hyperparameters()
+        self.out_dim = out_dim
+        self.hidden_dim = hidden_dim
+        # Add a simple layer that doesn't depend on hyperparameters
+        self.layer = torch.nn.Linear(10, 2)
+
+    def forward(self, x):
+        return self.layer(x)
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        loss = torch.nn.functional.mse_loss(self(x), y)
+        return loss
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), lr=0.1)
+
+
 def test_lightning_cli_ckpt_path_argument_hparams(cleandir):
     class CkptPathCLI(LightningCLI):
         def add_arguments_to_parser(self, parser):
@@ -562,14 +589,11 @@ def test_lightning_cli_ckpt_path_argument_hparams_subclass_mode(cleandir):
     assert cli.model.layer.out_features == 4
 
 
-def test_adapt_checkpoint_hparams_hook(cleandir):
+def test_adapt_checkpoint_hparams_hook_pop_keys(cleandir):
     """Test that the adapt_checkpoint_hparams hook is called and modifications are applied."""
 
     class AdaptHparamsCLI(LightningCLI):
-        def add_arguments_to_parser(self, parser):
-            parser.link_arguments("model.out_dim", "model.hidden_dim", compute_fn=lambda x: x * 2)
-
-        def adapt_checkpoint_hparams(self, subcommand, checkpoint_hparams):
+        def adapt_checkpoint_hparams(self, subcommand: str, checkpoint_hparams: dict) -> dict:
             """Remove out_dim and hidden_dim for non-fit subcommands."""
             if subcommand != "fit":
                 checkpoint_hparams.pop("out_dim", None)
@@ -579,17 +603,17 @@ def test_adapt_checkpoint_hparams_hook(cleandir):
     # First, create a checkpoint by running fit
     cli_args = ["fit", "--model.out_dim=3", "--trainer.max_epochs=1"]
     with mock.patch("sys.argv", ["any.py"] + cli_args):
-        cli = AdaptHparamsCLI(BoringCkptPathModel)
+        cli = AdaptHparamsCLI(AdaptHparamsModel)
 
     assert cli.config.fit.model.out_dim == 3
-    assert cli.config.fit.model.hidden_dim == 6
+    assert cli.config.fit.model.hidden_dim == 3
 
     checkpoint_path = next(Path(cli.trainer.log_dir, "checkpoints").glob("*.ckpt"))
 
     # Test that predict uses adapted hparams (without out_dim and hidden_dim)
     cli_args = ["predict", f"--ckpt_path={checkpoint_path}", "--model.out_dim=5", "--model.hidden_dim=10"]
     with mock.patch("sys.argv", ["any.py"] + cli_args):
-        cli = AdaptHparamsCLI(BoringCkptPathModel)
+        cli = AdaptHparamsCLI(AdaptHparamsModel)
 
     # Since we removed out_dim and hidden_dim for predict, the CLI values should be used
     assert cli.config.predict.model.out_dim == 5
@@ -600,24 +624,21 @@ def test_adapt_checkpoint_hparams_hook_empty_dict(cleandir):
     """Test that returning empty dict from adapt_checkpoint_hparams disables checkpoint hyperparameter loading."""
 
     class AdaptHparamsEmptyCLI(LightningCLI):
-        def add_arguments_to_parser(self, parser):
-            parser.link_arguments("model.out_dim", "model.hidden_dim", compute_fn=lambda x: x * 2)
-
-        def adapt_checkpoint_hparams(self, subcommand, checkpoint_hparams):
+        def adapt_checkpoint_hparams(self, subcommand: str, checkpoint_hparams: dict) -> dict:
             """Disable checkpoint hyperparameter loading."""
             return {}
 
     # First, create a checkpoint
     cli_args = ["fit", "--model.out_dim=3", "--trainer.max_epochs=1"]
     with mock.patch("sys.argv", ["any.py"] + cli_args):
-        cli = AdaptHparamsEmptyCLI(BoringCkptPathModel)
+        cli = AdaptHparamsEmptyCLI(AdaptHparamsModel)
 
     checkpoint_path = next(Path(cli.trainer.log_dir, "checkpoints").glob("*.ckpt"))
 
     # Test that predict uses default values when hook returns empty dict
     cli_args = ["predict", f"--ckpt_path={checkpoint_path}"]
     with mock.patch("sys.argv", ["any.py"] + cli_args):
-        cli = AdaptHparamsEmptyCLI(BoringCkptPathModel)
+        cli = AdaptHparamsEmptyCLI(AdaptHparamsModel)
 
     # Model should use default values (out_dim=8, hidden_dim=16)
     assert cli.config_init.predict.model.out_dim == 8

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -497,9 +497,10 @@ class BoringCkptPathModel(BoringModel):
 
 class AdaptHparamsModel(LightningModule):
     """Simple model for testing adapt_checkpoint_hparams hook without dynamic neural network layers.
-    
-    This model stores hyperparameters as attributes without creating layers that would cause
-    size mismatches when hyperparameters are changed between fit and predict phases.
+
+    This model stores hyperparameters as attributes without creating layers that would cause size mismatches when
+    hyperparameters are changed between fit and predict phases.
+
     """
 
     def __init__(self, out_dim: int = 8, hidden_dim: int = 16) -> None:
@@ -515,8 +516,7 @@ class AdaptHparamsModel(LightningModule):
 
     def training_step(self, batch, batch_idx):
         x, y = batch
-        loss = torch.nn.functional.mse_loss(self(x), y)
-        return loss
+        return torch.nn.functional.mse_loss(self(x), y)
 
     def configure_optimizers(self):
         return torch.optim.Adam(self.parameters(), lr=0.1)

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -589,12 +589,12 @@ def test_adapt_checkpoint_hparams_hook_pop_keys(cleandir):
             return checkpoint_hparams
 
     # First, create a checkpoint by running fit
-    cli_args = ["fit", "--model.out_dim=3", "--trainer.max_epochs=1"]
+    cli_args = ["fit", "--model.out_dim=3", "--model.hidden_dim=6", "--trainer.max_epochs=1"]
     with mock.patch("sys.argv", ["any.py"] + cli_args):
         cli = AdaptHparamsCLI(AdaptHparamsModel)
 
     assert cli.config.fit.model.out_dim == 3
-    assert cli.config.fit.model.hidden_dim == 3
+    assert cli.config.fit.model.hidden_dim == 6
 
     checkpoint_path = next(Path(cli.trainer.log_dir, "checkpoints").glob("*.ckpt"))
 

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -495,7 +495,7 @@ class BoringCkptPathModel(BoringModel):
         self.layer = torch.nn.Linear(32, out_dim)
 
 
-class AdaptHparamsModel(LightningModule):
+class AdaptHparamsModel(BoringModel):
     """Simple model for testing adapt_checkpoint_hparams hook without dynamic neural network layers.
 
     This model stores hyperparameters as attributes without creating layers that would cause size mismatches when
@@ -508,18 +508,6 @@ class AdaptHparamsModel(LightningModule):
         self.save_hyperparameters()
         self.out_dim = out_dim
         self.hidden_dim = hidden_dim
-        # Add a simple layer that doesn't depend on hyperparameters
-        self.layer = torch.nn.Linear(10, 2)
-
-    def forward(self, x):
-        return self.layer(x)
-
-    def training_step(self, batch, batch_idx):
-        x, y = batch
-        return torch.nn.functional.mse_loss(self(x), y)
-
-    def configure_optimizers(self):
-        return torch.optim.Adam(self.parameters(), lr=0.1)
 
 
 def test_lightning_cli_ckpt_path_argument_hparams(cleandir):


### PR DESCRIPTION
## What does this PR do?

Fixes #21255

This PR adds a public `adapt_checkpoint_hparams()` hook to `LightningCLI` that allows users to customize hyperparameters loaded from checkpoints before they are used to instantiate model classes. This solves the problem of loading checkpoints across different module classes (e.g., from `TrainingModule` to `InferenceModule`).

### Problem

When using `LightningCLI` with checkpoints, hyperparameters saved during training are automatically loaded and applied when running other subcommands (test, predict, etc.). This is convenient when using the same module class, but fails when using a different class with incompatible `__init__` parameters.

**Example scenario:**
```python
# TrainingModule saves 'lr' hyperparameter
class TrainingModule(LightningModule):
    def __init__(self, lr: float = 1e-3):
        ...

# InferenceModule doesn't accept 'lr'
class InferenceModule(LightningModule):
    def __init__(self):  # No 'lr' parameter!
        ...
```

Running `cli predict --ckpt_path checkpoint.ckpt` with `InferenceModule` fails because the CLI tries to pass `lr=1e-3` from the checkpoint to `InferenceModule.__init__()`.

### Solution

Added `adapt_checkpoint_hparams()` public method that users can override to customize loaded hyperparameters:

```python
class MyCLI(LightningCLI):
    def adapt_checkpoint_hparams(self, checkpoint_hparams: Dict[str, Any]) -> Dict[str, Any]:
        # Remove training-specific hyperparameters
        checkpoint_hparams.pop("lr", None)
        checkpoint_hparams.pop("weight_decay", None)
        return checkpoint_hparams
```

### Implementation Details

- **Added**: `adapt_checkpoint_hparams()` public method in `LightningCLI`
- **Modified**: `_parse_ckpt_path()` to call the hook after loading but before applying hyperparameters
- **Backward compatible**: Default implementation returns hyperparameters unchanged
- **Flexible**: Users can remove, modify, or completely disable checkpoint hyperparameters

### Why This Approach?

As discussed in #21255, this is superior to alternatives:

1. **Better than disabling checkpoint loading**: Preserves valuable hyperparameter information (e.g., `hidden_dim`)
2. **Better than CLI flags**: Maintains consistency with Trainer parameter pattern
3. **Better than modifying private methods**: Provides official public API

### Testing

The implementation:
- ✅ Maintains backward compatibility (existing code unaffected)
- ✅ Provides maximum flexibility via public hook
- ✅ Works with both regular and subclass module modes
- ✅ Handles `_class_path` modification when needed

### Example Use Cases

1. **Remove training-only parameters:**
   ```python
   def adapt_checkpoint_hparams(self, hparams):
       hparams.pop("lr", None)
       return hparams
   ```

2. **Change module class in subclass mode:**
   ```python
   def adapt_checkpoint_hparams(self, hparams):
       hparams["_class_path"] = "mymodule.InferenceModule"
       return hparams
   ```

3. **Disable all checkpoint hyperparameters:**
   ```python
   def adapt_checkpoint_hparams(self, hparams):
       return {}
   ```

## Does your PR introduce any breaking changes?

No, this is a purely additive change. The default implementation returns hyperparameters unchanged, preserving existing behavior.

## Before submitting

- [ ] Was this discussed/approved via a GitHub issue? Yes - #21255
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you list all the breaking changes introduced by this pull request?
- [ ] Did you update the CHANGELOG?

## PR review

- [ ] Is this pull request ready for review? Yes
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

**cc:** @mauvilsa @ziw-liu


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21408.org.readthedocs.build/en/21408/

<!-- readthedocs-preview pytorch-lightning end -->