### PR TITLE
Fix save_hyperparameters(ignore) persistence across inheritance

### DIFF
--- a/src/lightning/pytorch/utilities/parsing.py
+++ b/src/lightning/pytorch/utilities/parsing.py
@@ -168,6 +168,7 @@ def save_hyperparameters(
     else:
         init_args = {}
         from lightning.pytorch.core.mixins import HyperparametersMixin
+
         for local_args in collect_init_args(frame, [], classes=(HyperparametersMixin,)):
             init_args.update(local_args)
 
@@ -198,7 +199,6 @@ def save_hyperparameters(
 
     ignore = list(set(ignore))
     init_args = {k: v for k, v in init_args.items() if k not in ignore}
-
 
     if not args:
         # take all arguments

--- a/tests/tests_pytorch/utilities/test_parsing.py
+++ b/tests/tests_pytorch/utilities/test_parsing.py
@@ -250,4 +250,3 @@ def test_save_hparams_ignore_persists_across_inheritance():
 
     model = Child(1, 2)
     assert "b" not in model.hparams
-

--- a/tests/tests_pytorch/utilities/test_parsing.py
+++ b/tests/tests_pytorch/utilities/test_parsing.py
@@ -235,3 +235,19 @@ def test_collect_init_args():
     my_class = AutomaticArgsChild("test1", "test2", anykw=32, childkw=22, otherkw=123)
     assert my_class.result[0] == {"anyarg": "test1", "anykw": 32, "otherkw": 123}
     assert my_class.result[1] == {"anyarg": "test1", "childarg": "test2", "anykw": 32, "childkw": 22, "otherkw": 123}
+
+
+def test_save_hparams_ignore_persists_across_inheritance():
+    class Base(LightningModule):
+        def __init__(self, a, b):
+            super().__init__()
+            self.save_hyperparameters()
+
+    class Child(Base):
+        def __init__(self, a, b):
+            super().__init__(a, b)
+            self.save_hyperparameters(ignore="b")
+
+    model = Child(1, 2)
+    assert "b" not in model.hparams
+


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where `save_hyperparameters(ignore=...)` was not persistent across inheritance.
When both a base class and a subclass call `save_hyperparameters`, ignored parameters could
reappear in `hparams` if the base class saved them first.

This PR makes ignored hyperparameters persistent per instance and ensures they are removed
from existing `hparams` when ignored in subsequent calls. A regression test is added to cover
the inheritance behavior.

Fixes #21488

## Does this PR introduce any breaking changes?

No. This change only affects the internal handling of ignored hyperparameters and preserves
existing behavior for single `save_hyperparameters` calls.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue?  
  Yes, discussed in #21488

- [x] Did you read the contributor guideline, **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**?
- Did you make sure to **update the documentation** with your changes?  
  Not required (internal bug fix)

- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?  
  N/A

- Did you **update the CHANGELOG**?  
  Not required (bug fix with test)

</details>


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21489.org.readthedocs.build/en/21489/

<!-- readthedocs-preview pytorch-lightning end -->