### PR TITLE
Fix numpy 2.4.0 compatibility in TensorBoard logger

### DIFF
--- a/src/lightning/fabric/loggers/tensorboard.py
+++ b/src/lightning/fabric/loggers/tensorboard.py
@@ -18,7 +18,6 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
-
 from lightning_utilities.core.imports import RequirementCache
 from torch import Tensor
 from torch.nn import Module

--- a/src/lightning/fabric/loggers/tensorboard.py
+++ b/src/lightning/fabric/loggers/tensorboard.py
@@ -17,6 +17,8 @@ from argparse import Namespace
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+import numpy as np
+
 from lightning_utilities.core.imports import RequirementCache
 from torch import Tensor
 from torch.nn import Module
@@ -204,6 +206,9 @@ class TensorBoardLogger(Logger):
 
         for k, v in metrics.items():
             if isinstance(v, Tensor):
+                v = v.item()
+            elif isinstance(v, np.ndarray) and v.ndim == 0:
+                # Convert 0-dim numpy arrays to scalars (required for numpy >= 2.4.0)
                 v = v.item()
 
             if isinstance(v, dict):

--- a/src/lightning/fabric/loggers/tensorboard.py
+++ b/src/lightning/fabric/loggers/tensorboard.py
@@ -17,7 +17,6 @@ from argparse import Namespace
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-import numpy as np
 from lightning_utilities.core.imports import RequirementCache
 from torch import Tensor
 from torch.nn import Module
@@ -202,6 +201,9 @@ class TensorBoardLogger(Logger):
         assert rank_zero_only.rank == 0, "experiment tried to log from global_rank != 0"
 
         metrics = _add_prefix(metrics, self._prefix, self.LOGGER_JOIN_CHAR)
+
+        # Local import to avoid making numpy a top-level dependency of the package.
+        import numpy as np
 
         for k, v in metrics.items():
             if isinstance(v, Tensor):

--- a/tests/tests_fabric/loggers/test_tensorboard.py
+++ b/tests/tests_fabric/loggers/test_tensorboard.py
@@ -111,6 +111,23 @@ def test_tensorboard_log_metrics(tmp_path, step_idx):
     logger.log_metrics(metrics, step_idx)
 
 
+def test_tensorboard_log_metrics_with_zero_dim_ndarray(tmp_path):
+    """Regression test: a 0-dim numpy array must be converted to a Python
+    scalar before being passed to ``add_scalar`` so that numpy >= 2.4.0
+    (which forbids implicit conversion of 0-dim arrays to scalars) does
+    not raise ``TypeError``. See issue #21503.
+    """
+    import numpy as np
+
+    logger = TensorBoardLogger(tmp_path)
+    # Both forms can occur in user code; both used to raise on numpy >= 2.4.
+    metrics = {
+        "scalar_array": np.array(0.5),  # 0-dim ndarray
+        "typed_scalar": np.float64(3.14),  # 0-dim ndarray of a concrete dtype
+    }
+    logger.log_metrics(metrics)
+
+
 def test_tensorboard_log_hyperparams(tmp_path):
     logger = TensorBoardLogger(tmp_path)
     hparams = {


### PR DESCRIPTION
## Summary

Fixes #21503

As of [numpy 2.4.0](https://numpy.org/doc/stable/release/2.4.0-notes.html#raise-typeerror-on-attempt-to-convert-array-with-ndim-0-to-scalar), converting a 0-dimensional array to a scalar is now a `TypeError`, following the expiration of a lengthy deprecation period.

## Problem

The `log_metrics` method in `TensorBoardLogger` can receive 0-dimensional numpy arrays as metric values. When these are passed to TensorBoard's `add_scalar()`, they fail with numpy >= 2.4.0 because the implicit conversion to scalar is no longer allowed.

## Solution

Explicitly convert 0-dimensional numpy arrays to Python scalars using `.item()` before passing them to `add_scalar()`. This is the same approach already used for PyTorch Tensors.

## Changes

- Added `import numpy as np` to the tensorboard logger
- Added check for `np.ndarray` with `ndim == 0` and convert using `.item()`

## Test plan

```python
import numpy as np
from lightning.fabric.loggers import TensorBoardLogger

logger = TensorBoardLogger("logs")
# This should work without TypeError
logger.log_metrics({"metric": np.array(0.5)})  # 0-dim array
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21529.org.readthedocs.build/en/21529/

<!-- readthedocs-preview pytorch-lightning end -->