### PR TITLE
Add GradientStatsMonitor callback for gradient tracking

### DIFF
--- a/src/lightning/pytorch/callbacks/__init__.py
+++ b/src/lightning/pytorch/callbacks/__init__.py
@@ -33,6 +33,7 @@ from lightning.pytorch.callbacks.stochastic_weight_avg import StochasticWeightAv
 from lightning.pytorch.callbacks.throughput_monitor import ThroughputMonitor
 from lightning.pytorch.callbacks.timer import Timer
 from lightning.pytorch.callbacks.weight_averaging import EMAWeightAveraging, WeightAveraging
+
 from .gradients_statistics_monitor import GradientStatsMonitor
 
 __all__ = [

--- a/src/lightning/pytorch/callbacks/__init__.py
+++ b/src/lightning/pytorch/callbacks/__init__.py
@@ -33,6 +33,7 @@ from lightning.pytorch.callbacks.stochastic_weight_avg import StochasticWeightAv
 from lightning.pytorch.callbacks.throughput_monitor import ThroughputMonitor
 from lightning.pytorch.callbacks.timer import Timer
 from lightning.pytorch.callbacks.weight_averaging import EMAWeightAveraging, WeightAveraging
+from .gradients_statistics_monitor import GradientStatsMonitor
 
 __all__ = [
     "BackboneFinetuning",
@@ -61,4 +62,5 @@ __all__ = [
     "TQDMProgressBar",
     "EMAWeightAveraging",
     "WeightAveraging",
+    "GradientStatsMonitor",
 ]

--- a/src/lightning/pytorch/callbacks/gradients_statistics_monitor.py
+++ b/src/lightning/pytorch/callbacks/gradients_statistics_monitor.py
@@ -1,0 +1,198 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict
+
+import torch
+from lightning.pytorch.callbacks import Callback
+from lightning.pytorch.utilities.rank_zero import rank_zero_warn
+
+class GradientStatsMonitor(Callback):
+    """
+    A PyTorch Lightning callback that monitors and logs gradient statistics during training.
+
+    This callback collects gradients after each training batch and computes a set of
+    useful metrics to help diagnose training behavior, such as gradient flow, vanishing
+    or exploding gradients, and sparsity patterns.
+
+    Features:
+        - Logs global gradient norm across all parameters
+        - Optionally logs per-layer gradient norms
+        - Computes statistical properties of gradients:
+            * Mean
+            * Standard deviation
+        - Measures gradient sparsity (fraction of near-zero values)
+        - Detects potential exploding gradients via a configurable threshold
+        - Optionally logs gradient histograms for visualization (e.g., TensorBoard)
+
+    Logging Behavior:
+        - Metrics are logged every `log_every_n_steps` steps
+        - Logging is performed only on the global rank (for distributed training safety)
+        - Uses Lightning's `log_dict` for compatibility with all supported loggers
+
+    Args:
+        log_every_n_steps (int):
+            Frequency (in training steps) at which gradient statistics are logged.
+
+        per_layer (bool):
+            If True, logs gradient norms for each parameter individually.
+            Parameter names are formatted to be compatible with hierarchical loggers.
+
+        track_stats (bool):
+            If True, logs mean and standard deviation of all gradients.
+
+        track_sparsity (bool):
+            If True, logs the fraction of gradients that are near zero
+            (useful for detecting dead neurons or sparse updates).
+
+        explosion_threshold (float):
+            Threshold for the global gradient norm above which a warning is raised,
+            indicating potential exploding gradients.
+
+        log_histogram (bool):
+            If True, logs the full gradient distribution as a histogram using
+            logger backends that support it (e.g., TensorBoard).
+
+    Notes:
+        - Parameters with `grad=None` are safely ignored.
+        - If no gradients are available (e.g., frozen model), the callback exits silently.
+        - Designed to be lightweight and not interfere with the training loop.
+
+    """
+    def __init__(
+            self,
+            log_every_n_steps: int = 1,
+            per_layer: bool = False,
+            track_stats: bool = True,
+            track_sparsity: bool = True,
+            explosion_threshold: float = 1e3,
+            log_histogram: bool = False,
+            
+        ):
+            super().__init__()
+            self.log_every_n_steps = log_every_n_steps
+            self.per_layer = per_layer
+            self.track_stats = track_stats
+            self.track_sparsity = track_sparsity
+            self.explosion_threshold = explosion_threshold
+            self.log_histogram = log_histogram
+
+    # -------------------------
+    # State key
+    # -------------------------
+    @property
+    def state_key(self) -> str:
+        return self._generate_state_key(
+            log_every_n_steps=self.log_every_n_steps,
+            per_layer=self.per_layer,
+            track_stats=self.track_stats,
+            track_sparsity=self.track_sparsity,
+            explosion_threshold=self.explosion_threshold,
+            log_histogram=self.log_histogram,
+        )
+    
+
+    # -------------------------
+    # Core hook
+    # -------------------------
+     
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        EPS = 1e-6
+        if trainer.global_step % self.log_every_n_steps != 0:
+            return
+
+        total_norm = 0.0
+        all_grads = []
+
+        layer_norms: Dict[str, float] = {}
+        metrics: Dict[str, float] = {}
+
+        # -------------------------
+        # Collect gradients
+        # -------------------------
+        for name, param in pl_module.named_parameters():
+            if param.grad is None:
+                continue
+
+            grad = param.grad.detach()
+
+            # Flatten for global stats
+            all_grads.append(grad.view(-1))
+
+            # Norm
+            param_norm = grad.norm(2).item()
+            total_norm += param_norm ** 2 # for the global norm over the layers 
+
+            if self.per_layer:
+                safe_name = name.replace(".", "/")# Replace "." to make names compatible with hierarchical loggers (e.g., TensorBoard)
+                layer_norms[f"grad/{safe_name}_norm"] = param_norm
+
+        if len(all_grads) == 0:
+            return
+        
+        # -------------------------
+        # Global norm
+        # -------------------------
+        total_norm = total_norm ** 0.5
+        metrics["grad/global_norm"] = total_norm
+
+        # -------------------------
+        # Stack gradients
+        # -------------------------
+        all_grads_tensor = torch.cat(all_grads)
+
+        # -------------------------
+        # Mean / Variance
+        # -------------------------
+        if self.track_stats:
+            metrics["grad/mean"] = all_grads_tensor.mean().item()
+            metrics["grad/std"] = all_grads_tensor.std(unbiased=False).item()
+
+
+        # -------------------------
+        # Sparsity (fraction near zero)
+        # -------------------------
+        if self.track_sparsity:
+            zero_fraction = (all_grads_tensor.abs() < EPS).float().mean().item()
+            metrics["grad/sparsity"] = zero_fraction
+
+        # -------------------------
+        # Explosion warning
+        # -------------------------
+        if total_norm > self.explosion_threshold:
+            rank_zero_warn(
+                f"Gradient norm is very high ({total_norm:.2f}). Possible exploding gradients."
+            )
+
+        # -------------------------
+        # Per-layer norms
+        # -------------------------
+        if self.per_layer:
+            metrics.update(layer_norms)
+
+        # -------------------------
+        # Logging (scalars)
+        # -------------------------
+        if trainer.is_global_zero:
+            if trainer.logger is not None:
+                pl_module.log_dict(metrics, prog_bar=False, logger=True)
+
+            if self.log_histogram and trainer.logger is not None:
+                exp = getattr(trainer.logger, "experiment", None)
+                if exp is not None and hasattr(exp, "add_histogram"):
+                        exp.add_histogram(
+                            "grad/all",
+                            all_grads_tensor,
+                            global_step=trainer.global_step,
+                        )

--- a/src/lightning/pytorch/callbacks/gradients_statistics_monitor.py
+++ b/src/lightning/pytorch/callbacks/gradients_statistics_monitor.py
@@ -76,7 +76,7 @@ class GradientStatsMonitor(Callback):
             per_layer: bool = False,
             track_stats: bool = True,
             track_sparsity: bool = True,
-            explosion_threshold: float = 1e3,
+            explosion_threshold: float = 1,
             log_histogram: bool = False,
             
         ):

--- a/src/lightning/pytorch/callbacks/gradients_statistics_monitor.py
+++ b/src/lightning/pytorch/callbacks/gradients_statistics_monitor.py
@@ -72,22 +72,21 @@ class GradientStatsMonitor(Callback):
     """
 
     def __init__(
-            self,
-            log_every_n_steps: int = 1,
-            per_layer: bool = False,
-            track_stats: bool = True,
-            track_sparsity: bool = True,
-            explosion_threshold: float = 1e4,
-            log_histogram: bool = False,
-            
-        ):
-            super().__init__()
-            self.log_every_n_steps = log_every_n_steps
-            self.per_layer = per_layer
-            self.track_stats = track_stats
-            self.track_sparsity = track_sparsity
-            self.explosion_threshold = explosion_threshold
-            self.log_histogram = log_histogram
+        self,
+        log_every_n_steps: int = 1,
+        per_layer: bool = False,
+        track_stats: bool = True,
+        track_sparsity: bool = True,
+        explosion_threshold: float = 1e4,
+        log_histogram: bool = False,
+    ):
+        super().__init__()
+        self.log_every_n_steps = log_every_n_steps
+        self.per_layer = per_layer
+        self.track_stats = track_stats
+        self.track_sparsity = track_sparsity
+        self.explosion_threshold = explosion_threshold
+        self.log_histogram = log_histogram
 
     # -------------------------
     # State key

--- a/src/lightning/pytorch/callbacks/gradients_statistics_monitor.py
+++ b/src/lightning/pytorch/callbacks/gradients_statistics_monitor.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict
 
 import torch
+
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.utilities.rank_zero import rank_zero_warn
 
+
 class GradientStatsMonitor(Callback):
-    """
-    A PyTorch Lightning callback that monitors and logs gradient statistics during training.
+    """A PyTorch Lightning callback that monitors and logs gradient statistics during training.
 
     This callback collects gradients after each training batch and computes a set of
     useful metrics to help diagnose training behavior, such as gradient flow, vanishing
@@ -70,23 +70,23 @@ class GradientStatsMonitor(Callback):
         - Designed to be lightweight and not interfere with the training loop.
 
     """
+
     def __init__(
-            self,
-            log_every_n_steps: int = 1,
-            per_layer: bool = False,
-            track_stats: bool = True,
-            track_sparsity: bool = True,
-            explosion_threshold: float = 1e3,
-            log_histogram: bool = False,
-            
-        ):
-            super().__init__()
-            self.log_every_n_steps = log_every_n_steps
-            self.per_layer = per_layer
-            self.track_stats = track_stats
-            self.track_sparsity = track_sparsity
-            self.explosion_threshold = explosion_threshold
-            self.log_histogram = log_histogram
+        self,
+        log_every_n_steps: int = 1,
+        per_layer: bool = False,
+        track_stats: bool = True,
+        track_sparsity: bool = True,
+        explosion_threshold: float = 1e3,
+        log_histogram: bool = False,
+    ):
+        super().__init__()
+        self.log_every_n_steps = log_every_n_steps
+        self.per_layer = per_layer
+        self.track_stats = track_stats
+        self.track_sparsity = track_sparsity
+        self.explosion_threshold = explosion_threshold
+        self.log_histogram = log_histogram
 
     # -------------------------
     # State key
@@ -101,12 +101,11 @@ class GradientStatsMonitor(Callback):
             explosion_threshold=self.explosion_threshold,
             log_histogram=self.log_histogram,
         )
-    
 
     # -------------------------
     # Core hook
     # -------------------------
-     
+
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         EPS = 1e-6
         if trainer.global_step % self.log_every_n_steps != 0:
@@ -115,8 +114,8 @@ class GradientStatsMonitor(Callback):
         total_norm = 0.0
         all_grads = []
 
-        layer_norms: Dict[str, float] = {}
-        metrics: Dict[str, float] = {}
+        layer_norms: dict[str, float] = {}
+        metrics: dict[str, float] = {}
 
         # -------------------------
         # Collect gradients
@@ -132,19 +131,21 @@ class GradientStatsMonitor(Callback):
 
             # Norm
             param_norm = grad.norm(2).item()
-            total_norm += param_norm ** 2 # for the global norm over the layers 
+            total_norm += param_norm**2  # for the global norm over the layers
 
             if self.per_layer:
-                safe_name = name.replace(".", "/")# Replace "." to make names compatible with hierarchical loggers (e.g., TensorBoard)
+                safe_name = name.replace(
+                    ".", "/"
+                )  # Replace "." to make names compatible with hierarchical loggers (e.g., TensorBoard)
                 layer_norms[f"grad/{safe_name}_norm"] = param_norm
 
         if len(all_grads) == 0:
             return
-        
+
         # -------------------------
         # Global norm
         # -------------------------
-        total_norm = total_norm ** 0.5
+        total_norm = total_norm**0.5
         metrics["grad/global_norm"] = total_norm
 
         # -------------------------
@@ -159,7 +160,6 @@ class GradientStatsMonitor(Callback):
             metrics["grad/mean"] = all_grads_tensor.mean().item()
             metrics["grad/std"] = all_grads_tensor.std(unbiased=False).item()
 
-
         # -------------------------
         # Sparsity (fraction near zero)
         # -------------------------
@@ -171,9 +171,7 @@ class GradientStatsMonitor(Callback):
         # Explosion warning
         # -------------------------
         if total_norm > self.explosion_threshold:
-            rank_zero_warn(
-                f"Gradient norm is very high ({total_norm:.2f}). Possible exploding gradients."
-            )
+            rank_zero_warn(f"Gradient norm is very high ({total_norm:.2f}). Possible exploding gradients.")
 
         # -------------------------
         # Per-layer norms
@@ -191,8 +189,8 @@ class GradientStatsMonitor(Callback):
             if self.log_histogram and trainer.logger is not None:
                 exp = getattr(trainer.logger, "experiment", None)
                 if exp is not None and hasattr(exp, "add_histogram"):
-                        exp.add_histogram(
-                            "grad/all",
-                            all_grads_tensor,
-                            global_step=trainer.global_step,
-                        )
+                    exp.add_histogram(
+                        "grad/all",
+                        all_grads_tensor,
+                        global_step=trainer.global_step,
+                    )

--- a/tests/tests_pytorch/callbacks/test_gradients_statistics_monitor.py
+++ b/tests/tests_pytorch/callbacks/test_gradients_statistics_monitor.py
@@ -19,8 +19,7 @@ class SimpleModel(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         x, y = batch
-        loss = torch.nn.functional.mse_loss(self(x), y)
-        return loss
+        return torch.nn.functional.mse_loss(self(x), y)
 
     def configure_optimizers(self):
         return torch.optim.SGD(self.parameters(), lr=0.1)
@@ -79,7 +78,7 @@ def test_gradient_logging_called(tmp_path, mocker):
         enable_checkpointing=False,
         logger=True,
     )
-    
+
     spy = mocker.spy(model, "log_dict")
 
     trainer.fit(model, loader)
@@ -110,7 +109,7 @@ def test_per_layer_logging(tmp_path, mocker):
     trainer.fit(model, loader)
 
     logged = spy.call_args[0][0]
-    assert any("grad/" in k for k in logged.keys())
+    assert any("grad/" in k for k in logged)
 
 
 # -------------------------

--- a/tests/tests_pytorch/callbacks/test_gradients_statistics_monitor.py
+++ b/tests/tests_pytorch/callbacks/test_gradients_statistics_monitor.py
@@ -1,0 +1,196 @@
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+import lightning.pytorch as pl
+from lightning.pytorch import Trainer
+from lightning.pytorch.callbacks import GradientStatsMonitor
+
+
+# -------------------------
+# Dummy model
+# -------------------------
+class SimpleModel(pl.LightningModule):
+    def __init__(self):
+        super().__init__()
+        self.layer = torch.nn.Linear(10, 1)
+
+    def forward(self, x):
+        return self.layer(x)
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        loss = torch.nn.functional.mse_loss(self(x), y)
+        return loss
+
+    def configure_optimizers(self):
+        return torch.optim.SGD(self.parameters(), lr=0.1)
+
+
+def get_dataloader():
+    x = torch.randn(32, 10)
+    y = torch.randn(32, 1)
+    return DataLoader(TensorDataset(x, y), batch_size=8)
+
+
+# -------------------------
+# 1. State key test
+# -------------------------
+def test_gradient_stats_state_key():
+    cb = GradientStatsMonitor(per_layer=True)
+    assert "GradientStatsMonitor" in cb.state_key
+    assert "per_layer" in cb.state_key
+
+
+# -------------------------
+# 2. Runs without crashing
+# -------------------------
+def test_gradient_stats_runs(tmp_path):
+    model = SimpleModel()
+    loader = get_dataloader()
+
+    cb = GradientStatsMonitor()
+
+    trainer = Trainer(
+        max_epochs=1,
+        limit_train_batches=2,
+        callbacks=[cb],
+        default_root_dir=tmp_path,
+        enable_checkpointing=False,
+        logger=True,
+    )
+
+    trainer.fit(model, loader)
+
+
+# -------------------------
+# 3. Logging is triggered
+# -------------------------
+def test_gradient_logging_called(tmp_path, mocker):
+    model = SimpleModel()
+    loader = get_dataloader()
+
+    cb = GradientStatsMonitor(log_every_n_steps=1)
+
+    trainer = Trainer(
+        max_epochs=1,
+        limit_train_batches=2,
+        callbacks=[cb],
+        default_root_dir=tmp_path,
+        enable_checkpointing=False,
+        logger=True,
+    )
+    
+    spy = mocker.spy(model, "log_dict")
+
+    trainer.fit(model, loader)
+
+    assert spy.call_count > 0
+
+
+# -------------------------
+# 4. Per-layer logging works
+# -------------------------
+def test_per_layer_logging(tmp_path, mocker):
+    model = SimpleModel()
+    loader = get_dataloader()
+
+    cb = GradientStatsMonitor(per_layer=True)
+
+    trainer = Trainer(
+        max_epochs=1,
+        limit_train_batches=1,
+        callbacks=[cb],
+        default_root_dir=tmp_path,
+        enable_checkpointing=False,
+        logger=True,
+    )
+
+    spy = mocker.spy(model, "log_dict")
+
+    trainer.fit(model, loader)
+
+    logged = spy.call_args[0][0]
+    assert any("grad/" in k for k in logged.keys())
+
+
+# -------------------------
+# 5. Stats computation (mean/std exist)
+# -------------------------
+def test_gradient_stats_values(tmp_path, mocker):
+    model = SimpleModel()
+    loader = get_dataloader()
+
+    cb = GradientStatsMonitor(track_stats=True)
+
+    trainer = Trainer(
+        max_epochs=1,
+        limit_train_batches=1,
+        callbacks=[cb],
+        default_root_dir=tmp_path,
+        enable_checkpointing=False,
+        logger=True,
+    )
+
+    spy = mocker.spy(model, "log_dict")
+
+    trainer.fit(model, loader)
+
+    logged = spy.call_args[0][0]
+
+    assert "grad/mean" in logged
+    assert "grad/std" in logged
+
+
+# -------------------------
+# 6. Sparsity computation
+# -------------------------
+def test_gradient_sparsity(tmp_path, mocker):
+    model = SimpleModel()
+    loader = get_dataloader()
+
+    cb = GradientStatsMonitor(track_sparsity=True)
+
+    trainer = Trainer(
+        max_epochs=1,
+        limit_train_batches=1,
+        callbacks=[cb],
+        default_root_dir=tmp_path,
+        enable_checkpointing=False,
+        logger=True,
+    )
+
+    spy = mocker.spy(model, "log_dict")
+
+    trainer.fit(model, loader)
+
+    logged = spy.call_args[0][0]
+
+    assert "grad/sparsity" in logged
+
+
+# -------------------------
+# 7. No gradients edge case
+# -------------------------
+class NoGradModel(SimpleModel):
+    def on_after_backward(self):
+        # simulate no gradients
+        for p in self.parameters():
+            p.grad = None
+
+
+def test_no_gradients_does_not_crash(tmp_path):
+    model = NoGradModel()
+    loader = get_dataloader()
+
+    cb = GradientStatsMonitor()
+
+    trainer = Trainer(
+        max_epochs=1,
+        limit_train_batches=1,
+        callbacks=[cb],
+        default_root_dir=tmp_path,
+        enable_checkpointing=False,
+        logger=True,
+    )
+
+    trainer.fit(model, loader)

--- a/tests/tests_pytorch/callbacks/testofthetest.py
+++ b/tests/tests_pytorch/callbacks/testofthetest.py
@@ -1,7 +1,9 @@
 import torch
 from torch.utils.data import DataLoader, TensorDataset
+
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks import GradientStatsMonitor
+
 
 # -------------------------
 # Dummy model
@@ -16,17 +18,17 @@ class SimpleModel(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         x, y = batch
-        loss = torch.nn.functional.mse_loss(self(x), y)
-        return loss
+        return torch.nn.functional.mse_loss(self(x), y)
 
     def configure_optimizers(self):
         return torch.optim.SGD(self.parameters(), lr=0.1)
 
+
 # -------------------------
 # Dummy data
 # -------------------------
-x = torch.randn(32, 10)*1e1
-y = torch.randn(32, 1)*1e1
+x = torch.randn(32, 10) * 1e1
+y = torch.randn(32, 1) * 1e1
 loader = DataLoader(TensorDataset(x, y), batch_size=8)
 
 # -------------------------
@@ -50,6 +52,7 @@ trainer = pl.Trainer(
     logger=True,  # Lightning will print logs to console
 )
 
+
 # -------------------------
 # Override log_dict to print
 # -------------------------
@@ -59,6 +62,7 @@ class PrintModel(SimpleModel):
         for k, v in metrics.items():
             print(f"{k}: {v}")
         super().log_dict(metrics, *args, **kwargs)
+
 
 # -------------------------
 # Run training

--- a/tests/tests_pytorch/callbacks/testofthetest.py
+++ b/tests/tests_pytorch/callbacks/testofthetest.py
@@ -1,0 +1,67 @@
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+import lightning.pytorch as pl
+from lightning.pytorch.callbacks import GradientStatsMonitor
+
+# -------------------------
+# Dummy model
+# -------------------------
+class SimpleModel(pl.LightningModule):
+    def __init__(self):
+        super().__init__()
+        self.layer = torch.nn.Linear(10, 1)
+
+    def forward(self, x):
+        return self.layer(x)
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        loss = torch.nn.functional.mse_loss(self(x), y)
+        return loss
+
+    def configure_optimizers(self):
+        return torch.optim.SGD(self.parameters(), lr=0.1)
+
+# -------------------------
+# Dummy data
+# -------------------------
+x = torch.randn(32, 10)*1e1
+y = torch.randn(32, 1)*1e1
+loader = DataLoader(TensorDataset(x, y), batch_size=8)
+
+# -------------------------
+# Callback
+# -------------------------
+grad_monitor = GradientStatsMonitor(
+    log_every_n_steps=1,
+    per_layer=True,
+    track_stats=True,
+    track_sparsity=True,
+    log_histogram=False,  # keep False if you don't want TensorBoard for now
+)
+
+# -------------------------
+# Lightning Trainer
+# -------------------------
+trainer = pl.Trainer(
+    max_epochs=2,
+    limit_train_batches=2,  # just for quick test
+    callbacks=[grad_monitor],
+    logger=True,  # Lightning will print logs to console
+)
+
+# -------------------------
+# Override log_dict to print
+# -------------------------
+class PrintModel(SimpleModel):
+    def log_dict(self, metrics, *args, **kwargs):
+        print("\nLogged metrics:")
+        for k, v in metrics.items():
+            print(f"{k}: {v}")
+        super().log_dict(metrics, *args, **kwargs)
+
+# -------------------------
+# Run training
+# -------------------------
+model = PrintModel()
+trainer.fit(model, loader)


### PR DESCRIPTION
Closes #21589 
This PR introduces the GradientStatsMonitor callback for Lightning that tracks gradient statistics
during training. Features include:

- Global gradient norm computation
- Per-layer gradient norms
- Mean and standard deviation of gradients
- Gradient sparsity (fraction of near-zero gradients)
- Explosion detection and warning
- Optional histogram logging for TensorBoard-like loggers

The callback logs metrics to the trainer's logger after every N steps (`log_every_n_steps`),
and supports enabling/disabling per-layer tracking, stats tracking, sparsity tracking, and
histogram logging.

This PR also includes:

- Tests for state key generation
- Tests for per-layer logging, stats, and sparsity
- Edge-case handling for models with no gradients

**How to test manually:**  
Run the provided example script (`manual_test_grad_monitor.py`) to see printed metrics for
a dummy model and verify that gradient statistics are computed correctly.

**Motivation:**  
Provides developers and researchers with an easy way to monitor gradients and catch
issues like exploding or vanishing gradients during model training.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21596.org.readthedocs.build/en/21596/

<!-- readthedocs-preview pytorch-lightning end -->