### PR TITLE
fix: clone async checkpoint tensors to CPU to prevent GPU OOM

### DIFF
--- a/src/lightning/pytorch/plugins/io/async_plugin.py
+++ b/src/lightning/pytorch/plugins/io/async_plugin.py
@@ -100,9 +100,9 @@ def _clone_tensor(t: torch.Tensor) -> torch.Tensor:
     Detaches from autograd, moves to CPU, and ensures a point-in-time snapshot
     that won't be mutated by ongoing training.
 
-    For CUDA tensors ``cpu()`` already allocates a new host-memory copy, so an
-    extra ``clone()`` is unnecessary.  For CPU tensors ``cpu()`` is a no-op, so
-    ``clone()`` is required to break storage sharing.
+    For CPU tensors ``cpu()`` is a no-op, so ``clone()`` is required to break
+    storage sharing.  For all other devices (CUDA, TPU, XLA, …) ``cpu()``
+    already allocates a new host-memory copy, making ``clone()`` unnecessary.
 
     """
     if t.is_cpu:

--- a/src/lightning/pytorch/plugins/io/async_plugin.py
+++ b/src/lightning/pytorch/plugins/io/async_plugin.py
@@ -105,6 +105,6 @@ def _clone_tensor(t: torch.Tensor) -> torch.Tensor:
     ``clone()`` is required to break storage sharing.
 
     """
-    if t.is_cuda:
-        return t.detach().cpu()
-    return t.detach().clone()
+    if t.is_cpu:
+        return t.detach().clone()
+    return t.detach().cpu()

--- a/src/lightning/pytorch/plugins/io/async_plugin.py
+++ b/src/lightning/pytorch/plugins/io/async_plugin.py
@@ -103,6 +103,7 @@ def _clone_tensor(t: torch.Tensor) -> torch.Tensor:
     For CUDA tensors ``cpu()`` already allocates a new host-memory copy, so an
     extra ``clone()`` is unnecessary.  For CPU tensors ``cpu()`` is a no-op, so
     ``clone()`` is required to break storage sharing.
+
     """
     if t.is_cuda:
         return t.detach().cpu()

--- a/src/lightning/pytorch/plugins/io/async_plugin.py
+++ b/src/lightning/pytorch/plugins/io/async_plugin.py
@@ -95,8 +95,15 @@ class AsyncCheckpointIO(_WrappingCheckpointIO):
 
 # snapshot the checkpoint payload on the caller thread to avoid races with parameter mutation
 def _clone_tensor(t: torch.Tensor) -> torch.Tensor:
-    """Clones a tensor to CPU on the caller thread."""
-    # detach to avoid autograd history, move to CPU to avoid doubling GPU memory usage, and clone to take a
-    # point-in-time copy. Moving to CPU first is important because clone() on a CUDA tensor allocates new GPU memory,
-    # which can cause OOM errors for large model checkpoints.
-    return t.detach().cpu().clone()
+    """Clone a tensor to CPU memory.
+
+    Detaches from autograd, moves to CPU, and ensures a point-in-time snapshot
+    that won't be mutated by ongoing training.
+
+    For CUDA tensors ``cpu()`` already allocates a new host-memory copy, so an
+    extra ``clone()`` is unnecessary.  For CPU tensors ``cpu()`` is a no-op, so
+    ``clone()`` is required to break storage sharing.
+    """
+    if t.is_cuda:
+        return t.detach().cpu()
+    return t.detach().clone()

--- a/src/lightning/pytorch/plugins/io/async_plugin.py
+++ b/src/lightning/pytorch/plugins/io/async_plugin.py
@@ -95,6 +95,8 @@ class AsyncCheckpointIO(_WrappingCheckpointIO):
 
 # snapshot the checkpoint payload on the caller thread to avoid races with parameter mutation
 def _clone_tensor(t: torch.Tensor) -> torch.Tensor:
-    """Clones a tensor on the caller thread."""
-    # detach to avoid autograd history and clone to take a point-in-time copy
-    return t.detach().clone()
+    """Clones a tensor to CPU on the caller thread."""
+    # detach to avoid autograd history, move to CPU to avoid doubling GPU memory usage, and clone to take a
+    # point-in-time copy. Moving to CPU first is important because clone() on a CUDA tensor allocates new GPU memory,
+    # which can cause OOM errors for large model checkpoints.
+    return t.detach().cpu().clone()

--- a/tests/tests_pytorch/plugins/test_async_checkpoint.py
+++ b/tests/tests_pytorch/plugins/test_async_checkpoint.py
@@ -55,7 +55,7 @@ def test_async_checkpoint_should_snapshot_values_before_mutation():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_async_checkpoint_clones_tensors_to_cpu():
-    """Verify that _clone_tensor moves tensors to CPU to avoid doubling GPU memory usage."""
+    """Verify that _clone_tensor produces a CPU snapshot that does not share storage."""
     from lightning.pytorch.plugins.io.async_plugin import _clone_tensor
 
     t = torch.tensor([1.0, 2.0, 3.0])
@@ -67,3 +67,6 @@ def test_async_checkpoint_clones_tensors_to_cpu():
     assert torch.equal(cloned, t)
     # cloned tensor should not share storage with the original
     assert cloned.data_ptr() != t.data_ptr()
+    # mutation of the original must not affect the clone
+    t.add_(1.0)
+    assert torch.equal(cloned, torch.tensor([1.0, 2.0, 3.0]))

--- a/tests/tests_pytorch/plugins/test_async_checkpoint.py
+++ b/tests/tests_pytorch/plugins/test_async_checkpoint.py
@@ -51,3 +51,19 @@ def test_async_checkpoint_should_snapshot_values_before_mutation():
         "AsyncCheckpointIO must snapshot the checkpoint (clone tensors) on the main thread "
         "to avoid races with parameter mutation; got mutated value instead"
     )
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_async_checkpoint_clones_tensors_to_cpu():
+    """Verify that _clone_tensor moves tensors to CPU to avoid doubling GPU memory usage."""
+    from lightning.pytorch.plugins.io.async_plugin import _clone_tensor
+
+    t = torch.tensor([1.0, 2.0, 3.0])
+    cloned = _clone_tensor(t)
+
+    # cloned tensor should be on CPU
+    assert cloned.device == torch.device("cpu"), f"Expected CPU tensor, got {cloned.device}"
+    # values should match
+    assert torch.equal(cloned, t)
+    # cloned tensor should not share storage with the original
+    assert cloned.data_ptr() != t.data_ptr()

--- a/tests/tests_pytorch/plugins/test_async_checkpoint.py
+++ b/tests/tests_pytorch/plugins/test_async_checkpoint.py
@@ -6,6 +6,7 @@ import torch
 
 from lightning.fabric.plugins.io.checkpoint_io import CheckpointIO
 from lightning.pytorch.plugins.io.async_plugin import AsyncCheckpointIO
+from tests_pytorch.helpers.runif import RunIf
 
 
 class _CaptureCheckpointIO(CheckpointIO):
@@ -53,20 +54,22 @@ def test_async_checkpoint_should_snapshot_values_before_mutation():
     )
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_async_checkpoint_clones_tensors_to_cpu():
+@RunIf(min_cuda_gpus=1)
+@pytest.mark.parametrize(("device"), ["cpu", "cuda:0"])
+def test_async_checkpoint_clones_tensors_to_cpu(device):
     """Verify that _clone_tensor produces a CPU snapshot that does not share storage."""
     from lightning.pytorch.plugins.io.async_plugin import _clone_tensor
 
-    t = torch.tensor([1.0, 2.0, 3.0])
+    t = torch.tensor([1.0, 2.0, 3.0], device=device)
     cloned = _clone_tensor(t)
 
     # cloned tensor should be on CPU
     assert cloned.device == torch.device("cpu"), f"Expected CPU tensor, got {cloned.device}"
     # values should match
-    assert torch.equal(cloned, t)
+    assert torch.equal(cloned, t.cpu())
     # cloned tensor should not share storage with the original
     assert cloned.data_ptr() != t.data_ptr()
     # mutation of the original must not affect the clone
     t.add_(1.0)
     assert torch.equal(cloned, torch.tensor([1.0, 2.0, 3.0]))
+    assert t.device == torch.device(device), f"Original tensor should remain on {device}, got {t.device}"


### PR DESCRIPTION
## Summary

Clone async checkpoint tensors to CPU to prevent GPU OOM during async saves.

## Details

`AsyncCheckpointIO._clone_tensor()` previously called `t.detach().clone()`, which allocates new GPU memory for each cloned tensor. For large model checkpoints (e.g., 15GB+), this **doubles GPU memory usage** during checkpoint saves, which can cause OOM errors.

### Before (GPU clone):
```
[ASYNC CHECKPOINT BEFORE clone] GPU 0: allocated=21.54 GB
[ASYNC CHECKPOINT AFTER clone]  GPU 0: allocated=37.54 GB  ← +16 GB!
```

### After (CPU clone):
```
[ASYNC CHECKPOINT BEFORE clone] GPU 0: allocated=21.54 GB
[ASYNC CHECKPOINT AFTER clone]  GPU 0: allocated=21.54 GB  ← no change
```

### Changes
- **`async_plugin.py`**: Changed `t.detach().clone()` → `t.detach().cpu().clone()` in `_clone_tensor()`. Moving to CPU first avoids doubling GPU memory. CPU memory is typically abundant and this still prevents the race condition with parameter mutation.
- **`test_async_checkpoint.py`**: Added `test_async_checkpoint_clones_tensors_to_cpu()` to verify cloned tensors are on CPU and retain correct values.

Fixes #21630


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21631.org.readthedocs.build/en/21631/

<!-- readthedocs-preview pytorch-lightning end -->