### PR TITLE
feat: add `enable_device_summary` flag to Trainer

### DIFF
--- a/docs/source-pytorch/common/trainer.rst
+++ b/docs/source-pytorch/common/trainer.rst
@@ -534,6 +534,22 @@ Whether to enable or disable the model summarization. Defaults to True.
     trainer = Trainer(enable_model_summary=True, callbacks=[ModelSummary(max_depth=-1)])
 
 
+enable_device_summary
+^^^^^^^^^^^^^^^^^^^^^
+
+Whether to log device information (GPU, TPU availability and usage) at the start of a run.
+Defaults to True. Set to ``False`` to suppress the device info output, which is useful when
+calling ``Trainer.predict()`` in a loop.
+
+.. testcode::
+
+    # default used by the Trainer
+    trainer = Trainer(enable_device_summary=True)
+
+    # disable device summary
+    trainer = Trainer(enable_device_summary=False)
+
+
 enable_progress_bar
 ^^^^^^^^^^^^^^^^^^^
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added `suggest_integrations` flag to `Trainer` to control whether optional integration suggestions (e.g., litmodels, litlogger) are shown in logs ([#21632](https://github.com/Lightning-AI/pytorch-lightning/pull/21632))
 
-- Added `enable_device_summary` flag to `Trainer` to control whether device info (GPU/TPU availability) is logged at initialization ([#13378](https://github.com/Lightning-AI/pytorch-lightning/issues/13378))
+- Added `enable_device_summary` flag to `Trainer` to control whether device info (GPU/TPU availability) is logged at initialization ([#21637](https://github.com/Lightning-AI/pytorch-lightning/issues/21637))
 
 - Added `log_key_prefix` parameter to `LearningRateMonitor` callback for prefixing logged metric names ([#21612](https://github.com/Lightning-AI/pytorch-lightning/issues/21612))
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added `suggest_integrations` flag to `Trainer` to control whether optional integration suggestions (e.g., litmodels, litlogger) are shown in logs ([#21632](https://github.com/Lightning-AI/pytorch-lightning/pull/21632))
 
+- Added `enable_device_summary` flag to `Trainer` to control whether device info (GPU/TPU availability) is logged at initialization ([#13378](https://github.com/Lightning-AI/pytorch-lightning/issues/13378))
+
 - Added `log_key_prefix` parameter to `LearningRateMonitor` callback for prefixing logged metric names ([#21612](https://github.com/Lightning-AI/pytorch-lightning/issues/21612))
 
 ### Changed

--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -133,6 +133,7 @@ class Trainer:
         enable_autolog_hparams: bool = True,
         model_registry: Optional[str] = None,
         suggest_integrations: bool = True,
+        enable_device_summary: bool = True,
     ) -> None:
         r"""Customize every aspect of training via flags.
 
@@ -310,6 +311,11 @@ class Trainer:
             model_registry: The name of the model being uploaded to Model hub.
 
             suggest_integrations: Whether to display suggestions for optional Lightning integrations.
+                Default: ``True``.
+
+            enable_device_summary: Whether to log device information (GPU, TPU availability and usage)
+                at the start of a run. Set to ``False`` to suppress the device info output, which is
+                useful when using :meth:`~lightning.pytorch.trainer.trainer.Trainer.predict` in a loop.
                 Default: ``True``.
 
 
@@ -491,7 +497,8 @@ class Trainer:
             )
         self._detect_anomaly: bool = detect_anomaly
 
-        setup._log_device_info(self)
+        if enable_device_summary:
+            setup._log_device_info(self)
 
         self.should_stop = False
         self.state = TrainerState()


### PR DESCRIPTION
## What does this PR do?

Fixes #13378

Adds a new `enable_device_summary` boolean parameter to the `Trainer` that controls whether device information (GPU/TPU availability and usage) is logged during initialization. Defaults to `True` for backward compatibility.

Setting `enable_device_summary=False` suppresses the device info output, which is useful when calling `Trainer.predict()` in a loop where the repeated device summaries clutter the output:

```
GPU available: False, used: False
TPU available: False, using: 0 TPU cores
=======================================================
n_gen |  n_eval |  n_nds  |     eps      |  indicator  
=======================================================
    1 |     322 |       3 |            - |            -
GPU available: False, used: False
TPU available: False, using: 0 TPU cores
    2 |    1322 |       4 |  0.625000000 |        ideal
```

### Usage

```python
# Suppress device info when using predict in a loop
trainer = Trainer(enable_device_summary=False)
for batch in surrogate_loop:
    trainer.predict(model, dataloaders=batch_loader)
```

### Changes

- Added `enable_device_summary: bool = True` parameter to `Trainer.__init__`
- Gated the `_log_device_info()` call with the new flag
- Updated CHANGELOG and documentation

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21637.org.readthedocs.build/en/21637/

<!-- readthedocs-preview pytorch-lightning end -->