### PR TITLE
Add num_nodes() method to ClusterEnvironment

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `num_nodes()` abstract method to `ClusterEnvironment` to allow querying the number of nodes from the cluster ([#7361](https://github.com/Lightning-AI/pytorch-lightning/issues/7361))
+
 -
 
 ### Changed

--- a/src/lightning/fabric/plugins/environments/cluster_environment.py
+++ b/src/lightning/fabric/plugins/environments/cluster_environment.py
@@ -61,6 +61,10 @@ class ClusterEnvironment(ABC):
     def node_rank(self) -> int:
         """The rank (index) of the node on which the current process runs."""
 
+    @abstractmethod
+    def num_nodes(self) -> int:
+        """The number of nodes in the cluster."""
+
     def validate_settings(self, num_devices: int, num_nodes: int) -> None:
         """Validates settings configured in the script against the environment, and raises an exception if there is an
         inconsistency."""

--- a/src/lightning/fabric/plugins/environments/kubeflow.py
+++ b/src/lightning/fabric/plugins/environments/kubeflow.py
@@ -76,3 +76,7 @@ class KubeflowEnvironment(ClusterEnvironment):
     @override
     def node_rank(self) -> int:
         return self.global_rank()
+
+    @override
+    def num_nodes(self) -> int:
+        return int(os.environ.get("NUM_NODES", self.world_size()))

--- a/src/lightning/fabric/plugins/environments/lightning.py
+++ b/src/lightning/fabric/plugins/environments/lightning.py
@@ -100,6 +100,10 @@ class LightningEnvironment(ClusterEnvironment):
         return int(os.environ.get("NODE_RANK", group_rank))
 
     @override
+    def num_nodes(self) -> int:
+        return int(os.environ.get("NUM_NODES", 1))
+
+    @override
     def teardown(self) -> None:
         if "WORLD_SIZE" in os.environ:
             del os.environ["WORLD_SIZE"]

--- a/src/lightning/fabric/plugins/environments/lsf.py
+++ b/src/lightning/fabric/plugins/environments/lsf.py
@@ -135,6 +135,12 @@ class LSFEnvironment(ClusterEnvironment):
         ``LSB_DJOB_RANKFILE``."""
         return self._node_rank
 
+    @override
+    def num_nodes(self) -> int:
+        """The number of nodes is determined by the number of unique hosts in the rank file."""
+        hosts = self._read_hosts()
+        return len(set(hosts))
+
     def _get_node_rank(self) -> int:
         """A helper method for getting the node rank.
 

--- a/src/lightning/fabric/plugins/environments/mpi.py
+++ b/src/lightning/fabric/plugins/environments/mpi.py
@@ -114,6 +114,14 @@ class MPIEnvironment(ClusterEnvironment):
         assert self._node_rank is not None
         return self._node_rank
 
+    @override
+    @lru_cache(1)
+    def num_nodes(self) -> int:
+        hostname = socket.gethostname()
+        all_hostnames = self._comm_world.gather(hostname, root=0)
+        num = len(set(all_hostnames)) if all_hostnames is not None else 0
+        return self._comm_world.bcast(num, root=0)
+
     def _get_main_address(self) -> str:
         return self._comm_world.bcast(socket.gethostname(), root=0)
 

--- a/src/lightning/fabric/plugins/environments/slurm.py
+++ b/src/lightning/fabric/plugins/environments/slurm.py
@@ -155,6 +155,10 @@ class SLURMEnvironment(ClusterEnvironment):
         return int(os.environ["SLURM_NODEID"])
 
     @override
+    def num_nodes(self) -> int:
+        return int(os.environ.get("SLURM_NNODES", 1))
+
+    @override
     def validate_settings(self, num_devices: int, num_nodes: int) -> None:
         if _is_slurm_interactive_mode():
             return

--- a/src/lightning/fabric/plugins/environments/torchelastic.py
+++ b/src/lightning/fabric/plugins/environments/torchelastic.py
@@ -85,6 +85,10 @@ class TorchElasticEnvironment(ClusterEnvironment):
         return int(os.environ.get("GROUP_RANK", 0))
 
     @override
+    def num_nodes(self) -> int:
+        return int(os.environ.get("GROUP_WORLD_SIZE", 1))
+
+    @override
     def validate_settings(self, num_devices: int, num_nodes: int) -> None:
         if num_devices * num_nodes != self.world_size():
             raise ValueError(

--- a/src/lightning/fabric/plugins/environments/xla.py
+++ b/src/lightning/fabric/plugins/environments/xla.py
@@ -133,3 +133,22 @@ class XLAEnvironment(ClusterEnvironment):
         from torch_xla.utils.utils import getenv_as
 
         return getenv_as(xenv.HOST_ORDINAL, int, 0)
+
+    @override
+    @functools.lru_cache(maxsize=1)
+    def num_nodes(self) -> int:
+        """The number of hosts/nodes in the TPU Pod.
+
+        The output is cached for performance.
+
+        """
+        if _XLA_GREATER_EQUAL_2_1:
+            from torch_xla import runtime as xr
+
+            return xr.host_count()
+
+        import os
+
+        import torch_xla.core.xla_env_vars as xenv
+
+        return int(os.environ.get(xenv.HOST_WORLD_SIZE, 1))

--- a/tests/tests_fabric/plugins/environments/test_kubeflow.py
+++ b/tests/tests_fabric/plugins/environments/test_kubeflow.py
@@ -74,6 +74,20 @@ def test_attributes_from_environment_variables(caplog):
     assert "setting world size is not allowed" in caplog.text
 
 
+@mock.patch.dict(os.environ, {"WORLD_SIZE": "8", "RANK": "0", "NUM_NODES": "4"})
+def test_num_nodes():
+    """Test that num_nodes reads the NUM_NODES environment variable."""
+    env = KubeflowEnvironment()
+    assert env.num_nodes() == 4
+
+
+@mock.patch.dict(os.environ, {"WORLD_SIZE": "8", "RANK": "0"})
+def test_num_nodes_default():
+    """Test that num_nodes defaults to world_size when NUM_NODES is not set."""
+    env = KubeflowEnvironment()
+    assert env.num_nodes() == 8
+
+
 def test_detect_kubeflow():
     """Test that the KubeflowEnvironment does not support auto-detection."""
     with pytest.raises(NotImplementedError, match="can't be detected automatically"):

--- a/tests/tests_fabric/plugins/environments/test_lightning.py
+++ b/tests/tests_fabric/plugins/environments/test_lightning.py
@@ -29,6 +29,7 @@ def test_default_attributes():
     assert env.world_size() == 1
     assert env.local_rank() == 0
     assert env.node_rank() == 0
+    assert env.num_nodes() == 1
 
 
 @mock.patch.dict(os.environ, {"MASTER_ADDR": "1.2.3.4", "MASTER_PORT": "500", "LOCAL_RANK": "2", "NODE_RANK": "3"})
@@ -82,6 +83,20 @@ def test_teardown():
     assert "WORLD_SIZE" in os.environ
     env.teardown()
     assert "WORLD_SIZE" not in os.environ
+
+
+@mock.patch.dict(os.environ, {"NUM_NODES": "4"})
+def test_num_nodes():
+    """Test that num_nodes reads the NUM_NODES environment variable."""
+    env = LightningEnvironment()
+    assert env.num_nodes() == 4
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_num_nodes_default():
+    """Test that num_nodes defaults to 1 when NUM_NODES is not set."""
+    env = LightningEnvironment()
+    assert env.num_nodes() == 1
 
 
 def test_detect():

--- a/tests/tests_fabric/plugins/environments/test_slurm.py
+++ b/tests/tests_fabric/plugins/environments/test_slurm.py
@@ -70,6 +70,7 @@ def test_attributes_from_environment_variables(caplog):
     assert env.global_rank() == 1
     assert env.local_rank() == 2
     assert env.node_rank() == 3
+    assert env.num_nodes() == 1  # SLURM_NNODES not set, defaults to 1
     assert env.job_name() == "JOB"
     # setter should be no-op
     with caplog.at_level(logging.DEBUG, logger="lightning.fabric.plugins.environments"):
@@ -180,3 +181,17 @@ def test_validate_user_settings():
     ):
         env = SLURMEnvironment()
         env.validate_settings(num_devices=4, num_nodes=1)  # no error
+
+
+@mock.patch.dict(os.environ, {"SLURM_NTASKS": "8", "SLURM_NTASKS_PER_NODE": "4", "SLURM_NNODES": "2"})
+def test_num_nodes():
+    """Test that num_nodes reads the SLURM_NNODES environment variable."""
+    env = SLURMEnvironment()
+    assert env.num_nodes() == 2
+
+
+@mock.patch.dict(os.environ, {"SLURM_NTASKS": "4", "SLURM_NTASKS_PER_NODE": "4"})
+def test_num_nodes_default():
+    """Test that num_nodes defaults to 1 when SLURM_NNODES is not set."""
+    env = SLURMEnvironment()
+    assert env.num_nodes() == 1

--- a/tests/tests_fabric/plugins/environments/test_torchelastic.py
+++ b/tests/tests_fabric/plugins/environments/test_torchelastic.py
@@ -57,6 +57,7 @@ def test_attributes_from_environment_variables(caplog):
     assert env.global_rank() == 1
     assert env.local_rank() == 2
     assert env.node_rank() == 3
+    assert env.num_nodes() == 1  # GROUP_WORLD_SIZE not set, defaults to 1
     # setter should be no-op
     with caplog.at_level(logging.DEBUG, logger="lightning.fabric.plugins.environments"):
         env.set_global_rank(100)
@@ -92,3 +93,17 @@ def test_validate_user_settings():
     env.validate_settings(num_devices=4, num_nodes=2)
     with pytest.raises(ValueError, match=re.escape("the product (2 * 2) does not match the world size (8)")):
         env.validate_settings(num_devices=2, num_nodes=2)
+
+
+@mock.patch.dict(os.environ, {"GROUP_WORLD_SIZE": "4"})
+def test_num_nodes():
+    """Test that num_nodes reads the GROUP_WORLD_SIZE environment variable."""
+    env = TorchElasticEnvironment()
+    assert env.num_nodes() == 4
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_num_nodes_default():
+    """Test that num_nodes defaults to 1 when GROUP_WORLD_SIZE is not set."""
+    env = TorchElasticEnvironment()
+    assert env.num_nodes() == 1


### PR DESCRIPTION
## Summary

- Adds an abstract `num_nodes()` method to the `ClusterEnvironment` base class so the number of nodes can be queried directly from the cluster environment
- Implements `num_nodes()` in all seven concrete subclasses (SLURM, TorchElastic, Lightning, Kubeflow, LSF, MPI, XLA), each deriving the value from the appropriate environment-specific source
- Adds unit tests for the new method across all testable environments

## Motivation

Closes #7361. Currently `num_nodes` must be specified manually by the user, but in most cluster environments this information is already available (e.g., `SLURM_NNODES`, `GROUP_WORLD_SIZE`). This change allows the cluster environment to provide it automatically.

## Implementation Details

| Environment | Source |
|---|---|
| `SLURMEnvironment` | `SLURM_NNODES` env var (default: 1) |
| `TorchElasticEnvironment` | `GROUP_WORLD_SIZE` env var (default: 1) |
| `LightningEnvironment` | `NUM_NODES` env var (default: 1) |
| `KubeflowEnvironment` | `NUM_NODES` env var (default: `world_size`) |
| `LSFEnvironment` | Unique hosts in `LSB_DJOB_RANKFILE` |
| `MPIEnvironment` | Unique hostnames via `MPI.COMM_WORLD.gather` |
| `XLAEnvironment` | `xr.host_count()` (XLA >= 2.1) or `HOST_WORLD_SIZE` env var |

## Test plan

- [x] Added dedicated `test_num_nodes` and `test_num_nodes_default` tests for SLURM, TorchElastic, Lightning, and Kubeflow environments
- [x] Added inline assertion in existing `test_attributes_from_environment_variables` for SLURM and TorchElastic
- [x] All 42 environment tests pass locally

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21638.org.readthedocs.build/en/21638/

<!-- readthedocs-preview pytorch-lightning end -->