### PR TITLE
fix: honor train_bn in BackboneFinetuning.freeze_before_training

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `LightningModule.toggle_optimizer` / `untoggle_optimizer` breaking under `torch.compile` by disabling Dynamo tracing on these bookkeeping helpers ([#21513](https://github.com/Lightning-AI/pytorch-lightning/issues/21513))
 
+- Fixed `BackboneFinetuning` not honoring `train_bn` during the initial frozen phase, leaving `BatchNorm` layers trainable when `train_bn=False` ([#21652](https://github.com/Lightning-AI/pytorch-lightning/pull/21652))
+
 ---
 
 ## [2.6.4] - 2026-05-20

--- a/src/lightning/pytorch/callbacks/finetuning.py
+++ b/src/lightning/pytorch/callbacks/finetuning.py
@@ -455,7 +455,7 @@ class BackboneFinetuning(BaseFinetuning):
 
     @override
     def freeze_before_training(self, pl_module: "pl.LightningModule") -> None:
-        self.freeze(pl_module.backbone)
+        self.freeze(pl_module.backbone, train_bn=self.train_bn)
 
     @override
     def finetune_function(self, pl_module: "pl.LightningModule", epoch: int, optimizer: Optimizer) -> None:

--- a/tests/tests_pytorch/callbacks/test_finetuning_callback.py
+++ b/tests/tests_pytorch/callbacks/test_finetuning_callback.py
@@ -73,6 +73,37 @@ def test_finetuning_callback(tmp_path):
     assert model.backbone.has_been_used
 
 
+def test_finetuning_callback_train_bn_false(tmp_path):
+    """Test that BackboneFinetuning respects train_bn=False during the initial freeze phase."""
+    seed_everything(42)
+
+    class FinetuningBoringModel(BoringModel):
+        def __init__(self):
+            super().__init__()
+            self.backbone = nn.Sequential(nn.Linear(32, 32, bias=False), nn.BatchNorm1d(32), nn.ReLU())
+            self.layer = nn.Linear(32, 2)
+
+        def forward(self, x):
+            return self.layer(self.backbone(x))
+
+        def configure_optimizers(self):
+            return torch.optim.SGD(self.layer.parameters(), lr=0.1)
+
+        def train_dataloader(self):
+            return DataLoader(RandomDataset(32, 64), batch_size=2)
+
+    model = FinetuningBoringModel()
+    callback = BackboneFinetuning(unfreeze_backbone_at_epoch=3, train_bn=False, verbose=False)
+
+    trainer = Trainer(limit_train_batches=4, default_root_dir=tmp_path, callbacks=[callback], max_epochs=1)
+    trainer.fit(model)
+
+    # With train_bn=False, BatchNorm should be fully frozen (not trainable, no running stats)
+    assert not model.backbone[1].weight.requires_grad
+    assert not model.backbone[1].bias.requires_grad
+    assert not model.backbone[1].track_running_stats
+
+
 class TestBackboneFinetuningWarningCallback(BackboneFinetuning):
     def finetune_function(self, pl_module, epoch: int, optimizer):
         """Called when the epoch begins."""


### PR DESCRIPTION
## What does this PR do?

Fixes #21531

`BackboneFinetuning.freeze_before_training()` called `self.freeze(pl_module.backbone)` without forwarding the `train_bn` parameter, so BatchNorm layers stayed trainable during the initial frozen phase regardless of the `train_bn` setting passed to the constructor.

The unfreezing path in `finetune_function()` already passed `train_bn=self.train_bn` correctly — this change makes the freezing path consistent.

## Before submitting

- [x] Was this discussed/agreed via a GitHub issue? (see #21531)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you write any new necessary tests?
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/Lightning-AI/pytorch-lightning/blob/master/src/lightning/pytorch/CHANGELOG.md)?

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21652.org.readthedocs.build/en/21652/

<!-- readthedocs-preview pytorch-lightning end -->