### PR TITLE
Fix dataloader reload schedule when resuming from checkpoint (#21492)

### DIFF
--- a/src/lightning/pytorch/loops/fit_loop.py
+++ b/src/lightning/pytorch/loops/fit_loop.py
@@ -522,11 +522,13 @@ class _FitLoop(_Loop):
         state_dict = super().on_save_checkpoint()
         if self._combined_loader is not None and (loader_states := self._combined_loader._state_dicts()):
             state_dict["combined_loader"] = loader_states
+        state_dict["last_train_dl_reload_epoch"] = self._last_train_dl_reload_epoch
         return state_dict
 
     @override
     def on_load_checkpoint(self, state_dict: dict) -> None:
         self._combined_loader_states_to_load = state_dict.get("combined_loader", [])
+        self._last_train_dl_reload_epoch = state_dict.get("last_train_dl_reload_epoch", float("-inf"))
         super().on_load_checkpoint(state_dict)
 
     def _warn_if_modules_in_eval_mode(self) -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes #21492

### Problem
When resuming training from a checkpoint, the variable `_last_train_dl_reload_epoch` was not persisted in the checkpoint state.

Because of this, when training resumed, the `FitLoop` initialized `_last_train_dl_reload_epoch` to `-inf`, which caused incorrect dataloader reload scheduling when using:

Trainer(reload_dataloaders_every_n_epochs = n)

This resulted in unexpected dataloader reload behaviour after checkpoint resume.

---

### Solution
Persist `_last_train_dl_reload_epoch` in the loop checkpoint state:

Added logic to:

• save the variable inside `on_save_checkpoint()`
• restore the variable inside `on_load_checkpoint()`

```python
state_dict["last_train_dl_reload_epoch"] = self._last_train_dl_reload_epoch

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21657.org.readthedocs.build/en/21657/

<!-- readthedocs-preview pytorch-lightning end -->