### PR TITLE
Add typing_extensions.Override to SpikeDetection callback

### DIFF
--- a/src/lightning/pytorch/callbacks/spike.py
+++ b/src/lightning/pytorch/callbacks/spike.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping
 from typing import Any, Union
 
 import torch
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.fabric.utilities.spike import SpikeDetection as FabricSpikeDetection
@@ -10,6 +11,7 @@ from lightning.pytorch.callbacks.callback import Callback
 
 
 class SpikeDetection(FabricSpikeDetection, Callback):
+    @override
     @torch.no_grad()
     def on_train_batch_end(  # type: ignore
         self,


### PR DESCRIPTION
## Summary
Add `@override` decorator from `typing_extensions` to the `SpikeDetection.on_train_batch_end` method, improving type safety and making it explicit that this method overrides the parent class implementation.

## Changes
- Import `override` from `typing_extensions`
- Add `@override` decorator to `SpikeDetection.on_train_batch_end`

## Testing
- `python -m pytest tests/tests_pytorch/callbacks/test_spike.py` — existing tests pass
- `mypy src/lightning/pytorch/callbacks/spike.py` — type check passes

Closes #18695

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21664.org.readthedocs.build/en/21664/

<!-- readthedocs-preview pytorch-lightning end -->