### PR TITLE
Fix DeepSpeed auto batch size crash for DataLoader(batch_size=None)

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `SIGTERMException` producing a zero exit code instead of 143 (128 + SIGTERM) ([#21623](https://github.com/Lightning-AI/pytorch-lightning/issues/21623))
 
+- Fixed `DeepSpeedStrategy` crashing with `AttributeError` when the training dataloader has no batch sampler (e.g. `DataLoader(batch_size=None)`); now falls back to a batch size of 1 and warns ([#19460](https://github.com/Lightning-AI/pytorch-lightning/issues/19460))
+
 ---
 
 ## [2.6.2] - 2026-03-19

--- a/src/lightning/pytorch/strategies/deepspeed.py
+++ b/src/lightning/pytorch/strategies/deepspeed.py
@@ -940,6 +940,15 @@ class DeepSpeedStrategy(DDPStrategy):
         data_source = self.lightning_module.trainer.fit_loop._data_source
         if data_source.is_defined():
             train_dataloader = data_source.dataloader()
-            if hasattr(train_dataloader, "batch_sampler"):
-                batch_size = train_dataloader.batch_sampler.batch_size
+            batch_sampler = getattr(train_dataloader, "batch_sampler", None)
+            if batch_sampler is not None:
+                batch_size = batch_sampler.batch_size
+            else:
+                rank_zero_warn(
+                    "Tried to infer the batch size for DeepSpeed logging from the `train_dataloader`,"
+                    " but the batch sampler is not defined (for example, when using"
+                    " `DataLoader(batch_size=None)`). Falling back to a batch size of 1."
+                    " To keep DeepSpeed logging consistent, pass it explicitly via"
+                    " `Trainer(strategy=DeepSpeedStrategy(logging_batch_size_per_gpu=...))`."
+                )
         return batch_size

--- a/tests/tests_pytorch/strategies/test_deepspeed.py
+++ b/tests/tests_pytorch/strategies/test_deepspeed.py
@@ -236,6 +236,20 @@ def test_deepspeed_auto_batch_size_config_select(_, __, tmp_path, dataset_cls, v
         trainer.fit(model)
 
 
+@RunIf(deepspeed=True)
+def test_deepspeed_auto_batch_size_none_batch_sampler():
+    """Ensure `_auto_select_batch_size` falls back to 1 and warns when the dataloader has no batch sampler, as is
+    the case for `DataLoader(batch_size=None)`."""
+    strategy = DeepSpeedStrategy()
+    strategy._lightning_module = Mock()
+    data_source = strategy._lightning_module.trainer.fit_loop._data_source
+    data_source.is_defined.return_value = True
+    data_source.dataloader.return_value = DataLoader(RandomDataset(32, 64), batch_size=None)
+
+    with pytest.warns(UserWarning, match="batch sampler is not defined"):
+        assert strategy._auto_select_batch_size() == 1
+
+
 @RunIf(min_cuda_gpus=1, standalone=True, deepspeed=True)
 def test_deepspeed_run_configure_optimizers(tmp_path):
     """Test end to end that deepspeed works with defaults (without ZeRO as that requires compilation), whilst using

--- a/tests/tests_pytorch/strategies/test_deepspeed.py
+++ b/tests/tests_pytorch/strategies/test_deepspeed.py
@@ -238,8 +238,8 @@ def test_deepspeed_auto_batch_size_config_select(_, __, tmp_path, dataset_cls, v
 
 @RunIf(deepspeed=True)
 def test_deepspeed_auto_batch_size_none_batch_sampler():
-    """Ensure `_auto_select_batch_size` falls back to 1 and warns when the dataloader has no batch sampler, as is
-    the case for `DataLoader(batch_size=None)`."""
+    """Ensure `_auto_select_batch_size` falls back to 1 and warns when the dataloader has no batch sampler, as is the
+    case for `DataLoader(batch_size=None)`."""
     strategy = DeepSpeedStrategy()
     strategy._lightning_module = Mock()
     data_source = strategy._lightning_module.trainer.fit_loop._data_source


### PR DESCRIPTION
## What does this PR do?

Fixes #19460.

`DeepSpeedStrategy._auto_select_batch_size` does `hasattr(train_dataloader, "batch_sampler")` and then dereferences `train_dataloader.batch_sampler.batch_size`. When the user passes `DataLoader(batch_size=None)` (common for iterable datasets that yield pre-batched tensors), PyTorch sets `batch_sampler` to `None` rather than omitting the attribute, so `hasattr` still returns `True` and the dereference raises `AttributeError: 'NoneType' object has no attribute 'batch_size'`.

Before #19209 the code was wrapped in a broad `try/except` that silently swallowed the error and fell back to `1`. Per @awaelchli 's suggestion on the issue, this PR replaces that with an explicit `None` check and a `rank_zero_warn` pointing the user to `DeepSpeedStrategy(logging_batch_size_per_gpu=...)` so they can set the logging batch size themselves if the default of 1 is not appropriate.

Added a unit test that mocks the data source to return `DataLoader(batch_size=None)` and asserts both the returned value and the warning. The test is gated on `@RunIf(deepspeed=True)` like the rest of the file.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? Yes, #19460 (maintainer invited a PR).
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? N/A — internal method, no public API change.
- Did you write any **new necessary tests**? Yes, `test_deepspeed_auto_batch_size_none_batch_sampler`.
- [x] Did you verify new and **existing tests pass** locally with your changes? Ran `ruff`/`mypy` on the changed files; the new test is skipped on my machine (Windows, no `deepspeed`) like the rest of the file, so I also reproduced the regression and verified the fix path by executing `_auto_select_batch_size` directly on a `DataLoader(batch_size=None)`.
- Did you list all the **breaking changes** introduced by this pull request? None.
- Did you **update the CHANGELOG**? Yes, under `### Fixed` in `src/lightning/pytorch/CHANGELOG.md`.

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21669.org.readthedocs.build/en/21669/

<!-- readthedocs-preview pytorch-lightning end -->