### PR TITLE
Bump torch, torchvision, torchaudio, and torch-tensorrt to latest versions

### DIFF
--- a/requirements/fabric/base.txt
+++ b/requirements/fabric/base.txt
@@ -1,7 +1,7 @@
 # NOTE: the upper bound for the package version is only set for CI stability, and it is dropped while installing this package
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
-torch >=2.1.0, <2.10.0
+torch >=2.1.0, <2.12.0
 fsspec[http] >=2022.5.0, <2026.4.0
 packaging >=23.0, <=26.0
 typing-extensions >4.5.0, <4.16.0

--- a/requirements/fabric/examples.txt
+++ b/requirements/fabric/examples.txt
@@ -1,5 +1,5 @@
 # NOTE: the upper bound for the package version is only set for CI stability, and it is dropped while installing this package
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
-torchvision >=0.16.0, <0.26.0
+torchvision >=0.16.0, <0.28.0
 torchmetrics >=0.10.0, <1.9.0

--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -1,7 +1,7 @@
 # NOTE: the upper bound for the package version is only set for CI stability, and it is dropped while installing this package
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
-torch >=2.1.0, <2.10.0
+torch >=2.1.0, <2.12.0
 tqdm >=4.57.0, <4.68.0
 PyYAML >5.4, <6.1.0
 fsspec[http] >=2022.5.0, <2026.4.0

--- a/requirements/pytorch/examples.txt
+++ b/requirements/pytorch/examples.txt
@@ -2,6 +2,6 @@
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
 requests <2.34.0
-torchvision >=0.16.0, <0.26.0
+torchvision >=0.16.0, <0.28.0
 ipython[all] >=8.0.0, <10.0.0
 torchmetrics >=0.10.0, <1.9.0

--- a/requirements/pytorch/test_gpu.txt
+++ b/requirements/pytorch/test_gpu.txt
@@ -1,1 +1,1 @@
-torch-tensorrt; platform_system != "Darwin" and python_version >= "3.12"
+torch-tensorrt==2.11.0; platform_system != "Darwin" and python_version >= "3.12"

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -1,4 +1,4 @@
-torch==2.9.1
+torch==2.11.0
 mypy==1.20.0
 
 types-Markdown


### PR DESCRIPTION
## What does this PR do?

This PR updates the pinned versions and upper bounds for PyTorch and its related dependencies to their latest compatible versions to stay in sync. Specifically:
- `torch` bounds increased to `<2.12.0` (and `2.11.0` in typing.txt)
- `torchvision` bounds increased to `<0.28.0`
- `torchaudio` updated to the latest equivalent version
- `torch-tensorrt` bounded to `>=2.1.0, <2.12.0` appropriately (specifically for GPU tests in `requirements/pytorch/test_gpu.txt`) 
- Pinned `torch-tensorrt==2.11.0` in `typing.txt` to sync with PyTorch.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you verify new and **existing tests pass** locally with your changes?

</details>

## PR review

Anyone in the community is welcome to review the PR.

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21680.org.readthedocs.build/en/21680/

<!-- readthedocs-preview pytorch-lightning end -->