### PR TITLE
ci: bump auto-label-merge-conflicts commit hash

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -3,6 +3,8 @@ name: Label conflicts
 on:
   push:
     branches: ["main"]
+  pull_request:
+    types: ["synchronize", "reopened", "opened"]
   pull_request_target:
     types: ["synchronize", "reopened", "opened"]
 
@@ -14,9 +16,7 @@ jobs:
   triage-conflicts:
     runs-on: ubuntu-latest
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@591722e97f3c4142df3eca156ed0dcf2bcd362bd # Oct 25, 2021
+      - uses: eps1lon/actions-label-merge-conflict@636b369ea34ff799b8db5182df6f19e39b2d4adb # v3.0.3
         with:
-          CONFLICT_LABEL_NAME: "has conflicts"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAX_RETRIES: 3
-          WAIT_MS: 5000
+          dirtyLabel: "has conflicts"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -5,8 +5,6 @@ on:
     branches: ["main"]
   pull_request_target:
     types: ["synchronize", "reopened", "opened"]
-  pull_request:
-    types: ["synchronize", "reopened", "opened"]
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
   pull_request_target:
     types: ["synchronize", "reopened", "opened"]
+  pull_request:
+    types: ["synchronize", "reopened", "opened"]
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -3,8 +3,6 @@ name: Label conflicts
 on:
   push:
     branches: ["main"]
-  pull_request:
-    types: ["synchronize", "reopened", "opened"]
   pull_request_target:
     types: ["synchronize", "reopened", "opened"]
 
@@ -16,7 +14,9 @@ jobs:
   triage-conflicts:
     runs-on: ubuntu-latest
     steps:
-      - uses: eps1lon/actions-label-merge-conflict@636b369ea34ff799b8db5182df6f19e39b2d4adb # v3.0.3
+      - uses: mschilde/auto-label-merge-conflicts@cd484bbf0476fbe79474a937681a253e094cac3d # May 9, 2026
         with:
-          dirtyLabel: "has conflicts"
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          CONFLICT_LABEL_NAME: "has conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_RETRIES: 3
+          WAIT_MS: 5000


### PR DESCRIPTION
## What does this PR do?

Fixes the `triage-conflicts` CI check that has been failing due to a broken upstream Docker build in `mschilde/auto-label-merge-conflicts`.

### Root Cause

The `mschilde/auto-label-merge-conflicts` action uses a Docker-based runner with `node:alpine`, which no longer ships `yarn` by default. This causes the Docker build to fail with:
```
/bin/sh: yarn: not found
```

### Fix

- Bumped the commit hash for `mschilde/auto-label-merge-conflicts` to include the recent upstream fix that resolves the `yarn: not found` error. which got added by: https://github.com/mschilde/auto-label-merge-conflicts/pull/67 
