### PR TITLE
Bugfix/19990 log when done

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `SIGTERMException` producing a zero exit code instead of 143 (128 + SIGTERM) ([#21623](https://github.com/Lightning-AI/pytorch-lightning/issues/21623))
 
+- Fixed a flaw in the `_LoggerConnetor`'s `should_update_logs` logic, which caused logs to be updated every step when actual stopping was prevented by `min_steps` or `min_epochs` ([#19990](https://github.com/Lightning-AI/pytorch-lightning/issues/19990))
+
 ---
 
 ## [2.6.2] - 2026-03-19

--- a/src/lightning/pytorch/trainer/connectors/logger_connector/logger_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/logger_connector/logger_connector.py
@@ -54,15 +54,21 @@ class _LoggerConnector:
             return False
         if (loop := trainer._active_loop) is None:
             return True
+
+        done = trainer.should_stop
         if isinstance(loop, pl.loops._FitLoop):
             # `+ 1` because it can be checked before a step is executed, for example, in `on_train_batch_start`
             step = loop.epoch_loop._batches_that_stepped + 1
+
+            # fit loops also check if we actually can stop early (min_epochs, min_steps)
+            done = loop.done
         elif isinstance(loop, (pl.loops._EvaluationLoop, pl.loops._PredictionLoop)):
             step = loop.batch_progress.current.ready
         else:
             raise NotImplementedError(loop)
         should_log = step % trainer.log_every_n_steps == 0
-        return should_log or trainer.should_stop
+
+        return should_log or done
 
     def configure_logger(self, logger: Union[bool, Logger, Iterable[Logger]]) -> None:
         if not logger:


### PR DESCRIPTION
## What does this PR do?

The `_LoggerConnector`'s [`should_update_logs`](https://github.com/Lightning-AI/pytorch-lightning/blob/78bf0214a0ad7571391619dca952c13988c0dc51/src/lightning/pytorch/trainer/connectors/logger_connector/logger_connector.py#L51) method checks, if the trainer `should_stop` to log one final time. However, for `_FitLoop` type loops, this results in a logic flaw, in combination with a `EarlyStopping` like callback, and having `min_epochs` or `min_steps` set on the `Trainer` object. Since the trainer's `should_stop` is set to `True` by the callback, `should_update_logs` now returns True - but the `_FitLoop` has its own `done` logic, which returns False unless `min_epochs` or `min_steps` has been reached, resulting in an effective `log_every_n_steps` of 1.

Fixes #19990

<img width="1067" height="432" alt="image" src="https://github.com/user-attachments/assets/03b095d2-32e3-4bcd-975b-e90085c3b616" />

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

Changes:

- logging should now behave differently if training with `EarlyStopping` type callbacks and requiring `min_epochs` or `min_steps`

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs). See #19990
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request? (I hope so)
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

Yeah, I had fun :sunglasses: 

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21705.org.readthedocs.build/en/21705/

<!-- readthedocs-preview pytorch-lightning end -->