### PR TITLE
ci: bump auto-label-merge-conflicts commit hash (backport #21704)

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -14,7 +14,7 @@ jobs:
   triage-conflicts:
     runs-on: ubuntu-latest
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@591722e97f3c4142df3eca156ed0dcf2bcd362bd # Oct 25, 2021
+      - uses: mschilde/auto-label-merge-conflicts@cd484bbf0476fbe79474a937681a253e094cac3d # May 9, 2026
         with:
           CONFLICT_LABEL_NAME: "has conflicts"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
     rev: v1.7.7
     hooks:
       - id: docformatter
+        language_version: python3.13
         additional_dependencies: [tomli]
         args: ["--in-place"]
 


### PR DESCRIPTION
Backporting commit 88352b70b from master to release/2.6.x

Ref pr: https://github.com/Lightning-AI/pytorch-lightning/pull/21704

Purpose: To unblock the cherrypick pr #21701 

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21711.org.readthedocs.build/en/21711/

<!-- readthedocs-preview pytorch-lightning end -->