### PR TITLE
fix(slurm): detect srun inside interactive salloc via SLURM_STEP_ID

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed DeepSpeed checkpoint path validation rejecting remote filesystem URIs (S3, GCS, HDFS) ([#21636](https://github.com/Lightning-AI/pytorch-lightning/pull/21636))
 
+- Fixed `SLURMEnvironment` raising a spurious "srun is available but not used" warning when running `srun python ...` inside an interactive `salloc` allocation ([#20776](https://github.com/Lightning-AI/pytorch-lightning/issues/20776))
+
 - Fixed `FSDPStrategy` raising `RuntimeError` under PyTorch 2.5+ when `root_device` is CPU, by passing an explicit `torch.device("cpu")` instead of `device_id=None` (relevant only when the GPU-accelerator guard is bypassed) ([#21774](https://github.com/Lightning-AI/pytorch-lightning/pull/21774))
 
 - Fixed inconsistent FLOPs reporting on NVIDIA H100/H200 GPUs by defaulting to dense FLOPs, with sparse FLOPs now requiring an explicit opt-in. ([#21743](https://github.com/Lightning-AI/pytorch-lightning/pull/21743))

--- a/src/lightning/fabric/plugins/environments/slurm.py
+++ b/src/lightning/fabric/plugins/environments/slurm.py
@@ -225,7 +225,14 @@ class SLURMEnvironment(ClusterEnvironment):
 
 
 def _is_srun_used() -> bool:
-    return "SLURM_NTASKS" in os.environ and not _is_slurm_interactive_mode()
+    if "SLURM_NTASKS" not in os.environ:
+        return False
+    # `srun` sets `SLURM_STEP_ID` in the launched process, while `salloc` alone does not. This catches
+    # the case of running `srun python ...` inside an interactive `salloc` allocation, where
+    # `SLURM_JOB_NAME` inherited from the allocation is ``bash`` or ``interactive``.
+    if "SLURM_STEP_ID" in os.environ:
+        return True
+    return not _is_slurm_interactive_mode()
 
 
 def _is_slurm_interactive_mode() -> bool:

--- a/tests/tests_fabric/plugins/environments/test_slurm.py
+++ b/tests/tests_fabric/plugins/environments/test_slurm.py
@@ -129,6 +129,15 @@ def test_detect():
     with mock.patch.dict(os.environ, {"SLURM_JOB_NAME": "interactive"}):
         assert not SLURMEnvironment.detect()
 
+    # `srun` launched from inside an `salloc` interactive allocation sets
+    # SLURM_STEP_ID, which indicates srun is actively driving the process.
+    with mock.patch.dict(
+        os.environ,
+        {"SLURM_NTASKS": "2", "SLURM_JOB_NAME": "interactive", "SLURM_STEP_ID": "0"},
+        clear=True,
+    ):
+        assert SLURMEnvironment.detect()
+
 
 @RunIf(skip_windows=True)
 @pytest.mark.skipif(shutil.which("srun") is not None, reason="must run on a machine where srun is not available")
@@ -149,6 +158,36 @@ def test_srun_available_and_not_used(monkeypatch):
     with no_warning_call(PossibleUserWarning, match=expected):
         SLURMEnvironment()
         assert not SLURMEnvironment.detect()
+
+
+@RunIf(skip_windows=True)
+@pytest.mark.skipif(shutil.which("srun") is not None, reason="must run on a machine where srun is not available")
+def test_no_srun_warning_inside_salloc_with_srun(monkeypatch):
+    """No `srun` warning when running ``srun python ...`` inside an interactive ``salloc`` allocation.
+
+    Inside an interactive allocation (``SLURM_JOB_NAME`` is ``bash`` or ``interactive``), a nested ``srun`` still
+    sets ``SLURM_STEP_ID``. This distinguishes it from a plain ``python`` invocation in the same shell.
+
+    """
+    monkeypatch.setattr(sys, "argv", ["train.py"])
+    expected = "`srun` .* available .* but is not used"
+
+    with (
+        mock.patch("lightning.fabric.plugins.environments.slurm.shutil.which", return_value="/usr/bin/srun"),
+        mock.patch.dict(
+            os.environ,
+            {
+                "SLURM_NTASKS": "2",
+                "SLURM_NTASKS_PER_NODE": "1",
+                "SLURM_JOB_NAME": "interactive",
+                "SLURM_STEP_ID": "0",
+            },
+            clear=True,
+        ),
+        no_warning_call(PossibleUserWarning, match=expected),
+    ):
+        SLURMEnvironment()
+        assert SLURMEnvironment.detect()
 
 
 def test_srun_variable_validation():


### PR DESCRIPTION
### What does this PR do?

Fixes #20776.

`_is_srun_used()` returned `False` whenever `SLURM_JOB_NAME` was `bash` or `interactive`. Those values are inherited from an outer `salloc` allocation, but a nested `srun python …` inside that allocation IS a real srun invocation. The old check gave the wrong answer in that case, triggering a spurious "srun is available but is not used" warning and making `SLURMEnvironment.detect()` skip a real SLURM job.

The fix keys off `SLURM_STEP_ID` first, `srun` sets it, bare `salloc` does not. So an `salloc → srun python …` workflow is now correctly classified as srun-used. The pre-existing `bash` / `interactive` exclusion stays so `salloc` alone (no inner srun) still bails out cleanly.

### How was this PR tested?

Added two tests in `tests/tests_fabric/plugins/environments/test_slurm.py`:

- `test_no_srun_warning_inside_salloc_with_srun`, sets `SLURM_JOB_NAME=interactive` and `SLURM_STEP_ID=42`, asserts `_is_srun_used()` returns True and no spurious warning fires.
- Extended `test_detect` to cover the same shape.

Both fail without the change and pass with it.

### Before submitting

- [x] Was this **discussed/agreed** via a GitHub issue? (yes, #20776)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (no doc change, internal helper)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you update the **CHANGELOG**? (added under `src/lightning/fabric/CHANGELOG.md > Unreleased > Fixed`)

<!-- readthedocs-preview pytorch-lightning start -->
----
Documentation preview: https://pytorch-lightning--21712.org.readthedocs.build/en/21712/

<!-- readthedocs-preview pytorch-lightning end -->
