### PR TITLE
feat(onnx): add input_check flag to LightningModule.to_onnx

### DIFF
--- a/docs/source-pytorch/deploy/production_advanced.rst
+++ b/docs/source-pytorch/deploy/production_advanced.rst
@@ -59,6 +59,13 @@ Once you have the exported model, you can run it on your ONNX runtime in the fol
     ort_inputs = {input_name: np.random.randn(1, 64)}
     ort_outs = ort_session.run(None, ort_inputs)
 
+If you want to catch a malformed export early, pass ``input_check=True`` to run
+``onnx.checker.check_model`` on the saved file before you ever hand it off to a runtime:
+
+.. code-block:: python
+
+    model.to_onnx(filepath, input_sample, input_check=True)
+
 ----
 
 ****************************

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added support for remote storage (fsspec URLs) when saving and loading distributed checkpoints with `ModelParallelStrategy` ([#21797](https://github.com/Lightning-AI/pytorch-lightning/issues/21797))
 
+- Added `input_check` argument to `LightningModule.to_onnx` to run `onnx.checker.check_model` on the exported model ([#7279](https://github.com/Lightning-AI/pytorch-lightning/issues/7279))
+
 ### Changed
 
 -

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -1452,6 +1452,7 @@ class LightningModule(
         self,
         file_path: Union[str, Path, BytesIO, None] = None,
         input_sample: Optional[Any] = None,
+        input_check: bool = False,
         **kwargs: Any,
     ) -> Optional["ONNXProgram"]:
         """Saves the model in ONNX format.
@@ -1459,6 +1460,9 @@ class LightningModule(
         Args:
             file_path: The path of the file the onnx model should be saved to. Default: None (no file saved).
             input_sample: An input for tracing. Default: None (Use self.example_input_array)
+            input_check: If ``True``, run :func:`onnx.checker.check_model` on the exported model to
+                validate its protobuf structure. Requires ``file_path`` to be a path or ``BytesIO``;
+                cannot be used when ``dynamo=True`` is passed via ``kwargs``. Default: ``False``.
 
             **kwargs: Will be passed to torch.onnx.export function.
 
@@ -1486,6 +1490,14 @@ class LightningModule(
                 "requires `onnxscript` and `torch>=2.5.0` to be installed."
             )
 
+        if input_check and kwargs.get("dynamo", False):
+            # dynamo path returns an ONNXProgram and may not produce a standalone protobuf file
+            # that `onnx.checker.check_model` can load.
+            raise ValueError("`input_check=True` is not supported together with `dynamo=True`.")
+
+        if input_check and file_path is None:
+            raise ValueError("`input_check=True` requires `file_path` to be a path or BytesIO, got None.")
+
         mode = self.training
 
         if input_sample is None:
@@ -1504,6 +1516,19 @@ class LightningModule(
         #               BytesIO does work, too.
         ret = torch.onnx.export(self, input_sample, file_path, **kwargs)  # type: ignore
         self.train(mode)
+
+        if input_check:
+            import onnx
+
+            if isinstance(file_path, BytesIO):
+                pos = file_path.tell()
+                file_path.seek(0)
+                onnx_model = onnx.load_model_from_string(file_path.read())
+                file_path.seek(pos)
+            else:
+                onnx_model = onnx.load(file_path)
+            onnx.checker.check_model(onnx_model)
+
         return ret
 
     @torch.no_grad()

--- a/tests/tests_pytorch/models/test_onnx.py
+++ b/tests/tests_pytorch/models/test_onnx.py
@@ -142,6 +142,63 @@ def test_error_if_no_input(tmp_path):
         model.to_onnx(file_path)
 
 
+@RunIf(onnx=True)
+def test_input_check_runs_onnx_checker(tmp_path):
+    """`input_check=True` should load the exported model and run `onnx.checker.check_model`."""
+    import onnx
+
+    model = BoringModel()
+    input_sample = torch.randn((1, 32))
+
+    file_path = os.path.join(tmp_path, "model.onnx")
+    model.to_onnx(file_path, input_sample, input_check=True)
+    assert os.path.isfile(file_path)
+    # Sanity-check: same file should also pass onnx.checker when loaded independently.
+    onnx.checker.check_model(onnx.load(file_path))
+
+    # BytesIO path: the cursor position should be unchanged after the check reads the buffer.
+    buf = BytesIO()
+    model.to_onnx(file_path=buf, input_sample=input_sample, input_check=True)
+    end_pos = buf.tell()
+    assert end_pos > 4e2
+    assert len(buf.getvalue()) == end_pos
+
+
+@RunIf(onnx=True)
+def test_input_check_raises_without_file_path():
+    """`input_check=True` needs a path or BytesIO to load the exported model from."""
+    model = BoringModel()
+    model.example_input_array = torch.randn((1, 32))
+    with pytest.raises(ValueError, match=r"`input_check=True` requires `file_path`"):
+        model.to_onnx(file_path=None, input_check=True)
+
+
+@RunIf(onnx=True)
+def test_input_check_detects_invalid_model(tmp_path, monkeypatch):
+    """If the saved file isn't a valid ONNX model, `input_check=True` should raise."""
+    import onnx
+
+    model = BoringModel()
+    input_sample = torch.randn((1, 32))
+    file_path = os.path.join(tmp_path, "model.onnx")
+
+    def _raise(_):
+        raise onnx.checker.ValidationError("forced failure")
+
+    monkeypatch.setattr(onnx.checker, "check_model", _raise)
+    with pytest.raises(onnx.checker.ValidationError, match="forced failure"):
+        model.to_onnx(file_path, input_sample, input_check=True)
+
+
+@RunIf(onnx=True, min_torch="2.5.0", dynamo=True, onnxscript=True)
+def test_input_check_rejects_dynamo():
+    """`input_check=True` is not compatible with the dynamo exporter."""
+    model = BoringModel()
+    model.example_input_array = torch.randn((1, 32))
+    with pytest.raises(ValueError, match=r"`input_check=True` is not supported together with `dynamo=True`"):
+        model.to_onnx(input_check=True, dynamo=True)
+
+
 @pytest.mark.parametrize(
     "dynamo",
     [


### PR DESCRIPTION
## What does this PR do?

Adds an `input_check: bool = False` argument to `LightningModule.to_onnx`. When set, after `torch.onnx.export` returns we load the saved model and run `onnx.checker.check_model` on it, so the caller gets a `ValidationError` instead of finding out at deploy time that the exported protobuf is malformed.

Default behavior is unchanged: `input_check=False`.

Refs #7279.

### Notes on scope

The original issue lists two things: the spec check (`onnx.checker.check_model`) and a PyTorch-vs-onnxruntime output comparison. I only did the first one here — the runtime comparison needs `onnxruntime` as a hard dep and a way to deal with multi-output / dict-output models, which feels like a separate PR. Happy to add it as a follow-up if you'd like.

### Behavior

- `file_path` is a `str`/`Path` → loaded with `onnx.load`, then checked.
- `file_path` is `BytesIO` → loaded with `onnx.load_model_from_string`; the buffer's cursor position is restored so the caller sees the same state as without the flag.
- `file_path is None` → raises `ValueError`; there is nothing to load.
- `dynamo=True` → raises `ValueError`; that path returns an `ONNXProgram` rather than a standalone protobuf file we can hand to the checker.

### Tests

Added to `tests/tests_pytorch/models/test_onnx.py`:

- `test_input_check_runs_onnx_checker` — happy path for both file and `BytesIO`.
- `test_input_check_raises_without_file_path` — `ValueError` when `file_path=None`.
- `test_input_check_detects_invalid_model` — monkeypatches `onnx.checker.check_model` to fail; verifies the error propagates.
- `test_input_check_rejects_dynamo` — `ValueError` when combined with `dynamo=True`.

All onnx tests pass locally on macOS (`torch 2.12.0`, `onnx 1.21.0`, `onnxruntime 1.26.0`):

```
13 passed, 5 skipped
```

Ruff lint + format pass.

## Before submitting

- [x] Was this **discussed/agreed** via a GitHub issue? — yes, #7279
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (added a short note in `docs/source-pytorch/deploy/production_advanced.rst`)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request? — none, new kwarg defaults to `False`.
- [x] Did you **update the CHANGELOG**?

## PR review

Anyone in the community is welcome to review the PR.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21716.org.readthedocs.build/en/21716/

<!-- readthedocs-preview pytorch-lightning end -->