### PR TITLE
Remove pull_request_target from enabled workflows

### DIFF
--- a/.github/workflows/ci-rtfd.yml
+++ b/.github/workflows/ci-rtfd.yml
@@ -1,6 +1,6 @@
 name: RTFD Preview
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
 

--- a/.github/workflows/ci-rtfd.yml
+++ b/.github/workflows/ci-rtfd.yml
@@ -9,6 +9,8 @@ permissions:
 
 jobs:
   documentation-links:
+    # This job writes PR comments, so skip fork PRs instead of using pull_request_target.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: readthedocs/actions/preview@v1

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -3,7 +3,7 @@ name: Label conflicts
 on:
   push:
     branches: ["main"]
-  pull_request_target:
+  pull_request:
     types: ["synchronize", "reopened", "opened"]
 
 concurrency:

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -12,6 +12,8 @@ concurrency:
 
 jobs:
   triage-conflicts:
+    # This job writes PR labels, so keep push runs but skip fork PRs.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: mschilde/auto-label-merge-conflicts@cd484bbf0476fbe79474a937681a253e094cac3d # May 9, 2026

--- a/.github/workflows/labeler-pr.yml
+++ b/.github/workflows/labeler-pr.yml
@@ -1,5 +1,5 @@
 name: Label Pull Requests
-on: [pull_request_target]
+on: [pull_request]
 
 jobs:
   triage:

--- a/.github/workflows/labeler-pr.yml
+++ b/.github/workflows/labeler-pr.yml
@@ -3,6 +3,8 @@ on: [pull_request]
 
 jobs:
   triage:
+    # This job writes PR labels, so skip fork PRs instead of using pull_request_target.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/probot-auto-cc.yml
+++ b/.github/workflows/probot-auto-cc.yml
@@ -3,8 +3,9 @@ name: Probot
 on:
   issues:
     types: [labeled]
-  # Intentionally uses the unprivileged pull_request event, so this job will not
-  # run on forks.
+  # should use `pull_request_target` but it's blocked by
+  # https://github.com/probot/probot/issues/1635
+  # so this job will not run on forks until the above is fixed
   pull_request:
     types: [labeled, ready_for_review]
 

--- a/.github/workflows/probot-auto-cc.yml
+++ b/.github/workflows/probot-auto-cc.yml
@@ -3,9 +3,8 @@ name: Probot
 on:
   issues:
     types: [labeled]
-  # should use `pull_request_target` but it's blocked by
-  # https://github.com/probot/probot/issues/1635
-  # so this job will not run on forks until the above is fixed
+  # Intentionally uses the unprivileged pull_request event, so this job will not
+  # run on forks.
   pull_request:
     types: [labeled, ready_for_review]
 


### PR DESCRIPTION
## What does this PR do?

Removes `pull_request_target` from enabled GitHub Actions workflows and switches them to the unprivileged `pull_request` event.

This is a security hardening change to avoid privileged workflow execution on fork PRs. The workflows that write PR labels/comments now explicitly skip fork PRs instead of using `pull_request_target`.

## Changed workflows

- `.github/workflows/labeler-pr.yml`: runs only for same-repo PRs because it writes PR labels.
- `.github/workflows/ci-rtfd.yml`: runs only for same-repo PRs because it writes PR preview comments.
- `.github/workflows/label-conflicts.yml`: keeps `push` runs and skips fork PRs because it writes PR labels.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21718.org.readthedocs.build/en/21718/

<!-- readthedocs-preview pytorch-lightning end -->