### PR TITLE
Pin low-risk GitHub workflow actions to SHAs (1/n)

### DIFF
--- a/.github/workflows/call-clear-cache.yml
+++ b/.github/workflows/call-clear-cache.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   cron-clear:
     if: github.event_name == 'schedule' || github.event_name == 'pull_request'
-    uses: Lightning-AI/utilities/.github/workflows/cleanup-caches.yml@v0.15.3
+    uses: Lightning-AI/utilities/.github/workflows/cleanup-caches.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       scripts-ref: v0.15.2
       dry-run: ${{ github.event_name == 'pull_request' }}
@@ -32,7 +32,7 @@ jobs:
 
   direct-clear:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
-    uses: Lightning-AI/utilities/.github/workflows/cleanup-caches.yml@v0.15.3
+    uses: Lightning-AI/utilities/.github/workflows/cleanup-caches.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       scripts-ref: v0.15.2
       dry-run: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cleanup
         run: |

--- a/.github/workflows/labeler-issue.yml
+++ b/.github/workflows/labeler-issue.yml
@@ -19,16 +19,16 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Parse issue form
-        uses: stefanbuck/github-issue-parser@v3
+        uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3.2.5
         id: issue-parser
         with:
           template-path: .github/ISSUE_TEMPLATE/1_bug_report.yaml
 
       - name: Set labels based on severity field
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # v3.2.4
         with:
           issue-form: ${{ steps.issue-parser.outputs.jsonString }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Pins external actions and reusable workflows in low-risk GitHub workflows to verified commit SHAs while keeping the original tags in comments for readability.

Updated workflows:
- Issue labeling
- Cache cleanup
- Weekly/manual cache clearing

## Pinned references

- `actions/checkout@v6`  
  Release/tag: https://github.com/actions/checkout/releases/tag/v6

- `stefanbuck/github-issue-parser@v3`  
  Release/tag: https://github.com/stefanbuck/github-issue-parser/releases/tag/v3

- `redhat-plumbers-in-action/advanced-issue-labeler@v3`  
  Release/tag: https://github.com/redhat-plumbers-in-action/advanced-issue-labeler/releases/tag/v3

- `Lightning-AI/utilities/.github/workflows/cleanup-caches.yml@v0.15.3`  
  Release/tag: https://github.com/Lightning-AI/utilities/releases/tag/v0.15.3

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21719.org.readthedocs.build/en/21719/

<!-- readthedocs-preview pytorch-lightning end -->