### PR TITLE
ci: disable litbot checkgroup

### DIFF
--- a/.github/checkgroup.yml
+++ b/.github/checkgroup.yml
@@ -130,40 +130,40 @@ subprojects:
     checks:
       - "fabric-cpu-guardian" # aggregated check for all cases
 
-  - id: "lightning_fabric: lit GPU"
-    paths:
-      - ".actions/*"
-      - ".lightning/workflows/fabric.yml"
-      - "examples/fabric/**"
-      - "examples/run_fabric_examples.sh"
-      - "requirements/fabric/**"
-      - "src/lightning/__init__.py"
-      - "src/lightning/__setup__.py"
-      - "src/lightning/__version__.py"
-      - "src/lightning/fabric/**"
-      - "src/lightning_fabric/*"
-      - "tests/tests_fabric/**"
-      - "tests/run_standalone_*.sh"
-      - "pyproject.toml" # includes pytest config
-      - "!requirements/*/docs.txt"
-      - "!*.md"
-      - "!**/*.md"
-    checks:
-      - "fabric.yml / Lit Job (nvidia/cuda:12.1.1-devel-ubuntu22.04, fabric, 3.10)"
-      - "fabric.yml / Lit Job (fabric, 3.12)"
-      - "fabric.yml / Lit Job (lightning, 3.12)"
-
-  # Temporarily disabled
-  #  - id: "lightning_fabric: TPU workflow"
-  #    paths:
-  #      # tpu CI availability is very limited, so we only require tpu tests
-  #      # to pass when their configurations are modified
-  #      - ".github/workflows/tpu-tests.yml.disabled"
-  #      - "tests/tests_fabric/run_tpu_tests.sh"
-  #    checks:
-  #      - "test-on-tpus (pytorch, pjrt, v4-8)"
-
-  # SECTION: common
+  # - id: "lightning_fabric: lit GPU"
+  #   paths:
+  #     - ".actions/*"
+  #     - ".lightning/workflows/fabric.yml"
+  #     - "examples/fabric/**"
+  #     - "examples/run_fabric_examples.sh"
+  #     - "requirements/fabric/**"
+  #     - "src/lightning/__init__.py"
+  #     - "src/lightning/__setup__.py"
+  #     - "src/lightning/__version__.py"
+  #     - "src/lightning/fabric/**"
+  #     - "src/lightning_fabric/*"
+  #     - "tests/tests_fabric/**"
+  #     - "tests/run_standalone_*.sh"
+  #     - "pyproject.toml" # includes pytest config
+  #     - "!requirements/*/docs.txt"
+  #     - "!*.md"
+  #     - "!**/*.md"
+  #   checks:
+  #     - "fabric.yml / Lit Job (nvidia/cuda:12.1.1-devel-ubuntu22.04, fabric, 3.10)"
+  #     - "fabric.yml / Lit Job (fabric, 3.12)"
+  #     - "fabric.yml / Lit Job (lightning, 3.12)"
+  #
+  # # Temporarily disabled
+  # #  - id: "lightning_fabric: TPU workflow"
+  # #    paths:
+  # #      # tpu CI availability is very limited, so we only require tpu tests
+  # #      # to pass when their configurations are modified
+  # #      - ".github/workflows/tpu-tests.yml.disabled"
+  # #      - "tests/tests_fabric/run_tpu_tests.sh"
+  # #    checks:
+  # #      - "test-on-tpus (pytorch, pjrt, v4-8)"
+  #
+  # # SECTION: common
 
   - id: "mypy"
     paths:

--- a/.github/checkgroup.yml
+++ b/.github/checkgroup.yml
@@ -21,62 +21,63 @@ subprojects:
     checks:
       - "pl-cpu-guardian" # aggregated check for all cases
 
-  - id: "pytorch_lightning: lit GPU"
-    paths:
-      - ".actions/*"
-      - ".lightning/workflows/pytorch.yml"
-      # only the azure GPU workflow runs the examples
-      # all examples don't need to be added because they aren't used in CI, but these are
-      - "examples/run_pl_examples.sh"
-      - "examples/pytorch/basics/backbone_image_classifier.py"
-      - "examples/pytorch/basics/autoencoder.py"
-      - "requirements/pytorch/**"
-      - "src/lightning/__init__.py"
-      - "src/lightning/__setup__.py"
-      - "src/lightning/__version__.py"
-      - "src/lightning/pytorch/**"
-      - "src/pytorch_lightning/*"
-      - "tests/tests_pytorch/**"
-      - "tests/run_standalone_*.sh"
-      - "pyproject.toml" # includes pytest config
-      - "requirements/fabric/**"
-      - "src/lightning/fabric/**"
-      - "src/lightning_fabric/*"
-      - "!requirements/docs.txt"
-      - "!requirements/*/docs.txt"
-      - "!*.md"
-      - "!**/*.md"
-    checks:
-      - "pytorch.yml / Lit Job (nvidia/cuda:12.1.1-devel-ubuntu22.04, pytorch, 3.10)"
-      - "pytorch.yml / Lit Job (lightning, 3.12)"
-      - "pytorch.yml / Lit Job (pytorch, 3.12)"
+  # Temporarily Disabled until LitBot is available again
+  # - id: "pytorch_lightning: lit GPU"
+  #   paths:
+  #     - ".actions/*"
+  #     - ".lightning/workflows/pytorch.yml"
+  #     # only the azure GPU workflow runs the examples
+  #     # all examples don't need to be added because they aren't used in CI, but these are
+  #     - "examples/run_pl_examples.sh"
+  #     - "examples/pytorch/basics/backbone_image_classifier.py"
+  #     - "examples/pytorch/basics/autoencoder.py"
+  #     - "requirements/pytorch/**"
+  #     - "src/lightning/__init__.py"
+  #     - "src/lightning/__setup__.py"
+  #     - "src/lightning/__version__.py"
+  #     - "src/lightning/pytorch/**"
+  #     - "src/pytorch_lightning/*"
+  #     - "tests/tests_pytorch/**"
+  #     - "tests/run_standalone_*.sh"
+  #     - "pyproject.toml" # includes pytest config
+  #     - "requirements/fabric/**"
+  #     - "src/lightning/fabric/**"
+  #     - "src/lightning_fabric/*"
+  #     - "!requirements/docs.txt"
+  #     - "!requirements/*/docs.txt"
+  #     - "!*.md"
+  #     - "!**/*.md"
+  #   checks:
+  #     - "pytorch.yml / Lit Job (nvidia/cuda:12.1.1-devel-ubuntu22.04, pytorch, 3.10)"
+  #     - "pytorch.yml / Lit Job (lightning, 3.12)"
+  #     - "pytorch.yml / Lit Job (pytorch, 3.12)"
 
-  - id: "Benchmarks"
-    paths:
-      - ".lightning/workflows/benchmark.yml"
-      - "requirements/fabric/**"
-      - "requirements/pytorch/**"
-      - "src/lightning/fabric/**"
-      - "src/lightning/pytorch/**"
-      - "tests/parity_fabric/**"
-      - "tests/parity_pytorch/**"
-      - "!requirements/fabric/docs.txt"
-      - "!requirements/pytorch/docs.txt"
-      - "!*.md"
-      - "!**/*.md"
-    checks:
-      - "benchmark.yml / Lit Job (fabric)"
-      - "benchmark.yml / Lit Job (pytorch)"
-
-  # Temporarily disabled
-  #  - id: "pytorch-lightning: TPU workflow"
-  #    paths:
-  #      # tpu CI availability is very limited, so we only require tpu tests
-  #      # to pass when their configurations are modified
-  #      - ".github/workflows/tpu-tests.yml.disabled"
-  #      - "tests/tests_pytorch/run_tpu_tests.sh"
-  #    checks:
-  #      - "test-on-tpus (pytorch, pjrt, v4-8)"
+  # - id: "Benchmarks"
+  #   paths:
+  #     - ".lightning/workflows/benchmark.yml"
+  #     - "requirements/fabric/**"
+  #     - "requirements/pytorch/**"
+  #     - "src/lightning/fabric/**"
+  #     - "src/lightning/pytorch/**"
+  #     - "tests/parity_fabric/**"
+  #     - "tests/parity_pytorch/**"
+  #     - "!requirements/fabric/docs.txt"
+  #     - "!requirements/pytorch/docs.txt"
+  #     - "!*.md"
+  #     - "!**/*.md"
+  #   checks:
+  #     - "benchmark.yml / Lit Job (fabric)"
+  #     - "benchmark.yml / Lit Job (pytorch)"
+  #
+  # # Temporarily disabled
+  # #  - id: "pytorch-lightning: TPU workflow"
+  # #    paths:
+  # #      # tpu CI availability is very limited, so we only require tpu tests
+  # #      # to pass when their configurations are modified
+  # #      - ".github/workflows/tpu-tests.yml.disabled"
+  # #      - "tests/tests_pytorch/run_tpu_tests.sh"
+  # #    checks:
+  # #      - "test-on-tpus (pytorch, pjrt, v4-8)"
 
   - id: "fabric: Docs"
     paths:


### PR DESCRIPTION
## What does this PR do?

Ports the litbot checkgroup disable to `release/stable`.

Comments out the `pytorch_lightning: lit GPU`, `lightning_fabric: lit GPU`, and `Benchmarks` sections in `.github/checkgroup.yml` since LitBot is currently unavailable.

Without this, PRs targeting `release/stable` that touch `src/lightning/pytorch/**` are blocked: the probot reads `checkgroup.yml` from the base branch (`release/stable`) for security reasons on fork PRs, so those GPU/benchmark jobs are required but never triggered — causing a 70-minute timeout on `required-jobs` (see #21727).

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>