### PR TITLE
Pin PyPI publish action for trusted publishing

### DIFF
--- a/.github/workflows/release-pkg.yml
+++ b/.github/workflows/release-pkg.yml
@@ -153,7 +153,8 @@ jobs:
           python -c "print('pkg=' + '${{ matrix.name }}'.lower())" >> $GITHUB_OUTPUT
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        # pypa/gh-action-pypi-publish v1.13.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           packages_dir: dist/${{ steps.folder.outputs.pkg }}
           verbose: true


### PR DESCRIPTION
## What

Pin pypa/gh-action-pypi-publish to the commit behind v1.13.0. 
Keep the existing package directory selection for the multi-package release workflow.

## Why
The existing v1.5.1 action uses token-based Twine upload and does not enter PyPI trusted publishing even with id-token: write. v1.13.0 matches the working TorchMetrics setup while using an immutable action SHA.
