### PR TITLE
Pin third-party CI workflow actions to SHAs (3/n)

### DIFF
--- a/.github/workflows/_legacy-checkpoints.yml
+++ b/.github/workflows/_legacy-checkpoints.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv and set Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.10"
           # TODO: Avoid activating environment like this
@@ -153,7 +153,7 @@ jobs:
         run: echo ${PL_VERSION} >> back-compatible-versions.txt
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: Adding test for legacy checkpoint created with ${{ env.PL_VERSION }}
           committer: GitHub <noreply@github.com>

--- a/.github/workflows/ci-tests-fabric.yml
+++ b/.github/workflows/ci-tests-fabric.yml
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv and set Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: ${{ matrix.config.python-version || '3.10' }}
           # TODO: Avoid activating environment like this
@@ -167,7 +167,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         # see: https://github.com/actions/toolkit/issues/399
         continue-on-error: true
         with:

--- a/.github/workflows/ci-tests-pytorch.yml
+++ b/.github/workflows/ci-tests-pytorch.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv and set Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: ${{ matrix.config.python-version || '3.10' }}
           # TODO: Avoid activating environment like this
@@ -202,12 +202,12 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }} # Run even if tests fail
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         # see: https://github.com/actions/toolkit/issues/399
         continue-on-error: true
         with:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv and set Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.11"
           # TODO: Avoid activating environment like this

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -74,7 +74,7 @@ jobs:
           lfs: ${{ matrix.pkg-name == 'pytorch' }}
 
       - name: Install uv and set Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.10"
           # TODO: Avoid activating environment like this

--- a/.github/workflows/docs-tutorials.yml
+++ b/.github/workflows/docs-tutorials.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Create Pull Request
         if: ${{ github.event_name != 'pull_request' && env.SHA_ACTUAL != env.SHA_LATEST }}
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: "docs: update ref to latest tutorials"
           committer: GitHub <noreply@github.com>

--- a/.github/workflows/release-pkg.yml
+++ b/.github/workflows/release-pkg.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Create Pull Request
         if: github.event_name != 'pull_request'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: "Bump lightning ver `${{ env.TAG }}`"
           committer: GitHub <noreply@github.com>


### PR DESCRIPTION
## What does this PR do?

Pins third-party CI workflow actions to verified commit SHAs.

Updated workflows:
- Legacy checkpoint generation
- Fabric tests
- PyTorch tests
- Code checks
- Docs builds
- Tutorial updates
- Package releases

## Pinned references

- `astral-sh/setup-uv@v7`  
  Release/tag: https://github.com/astral-sh/setup-uv/releases/tag/v7.6.0

- `codecov/codecov-action@v6`  
  Release/tag: https://github.com/codecov/codecov-action/releases/tag/v6.0.1

- `codecov/test-results-action@v1`  
  Release/tag: https://github.com/codecov/test-results-action/releases/tag/v1.2.1

- `peter-evans/create-pull-request@v8`  
  Release/tag: https://github.com/peter-evans/create-pull-request/releases/tag/v8.1.1