### PR TITLE
Pin cloud and release workflow actions to SHAs (4/n)

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -167,12 +167,12 @@ jobs:
           path: docs/build/html/
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.GCS_SA_KEY }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           project_id: ${{ secrets.GCS_PROJECT }}
 

--- a/.github/workflows/release-pkg.yml
+++ b/.github/workflows/release-pkg.yml
@@ -43,7 +43,7 @@ jobs:
           path: dist
       - run: ls -lh dist/
       - name: Upload to release
-        uses: AButler/upload-release-assets@v3.0
+        uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
         with:
           files: "dist/*/*"
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Pins cloud and release-adjacent workflow actions to verified commit SHAs.

Updated workflows:
- Docs builds
- Package releases

## Pinned references

- `google-github-actions/auth@v3`  
  Release/tag: https://github.com/google-github-actions/auth/releases/tag/v3.0.0

- `google-github-actions/setup-gcloud@v3`  
  Release/tag: https://github.com/google-github-actions/setup-gcloud/releases/tag/v3.0.1

- `AButler/upload-release-assets@v3.0`  
  Release/tag: https://github.com/AButler/upload-release-assets/releases/tag/v3.0