### PR TITLE
Pin internal workflow actions to SHAs (5/n)

### DIFF
--- a/.github/workflows/ci-check-md-links.yml
+++ b/.github/workflows/ci-check-md-links.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   check-md-links:
-    uses: Lightning-AI/utilities/.github/workflows/check-md-links.yml@main # can be pin with >=0.14.4
+    uses: Lightning-AI/utilities/.github/workflows/check-md-links.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       config-file: ".github/markdown-links-config.json"
       base-branch: "master"

--- a/.github/workflows/ci-schema.yml
+++ b/.github/workflows/ci-schema.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    uses: Lightning-AI/utilities/.github/workflows/check-schema.yml@v0.15.3
+    uses: Lightning-AI/utilities/.github/workflows/check-schema.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       # skip azure due to the wrong schema file by MSFT
       # https://github.com/Lightning-AI/lightning-flash/pull/1455#issuecomment-1244793607

--- a/.github/workflows/probot-auto-cc.yml
+++ b/.github/workflows/probot-auto-cc.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name == 'issue' || github.event.pull_request.draft == false
     timeout-minutes: 5
     steps:
-      - uses: Lightning-AI/probot@v5
+      - uses: Lightning-AI/probot@ebd013f82c41080e7ededded4bf06845b2683c54 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/probot-check-group.yml
+++ b/.github/workflows/probot-check-group.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event.pull_request.draft == false
     timeout-minutes: 71 # in case something is wrong with the internal timeout
     steps:
-      - uses: Lightning-AI/probot@v5.5
+      - uses: Lightning-AI/probot@538b14402b2c6607e01e6e289be782797d34fdbf # v5.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## What does this PR do?

Pins internal Lightning-AI actions and reusable workflows to verified commit SHAs.

Updated workflows:
- Markdown link checks
- Schema checks
- Auto CC labeling
- Required job grouping

## Pinned references

- `Lightning-AI/utilities/.github/workflows/check-md-links.yml@v0.15.3`  
  Release/tag: https://github.com/Lightning-AI/utilities/releases/tag/v0.15.3

- `Lightning-AI/utilities/.github/workflows/check-schema.yml@v0.15.3`  
  Release/tag: https://github.com/Lightning-AI/utilities/releases/tag/v0.15.3

- `Lightning-AI/probot@v5`  
  Release/tag: https://github.com/Lightning-AI/probot/releases/tag/v5

- `Lightning-AI/probot@v5.5`  
  Release/tag: https://github.com/Lightning-AI/probot/releases/tag/v5.5