### PR TITLE
fix: AccumulateGrad stream mismatch warning when using DDP with Fabric & Trainer

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -20,7 +20,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
--
+- fixed AccumulateGrad stream mismatch warning when using DDP with Fabric ([#21746](https://github.com/Lightning-AI/pytorch-lightning/pull/21746))
+
 
 ---
 

--- a/src/lightning/fabric/strategies/ddp.py
+++ b/src/lightning/fabric/strategies/ddp.py
@@ -125,7 +125,19 @@ class DDPStrategy(ParallelStrategy):
         """Wraps the model into a :class:`~torch.nn.parallel.distributed.DistributedDataParallel` module."""
         device_ids = self._determine_ddp_device_ids()
         # https://pytorch.org/docs/stable/notes/cuda.html#id5
-        ctx = torch.cuda.stream(torch.cuda.Stream()) if device_ids is not None else nullcontext()
+        if device_ids is not None:
+            capturing = torch.cuda.is_current_stream_capturing()
+            if capturing:
+                # DDP must be initialized on a side-stream for CUDA graph whole-network capture.
+                # The resulting AccumulateGrad stream mismatch is intentional in this case.
+                # See: https://pytorch.org/docs/stable/notes/cuda.html#cuda-graphs
+                ctx = torch.cuda.stream(torch.cuda.Stream())
+                torch.autograd.graph.set_warn_on_accumulate_grad_stream_mismatch(False)
+            else:
+                # Default stream avoids AccumulateGrad stream mismatch warnings during normal training.
+                ctx = torch.cuda.stream(torch.cuda.default_stream())
+        else:
+            ctx = nullcontext()
         with ctx:
             return DistributedDataParallel(module=module, device_ids=device_ids, **self._ddp_kwargs)
 

--- a/src/lightning/fabric/strategies/ddp.py
+++ b/src/lightning/fabric/strategies/ddp.py
@@ -124,6 +124,8 @@ class DDPStrategy(ParallelStrategy):
     def setup_module(self, module: Module) -> DistributedDataParallel:
         """Wraps the model into a :class:`~torch.nn.parallel.distributed.DistributedDataParallel` module."""
         device_ids = self._determine_ddp_device_ids()
+        ctx: Union[torch.cuda.StreamContext, nullcontext] = nullcontext()
+
         # https://pytorch.org/docs/stable/notes/cuda.html#id5
         if device_ids is not None:
             capturing = torch.cuda.is_current_stream_capturing()
@@ -136,8 +138,6 @@ class DDPStrategy(ParallelStrategy):
             else:
                 # Default stream avoids AccumulateGrad stream mismatch warnings during normal training.
                 ctx = torch.cuda.stream(torch.cuda.default_stream())
-        else:
-            ctx = nullcontext()
         with ctx:
             return DistributedDataParallel(module=module, device_ids=device_ids, **self._ddp_kwargs)
 

--- a/src/lightning/fabric/strategies/ddp.py
+++ b/src/lightning/fabric/strategies/ddp.py
@@ -130,7 +130,7 @@ class DDPStrategy(ParallelStrategy):
             if capturing:
                 # DDP must be initialized on a side-stream for CUDA graph whole-network capture.
                 # The resulting AccumulateGrad stream mismatch is intentional in this case.
-                # See: https://pytorch.org/docs/stable/notes/cuda.html#cuda-graphs
+                # See: https://pytorch.org/docs/stable/notes/cuda.html#id5
                 ctx = torch.cuda.stream(torch.cuda.Stream())
                 torch.autograd.graph.set_warn_on_accumulate_grad_stream_mismatch(False)
             else:

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -32,7 +32,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `LightningModule.toggle_optimizer` / `untoggle_optimizer` breaking under `torch.compile` by disabling Dynamo tracing on these bookkeeping helpers ([#21513](https://github.com/Lightning-AI/pytorch-lightning/issues/21513))
 
-
 ---
 
 ## [2.6.4] - 2026-05-20

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `SIGTERMException` producing a zero exit code instead of 143 (128 + SIGTERM) ([#21623](https://github.com/Lightning-AI/pytorch-lightning/issues/21623))
 
+- fixed AccumulateGrad stream mismatch warning when using DDP with Trainer ([#21746](https://github.com/Lightning-AI/pytorch-lightning/pull/21746))
+
 ---
 
 ## [2.6.4] - 2026-05-20

--- a/src/lightning/pytorch/strategies/ddp.py
+++ b/src/lightning/pytorch/strategies/ddp.py
@@ -196,7 +196,7 @@ class DDPStrategy(ParallelStrategy):
             if capturing:
                 # DDP must be initialized on a side-stream for CUDA graph whole-network capture.
                 # The resulting AccumulateGrad stream mismatch is intentional in this case.
-                # See: https://pytorch.org/docs/stable/notes/cuda.html#cuda-graphs
+                # See: https://pytorch.org/docs/stable/notes/cuda.html#id5
                 ctx = torch.cuda.stream(torch.cuda.Stream())
                 torch.autograd.graph.set_warn_on_accumulate_grad_stream_mismatch(False)
             else:

--- a/src/lightning/pytorch/strategies/ddp.py
+++ b/src/lightning/pytorch/strategies/ddp.py
@@ -189,6 +189,8 @@ class DDPStrategy(ParallelStrategy):
     def _setup_model(self, model: Module) -> DistributedDataParallel:
         """Wraps the model into a :class:`~torch.nn.parallel.distributed.DistributedDataParallel` module."""
         device_ids = self.determine_ddp_device_ids()
+        ctx: Union[torch.cuda.StreamContext, nullcontext] = nullcontext()
+
         log.debug(f"setting up DDP model with device ids: {device_ids}, kwargs: {self._ddp_kwargs}")
         # https://pytorch.org/docs/stable/notes/cuda.html#id5
         if device_ids is not None:
@@ -202,8 +204,6 @@ class DDPStrategy(ParallelStrategy):
             else:
                 # Default stream avoids AccumulateGrad stream mismatch warnings during normal training.
                 ctx = torch.cuda.stream(torch.cuda.default_stream())
-        else:
-            ctx = nullcontext()
         with ctx:
             return DistributedDataParallel(module=model, device_ids=device_ids, **self._ddp_kwargs)
 

--- a/src/lightning/pytorch/strategies/ddp.py
+++ b/src/lightning/pytorch/strategies/ddp.py
@@ -191,7 +191,19 @@ class DDPStrategy(ParallelStrategy):
         device_ids = self.determine_ddp_device_ids()
         log.debug(f"setting up DDP model with device ids: {device_ids}, kwargs: {self._ddp_kwargs}")
         # https://pytorch.org/docs/stable/notes/cuda.html#id5
-        ctx = torch.cuda.stream(torch.cuda.Stream()) if device_ids is not None else nullcontext()
+        if device_ids is not None:
+            capturing = torch.cuda.is_current_stream_capturing()
+            if capturing:
+                # DDP must be initialized on a side-stream for CUDA graph whole-network capture.
+                # The resulting AccumulateGrad stream mismatch is intentional in this case.
+                # See: https://pytorch.org/docs/stable/notes/cuda.html#cuda-graphs
+                ctx = torch.cuda.stream(torch.cuda.Stream())
+                torch.autograd.graph.set_warn_on_accumulate_grad_stream_mismatch(False)
+            else:
+                # Default stream avoids AccumulateGrad stream mismatch warnings during normal training.
+                ctx = torch.cuda.stream(torch.cuda.default_stream())
+        else:
+            ctx = nullcontext()
         with ctx:
             return DistributedDataParallel(module=model, device_ids=device_ids, **self._ddp_kwargs)
 

--- a/tests/tests_fabric/strategies/test_ddp.py
+++ b/tests/tests_fabric/strategies/test_ddp.py
@@ -146,7 +146,7 @@ def test_module_init_context(precision, expected_dtype):
 @mock.patch.dict(os.environ, {"LOCAL_RANK": "0"})
 @mock.patch("lightning.fabric.strategies.ddp.DistributedDataParallel")
 @mock.patch("torch.cuda.Stream")
-@mock.patch("torch.cuda.default_stream")  # add this
+@mock.patch("torch.cuda.default_stream")
 @mock.patch("torch.cuda.is_current_stream_capturing", return_value=False)
 @mock.patch("torch.cuda.stream")
 def test_setup_with_cuda_stream(cuda_stream_mock, *_):

--- a/tests/tests_fabric/strategies/test_ddp.py
+++ b/tests/tests_fabric/strategies/test_ddp.py
@@ -147,7 +147,7 @@ def test_module_init_context(precision, expected_dtype):
 @mock.patch("lightning.fabric.strategies.ddp.DistributedDataParallel")
 @mock.patch("torch.cuda.Stream")
 @mock.patch("torch.cuda.is_current_stream_capturing", return_value=False)
-@mock.patch("torch.cuda.stream")  # bottom-most → first positional arg → cuda_stream_mock
+@mock.patch("torch.cuda.stream")
 def test_setup_with_cuda_stream(cuda_stream_mock, *_):
     model = torch.nn.Linear(2, 2)
     strategy = DDPStrategy(parallel_devices=[torch.device("cpu")], cluster_environment=LightningEnvironment())

--- a/tests/tests_fabric/strategies/test_ddp.py
+++ b/tests/tests_fabric/strategies/test_ddp.py
@@ -146,7 +146,8 @@ def test_module_init_context(precision, expected_dtype):
 @mock.patch.dict(os.environ, {"LOCAL_RANK": "0"})
 @mock.patch("lightning.fabric.strategies.ddp.DistributedDataParallel")
 @mock.patch("torch.cuda.Stream")
-@mock.patch("torch.cuda.stream")
+@mock.patch("torch.cuda.is_current_stream_capturing", return_value=False)
+@mock.patch("torch.cuda.stream")  # bottom-most → first positional arg → cuda_stream_mock
 def test_setup_with_cuda_stream(cuda_stream_mock, *_):
     model = torch.nn.Linear(2, 2)
     strategy = DDPStrategy(parallel_devices=[torch.device("cpu")], cluster_environment=LightningEnvironment())

--- a/tests/tests_fabric/strategies/test_ddp.py
+++ b/tests/tests_fabric/strategies/test_ddp.py
@@ -144,7 +144,7 @@ def test_module_init_context(precision, expected_dtype):
 
 
 @mock.patch.dict(os.environ, {"LOCAL_RANK": "0"})
-@mock.patch("lightning_fabric.strategies.ddp.DistributedDataParallel")
+@mock.patch("lightning.fabric.strategies.ddp.DistributedDataParallel")
 @mock.patch("torch.cuda.Stream")
 @mock.patch("torch.cuda.default_stream")  # add this
 @mock.patch("torch.cuda.is_current_stream_capturing", return_value=False)

--- a/tests/tests_fabric/strategies/test_ddp.py
+++ b/tests/tests_fabric/strategies/test_ddp.py
@@ -144,8 +144,9 @@ def test_module_init_context(precision, expected_dtype):
 
 
 @mock.patch.dict(os.environ, {"LOCAL_RANK": "0"})
-@mock.patch("lightning.fabric.strategies.ddp.DistributedDataParallel")
+@mock.patch("lightning_fabric.strategies.ddp.DistributedDataParallel")
 @mock.patch("torch.cuda.Stream")
+@mock.patch("torch.cuda.default_stream")  # add this
 @mock.patch("torch.cuda.is_current_stream_capturing", return_value=False)
 @mock.patch("torch.cuda.stream")
 def test_setup_with_cuda_stream(cuda_stream_mock, *_):


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #21567

### Problem

When using `Fabric` with DDP and gradient accumulation, the following warning
was emitted on every backward pass:
```
UserWarning: The AccumulateGrad node's stream does not match the stream of the
node that produced the incoming gradient. This may incur unnecessary
synchronization and break CUDA graph capture if the AccumulateGrad node's
stream is the default stream...
```

This warning did **not** appear when using plain PyTorch DDP directly.

### Root Cause

The original `setup_module` initialized `DistributedDataParallel` inside a
**new side-stream** context (`torch.cuda.Stream()`):

```python
ctx = torch.cuda.stream(torch.cuda.Stream())
with ctx:
    return DistributedDataParallel(...)
```

This was intentional for supporting CUDA graph whole-network capture, which
requires DDP to be initialized on a side-stream (see PyTorch docs:
https://docs.pytorch.org/docs/2.12/notes/cuda.html#id5).

However, for normal training (the vast majority of use cases), this causes a
stream mismatch: DDP registers its `AccumulateGrad` hooks on the side-stream
during initialization, but all subsequent forward/backward passes run on the
**default stream**. PyTorch detects this cross-stream node reference and emits
the warning.

Plain PyTorch DDP does not hit this because users initialize DDP directly
without any stream context, it defaults to the default stream, so there is
no mismatch.

### Fix

Detect whether we are currently inside a CUDA graph capture context using
`torch.cuda.is_current_stream_capturing()`, and pick the appropriate stream:

- **Normal training** (`capturing=False`): initialize DDP on the default
  stream. No mismatch, no warning.
- **CUDA graph capture** (`capturing=True`): initialize DDP on a new
  side-stream as before (required by PyTorch). Additionally suppress the
  `AccumulateGrad` warning globally since the mismatch is intentional in
  this context.

This fix is applied to both `DDPStrategy` in `lightning_fabric` and
`DDPStrategy` in `pytorch_lightning`.

### Testing

Verified with the reproduction script from #21567 across 4 GPUs (torch 2.11
and 2.12). Warning no longer appears under normal DDP + gradient accumulation
training.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
