### PR TITLE
security: avoid shell fallback in SLURM requeue

### DIFF
--- a/src/lightning/pytorch/trainer/connectors/signal_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/signal_connector.py
@@ -86,18 +86,13 @@ class _SignalConnector:
             else:
                 job_id = os.environ["SLURM_JOB_ID"]
 
-            assert re.match("[0-9_-]+", job_id)
+            if re.fullmatch(r"[0-9_-]+", job_id) is None:
+                raise RuntimeError(f"Invalid SLURM job id: {job_id!r}")
             cmd = ["scontrol", "requeue", job_id]
 
             # requeue job
             log.info(f"requeing job {job_id}...")
-            try:
-                result = call(cmd)
-            except FileNotFoundError:
-                # This can occur if a subprocess call to `scontrol` is run outside a shell context
-                # Re-attempt call (now with shell context). If any error is raised, propagate to user.
-                # When running a shell command, it should be passed as a single string.
-                result = call(" ".join(cmd), shell=True)
+            result = call(cmd)
 
             # print result text
             if result == 0:

--- a/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
@@ -135,8 +135,23 @@ def test_auto_requeue_invalid_job_id(call_mock):
     call_mock.return_value = 0
     trainer = Trainer(plugins=[SLURMEnvironment()])
     connector = _SignalConnector(trainer)
-    with pytest.raises(AssertionError):
+    with pytest.raises(RuntimeError, match="Invalid SLURM job id"):
         connector._slurm_sigusr_handler_fn(None, None)
+    call_mock.assert_not_called()
+
+
+@RunIf(skip_windows=True)
+@mock.patch("lightning.pytorch.trainer.connectors.signal_connector.call")
+@mock.patch("lightning.pytorch.trainer.Trainer.save_checkpoint", mock.MagicMock())
+@mock.patch.dict(os.environ, {"SLURM_JOB_ID": "123; rm -rf /"})
+def test_auto_requeue_job_id_command_injection(call_mock):
+    """Test that a crafted SLURM_JOB_ID containing shell metacharacters is rejected."""
+    call_mock.return_value = 0
+    trainer = Trainer(plugins=[SLURMEnvironment()])
+    connector = _SignalConnector(trainer)
+    with pytest.raises(RuntimeError, match="Invalid SLURM job id"):
+        connector._slurm_sigusr_handler_fn(None, None)
+    call_mock.assert_not_called()
 
 
 def _registering_signals():


### PR DESCRIPTION
## What does this PR do?

This hardens SLURM auto-requeue handling by keeping the requeue call on the argv-based subprocess path and replacing the previous `assert` validation with an explicit runtime check.

The previous fallback retried `scontrol requeue <job_id>` through `shell=True` when `scontrol` was not found. Since the job id comes from the environment, this PR avoids ever turning that value into a shell command string. The validation also now uses `re.fullmatch(...)` and raises a normal exception so it is not removed when Python runs with optimizations.

## Test Plan

```bash
PYTHONPATH=src python -m pytest tests/tests_pytorch/trainer/connectors/test_signal_connector.py -q
python -m py_compile src/lightning/pytorch/trainer/connectors/signal_connector.py tests/tests_pytorch/trainer/connectors/test_signal_connector.py
git diff --check
```

On Windows, the pytest file reports the SLURM-specific tests as skipped by the existing `RunIf(skip_windows=True)` marker, so I also ran direct handler proofs outside the marker, including under `python -O`, and confirmed invalid job ids are rejected before `subprocess.call` is invoked.