### PR TITLE
Fix SpikeDetection.load_state_dict referencing nonexistent self.running

### DIFF
--- a/src/lightning/fabric/utilities/spike.py
+++ b/src/lightning/fabric/utilities/spike.py
@@ -165,7 +165,7 @@ class SpikeDetection:
         self.rtol = state_dict.pop("rtol")
         self.bad_batches = state_dict.pop("bad_batches")
         self.exclude_batches_path = state_dict.pop("bad_batches_path")
-        self.running.load_state_dict(state_dict.pop("running"))
+        self.running_mean.load_state_dict(state_dict.pop("running"))
         self.running_mean.base_metric.load_state_dict(state_dict.pop("mean"))
 
 

--- a/tests/tests_fabric/utilities/test_spike.py
+++ b/tests/tests_fabric/utilities/test_spike.py
@@ -81,3 +81,15 @@ def test_fabric_spike_detection_integration(tmp_path, global_rank_spike, num_dev
         spike_value=spike_value,
         should_raise=should_raise,
     )
+
+
+@pytest.mark.skipif(not _TORCHMETRICS_GREATER_EQUAL_1_0_0, reason="requires torchmetrics>=1.0.0")
+def test_spike_detection_state_dict_roundtrip():
+    # Regression: ``load_state_dict`` previously called
+    # ``self.running.load_state_dict(...)`` but the attribute is named
+    # ``self.running_mean`` (set in ``__init__``), so any resume of a
+    # SpikeDetection callback crashed with
+    # ``AttributeError: 'SpikeDetection' object has no attribute 'running'``.
+    src = SpikeDetection()
+    dst = SpikeDetection()
+    dst.load_state_dict(src.state_dict())


### PR DESCRIPTION
## Summary

`SpikeDetection` in `src/lightning/fabric/utilities/spike.py` stores its running-mean metric on `self.running_mean` (set in `__init__` at line 57) and saves it via `state_dict` under the key `"running"`:

```python
# line 156
"running": self.running_mean.state_dict(),
```

But `load_state_dict` then tries to restore it via `self.running`, an attribute that is never defined anywhere:

```python
# line 168 (before this PR)
self.running.load_state_dict(state_dict.pop("running"))
```

So any resume of a `SpikeDetection` callback's state crashes:

```python
src = SpikeDetection()
dst = SpikeDetection()
dst.load_state_dict(src.state_dict())
# AttributeError: 'SpikeDetection' object has no attribute 'running'
```

The asymmetry with the very next line — which correctly uses `self.running_mean.base_metric` — confirms it's a typo for `self.running_mean`, not a deliberate different attribute. `state_dict` and `load_state_dict` were never round-trippable.

## Fix

```diff
-        self.running.load_state_dict(state_dict.pop("running"))
+        self.running_mean.load_state_dict(state_dict.pop("running"))
```

## Test

Adds `test_spike_detection_state_dict_roundtrip` next to the existing tests in `tests/tests_fabric/utilities/test_spike.py`. It constructs two `SpikeDetection` instances and round-trips `state_dict` / `load_state_dict`. **Fails on `master` with the `AttributeError` above; passes with this change.** Reuses the same `_TORCHMETRICS_GREATER_EQUAL_1_0_0` skip the surrounding tests use.

`ruff check` and `ruff format --check` clean on both files.

## Notes

No related open PRs: `gh pr list --repo Lightning-AI/pytorch-lightning --state all --search "SpikeDetection"` returns #21664 (an `Override`-decorator typing change, unrelated) and #19282 (a kwarg-typo fix merged in 2024, unrelated). No test pins the current broken behavior.