### PR TITLE
Resolve ckpt_path='best' from disk in a fresh process

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `LightningModule.toggle_optimizer` / `untoggle_optimizer` breaking under `torch.compile` by disabling Dynamo tracing on these bookkeeping helpers ([#21513](https://github.com/Lightning-AI/pytorch-lightning/issues/21513))
 
+- Fixed `validate`/`test`/`predict` with `ckpt_path="best"` raising a `ValueError` in a fresh process by recovering `best_model_path` from the persisted checkpoint state on disk ([#21254](https://github.com/Lightning-AI/pytorch-lightning/issues/21254))
+
 ---
 
 ## [2.6.4] - 2026-05-20

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -897,7 +897,8 @@ class ModelCheckpoint(Checkpoint):
         for ckpt_path in sorted(candidates_ts, key=candidates_ts.get, reverse=True):  # type: ignore[arg-type]
             try:
                 checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=False)
-            except Exception:
+            except Exception as ex:
+                log.debug(f"Skipping unreadable checkpoint {ckpt_path} while resolving the best path: {ex}")
                 continue
             callback_states = checkpoint.get("callbacks") if isinstance(checkpoint, dict) else None
             if not isinstance(callback_states, dict):

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -896,7 +896,10 @@ class ModelCheckpoint(Checkpoint):
 
         for ckpt_path in sorted(candidates_ts, key=candidates_ts.get, reverse=True):  # type: ignore[arg-type]
             try:
-                checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+                # Open via `self._fs` (the filesystem the candidates were listed from) so this works on non-local
+                # filesystems too; the listed paths are relative to that filesystem, not necessarily local paths.
+                with self._fs.open(ckpt_path, "rb") as file:
+                    checkpoint = torch.load(file, map_location="cpu", weights_only=False)
             except Exception as ex:
                 log.debug(f"Skipping unreadable checkpoint {ckpt_path} while resolving the best path: {ex}")
                 continue
@@ -905,8 +908,12 @@ class ModelCheckpoint(Checkpoint):
                 continue
             state = callback_states.get(self.state_key, callback_states.get(self._legacy_state_key))
             best_model_path = state.get("best_model_path") if isinstance(state, dict) else None
-            if best_model_path and self._fs.exists(best_model_path):
-                return os.path.normpath(best_model_path)
+            if best_model_path and get_filesystem(best_model_path).exists(best_model_path):
+                # Only normalize bare local paths; any protocol URL (`file://`, `s3://`, ...) must keep its `//`
+                # intact, which `os.path.normpath` would otherwise collapse.
+                if "://" not in best_model_path:
+                    return os.path.normpath(best_model_path)
+                return best_model_path
         return None
 
     def __warn_if_dir_not_empty(self, dirpath: _PATH) -> None:

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -876,6 +876,38 @@ class ModelCheckpoint(Checkpoint):
             return {os.path.normpath(p) for p in self._fs.ls(ckpt_path, detail=False) if _is_last(Path(p))}
         return set()
 
+    def _find_best_model_path_on_disk(self, trainer: "pl.Trainer") -> Optional[str]:
+        """Recover the best model path by reading the persisted callback state from checkpoints on disk.
+
+        This is used to resolve ``ckpt_path="best"`` in a process that did not run ``fit`` and therefore has an empty
+        in-memory ``best_model_path``. Every checkpoint embeds this callback's ``state_dict``, so the most recently
+        modified checkpoint in the directory carries the final ``best_model_path``. Returns ``None`` if no checkpoint is
+        found or the recorded best path no longer exists on disk.
+
+        """
+        ckpt_dir = self.__resolve_ckpt_dir(trainer)
+        if not self._fs.exists(ckpt_dir):
+            return None
+
+        candidates = [p for p in self._fs.ls(ckpt_dir, detail=False) if Path(p).suffix == self.FILE_EXTENSION]
+        candidates_ts = {path: self._fs.modified(path) for path in candidates if self._fs.exists(path)}
+        if not candidates_ts:
+            return None
+
+        for ckpt_path in sorted(candidates_ts, key=candidates_ts.get, reverse=True):  # type: ignore[arg-type]
+            try:
+                checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+            except Exception:
+                continue
+            callback_states = checkpoint.get("callbacks") if isinstance(checkpoint, dict) else None
+            if not isinstance(callback_states, dict):
+                continue
+            state = callback_states.get(self.state_key, callback_states.get(self._legacy_state_key))
+            best_model_path = state.get("best_model_path") if isinstance(state, dict) else None
+            if best_model_path and self._fs.exists(best_model_path):
+                return os.path.normpath(best_model_path)
+        return None
+
     def __warn_if_dir_not_empty(self, dirpath: _PATH) -> None:
         if self.save_top_k != 0 and _is_dir(self._fs, dirpath, strict=True) and len(self._fs.ls(dirpath)) > 0:
             rank_zero_warn(f"Checkpoint directory {dirpath} exists and is not empty.")

--- a/src/lightning/pytorch/trainer/connectors/checkpoint_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/checkpoint_connector.py
@@ -178,9 +178,10 @@ class _CheckpointConnector:
                     has_best_model_path = self.trainer.checkpoint_callback._find_best_model_path_on_disk(self.trainer)
                 if not has_best_model_path:
                     raise ValueError(
-                        f'`.{fn}(ckpt_path="best")` is set but `ModelCheckpoint` is not configured to save the best'
-                        " model. If you trained in a different process, pass the checkpoint path explicitly via"
-                        f" `.{fn}(ckpt_path=...)`."
+                        f'`.{fn}(ckpt_path="best")` is set but no best model checkpoint could be found. Either'
+                        " `ModelCheckpoint` is not configured to save the best model, or you trained in a different"
+                        f" process and no recoverable checkpoint exists on disk. Pass the checkpoint path explicitly"
+                        f" via `.{fn}(ckpt_path=...)`."
                     )
             # load best weights (from in-memory state, or recovered from disk above)
             ckpt_path = has_best_model_path or getattr(self.trainer.checkpoint_callback, "best_model_path", None)

--- a/src/lightning/pytorch/trainer/connectors/checkpoint_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/checkpoint_connector.py
@@ -172,11 +172,18 @@ class _CheckpointConnector:
                         f'You cannot execute `.{fn}(ckpt_path="best")` with `fast_dev_run=True`.'
                         f" Please pass an exact checkpoint path to `.{fn}(ckpt_path=...)`"
                     )
-                raise ValueError(
-                    f'`.{fn}(ckpt_path="best")` is set but `ModelCheckpoint` is not configured to save the best model.'
-                )
-            # load best weights
-            ckpt_path = getattr(self.trainer.checkpoint_callback, "best_model_path", None)
+                # `best_model_path` is in-memory state that is empty in a process that did not run `fit`. Fall back to
+                # the best path persisted in the checkpoints on disk, mirroring the `"last"` disk-scan below.
+                if isinstance(self.trainer.checkpoint_callback, ModelCheckpoint):
+                    has_best_model_path = self.trainer.checkpoint_callback._find_best_model_path_on_disk(self.trainer)
+                if not has_best_model_path:
+                    raise ValueError(
+                        f'`.{fn}(ckpt_path="best")` is set but `ModelCheckpoint` is not configured to save the best'
+                        " model. If you trained in a different process, pass the checkpoint path explicitly via"
+                        f' `.{fn}(ckpt_path=...)`.'
+                    )
+            # load best weights (from in-memory state, or recovered from disk above)
+            ckpt_path = has_best_model_path or getattr(self.trainer.checkpoint_callback, "best_model_path", None)
 
         elif ckpt_path == "last":
             candidates = {getattr(ft, "ckpt_path", None) for ft in ft_checkpoints}

--- a/src/lightning/pytorch/trainer/connectors/checkpoint_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/checkpoint_connector.py
@@ -180,7 +180,7 @@ class _CheckpointConnector:
                     raise ValueError(
                         f'`.{fn}(ckpt_path="best")` is set but `ModelCheckpoint` is not configured to save the best'
                         " model. If you trained in a different process, pass the checkpoint path explicitly via"
-                        f' `.{fn}(ckpt_path=...)`.'
+                        f" `.{fn}(ckpt_path=...)`."
                     )
             # load best weights (from in-memory state, or recovered from disk above)
             ckpt_path = has_best_model_path or getattr(self.trainer.checkpoint_callback, "best_model_path", None)

--- a/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
@@ -22,6 +22,7 @@ import pytest
 import torch
 from lightning_utilities.core.imports import compare_version
 
+from lightning.fabric.utilities.cloud_io import get_filesystem
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import Callback, ModelCheckpoint
 from lightning.pytorch.demos.boring_classes import BoringModel
@@ -295,6 +296,48 @@ def test_best_ckpt_path_from_disk_in_fresh_process(tmp_path, trainer_fn):
     fn = getattr(fresh_trainer, trainer_fn)
     fn(LogValLossModel(), ckpt_path="best")
     assert os.path.normpath(fresh_trainer.ckpt_path) == os.path.normpath(best_model_path)
+
+
+def test_best_ckpt_path_from_disk_on_remote_filesystem(tmp_path):
+    """``ckpt_path="best"`` must be recoverable when checkpoints live on a non-local (fsspec) filesystem.
+
+    Guards the disk-recovery path against assuming a local filesystem: candidates are opened through the callback's
+    own ``self._fs`` (not ``torch.load`` on a raw path) and the recovered path is not ``normpath``-mangled, so
+    ``memory://``/``s3://``-style paths work.
+
+    """
+    remote_dir = "memory://test_best_ckpt_remote_fs"
+    remote_fs = get_filesystem(remote_dir)
+    if remote_fs.exists(remote_dir):  # isolate from a previous run without clearing the shared memory store
+        remote_fs.rm(remote_dir, recursive=True)
+
+    class LogValLossModel(BoringModel):
+        def validation_step(self, batch, batch_idx):
+            loss = self.step(batch)
+            self.log("val_loss", loss)
+            return {"x": loss}
+
+    # train: a best checkpoint is written to the remote filesystem
+    checkpoint_callback = ModelCheckpoint(dirpath=remote_dir, monitor="val_loss", save_top_k=1, mode="min")
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        max_epochs=1,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        logger=False,
+        callbacks=[checkpoint_callback],
+    )
+    trainer.fit(LogValLossModel())
+    best_model_path = checkpoint_callback.best_model_path
+    assert best_model_path.startswith("memory:")
+    assert get_filesystem(best_model_path).exists(best_model_path)
+
+    # fresh process: empty in-memory state, must recover "best" from the remote filesystem
+    fresh_checkpoint = ModelCheckpoint(dirpath=remote_dir, monitor="val_loss", save_top_k=1, mode="min")
+    assert fresh_checkpoint.best_model_path == ""
+    fresh_trainer = Trainer(default_root_dir=tmp_path, limit_val_batches=2, logger=False, callbacks=[fresh_checkpoint])
+    fresh_trainer.validate(LogValLossModel(), ckpt_path="best")
+    assert fresh_trainer.ckpt_path == best_model_path
 
 
 def test_best_ckpt_path_no_disk_fallback_raises(tmp_path):

--- a/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
@@ -249,6 +249,61 @@ def test_stateful_trainer_ckpt_path_support(tmp_path):
     assert trainer.ckpt_path == best_path
 
 
+@pytest.mark.parametrize("trainer_fn", ["validate", "test", "predict"])
+def test_best_ckpt_path_from_disk_in_fresh_process(tmp_path, trainer_fn):
+    """Test that ckpt_path="best" is resolved from disk when training happened in a separate process.
+
+    Regression test for https://github.com/Lightning-AI/pytorch-lightning/issues/21254. A fresh Trainer/process has an
+    empty in-memory ``best_model_path``, so ``"best"`` must be recovered from the persisted callback state on disk.
+
+    """
+    class LogValLossModel(BoringModel):
+        def validation_step(self, batch, batch_idx):
+            loss = self.step(batch)
+            self.log("val_loss", loss)
+            return {"x": loss}
+
+    # train in one "process": a best checkpoint is written to disk
+    model = LogValLossModel()
+    checkpoint_callback = ModelCheckpoint(dirpath=tmp_path, monitor="val_loss", save_top_k=1, mode="min")
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        max_epochs=1,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        logger=False,
+        callbacks=[checkpoint_callback],
+    )
+    trainer.fit(model)
+    best_model_path = checkpoint_callback.best_model_path
+    assert best_model_path and os.path.exists(best_model_path)
+
+    # simulate a fresh process: a new Trainer with a fresh ModelCheckpoint that has empty in-memory state
+    fresh_checkpoint = ModelCheckpoint(dirpath=tmp_path, monitor="val_loss", save_top_k=1, mode="min")
+    assert fresh_checkpoint.best_model_path == ""
+    fresh_trainer = Trainer(
+        default_root_dir=tmp_path,
+        limit_val_batches=2,
+        limit_test_batches=2,
+        limit_predict_batches=2,
+        logger=False,
+        callbacks=[fresh_checkpoint],
+    )
+
+    fn = getattr(fresh_trainer, trainer_fn)
+    fn(LogValLossModel(), ckpt_path="best")
+    assert os.path.normpath(fresh_trainer.ckpt_path) == os.path.normpath(best_model_path)
+
+
+def test_best_ckpt_path_no_disk_fallback_raises(tmp_path):
+    """Test that ckpt_path="best" still raises a clear error when no checkpoint exists on disk."""
+    model = BoringModel()
+    checkpoint_callback = ModelCheckpoint(dirpath=tmp_path, monitor="val_loss", save_top_k=1, mode="min")
+    trainer = Trainer(default_root_dir=tmp_path, logger=False, callbacks=[checkpoint_callback])
+    with pytest.raises(ValueError, match="is not configured to save the best model"):
+        trainer.validate(model, ckpt_path="best")
+
+
 @pytest.mark.parametrize(("strict_loading", "expected"), [(None, True), (True, True), (False, False)])
 def test_strict_loading(strict_loading, expected, tmp_path):
     """Test that the connector respects the `LightningModule.strict_loading` setting."""

--- a/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
@@ -257,6 +257,7 @@ def test_best_ckpt_path_from_disk_in_fresh_process(tmp_path, trainer_fn):
     empty in-memory ``best_model_path``, so ``"best"`` must be recovered from the persisted callback state on disk.
 
     """
+
     class LogValLossModel(BoringModel):
         def validation_step(self, batch, batch_idx):
             loss = self.step(batch)
@@ -276,7 +277,8 @@ def test_best_ckpt_path_from_disk_in_fresh_process(tmp_path, trainer_fn):
     )
     trainer.fit(model)
     best_model_path = checkpoint_callback.best_model_path
-    assert best_model_path and os.path.exists(best_model_path)
+    assert best_model_path
+    assert os.path.exists(best_model_path)
 
     # simulate a fresh process: a new Trainer with a fresh ModelCheckpoint that has empty in-memory state
     fresh_checkpoint = ModelCheckpoint(dirpath=tmp_path, monitor="val_loss", save_top_k=1, mode="min")


### PR DESCRIPTION
Fixes #21254

`Trainer.validate/test/predict(ckpt_path="best")` raises a ValueError when run in a process that did not call `fit`, even though a `ModelCheckpoint` saved a best checkpoint to disk. The "best" path is read only from the in-memory `ModelCheckpoint.best_model_path`, which is empty in a fresh process. The "last" path already recovers from disk; "best" did not.

This adds a disk fallback for "best", mirroring how "last" recovers: `ModelCheckpoint._find_best_model_path_on_disk` resolves the checkpoint directory the same way the callback does, scans newest first, and reads the persisted `best_model_path` from the callback state embedded in the saved checkpoints. If nothing is found, a clearer error is raised. The "last" path is unchanged.

Added a regression test that trains with a `ModelCheckpoint`, then in a fresh Trainer with a fresh `ModelCheckpoint` (empty in-memory state) calls validate/test/predict with `ckpt_path="best"` and asserts the best checkpoint is recovered from disk, plus a test that the clear error is still raised when no checkpoint exists.

Per the discussion on the issue, this implements the disk-recovery option. The alternative would be to only improve the error message, happy to switch if maintainers prefer that.
