### PR TITLE
Fix WeightAveraging swapping un-averaged model during validation before first update

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `WeightAveraging` (e.g. `EMAWeightAveraging`) swapping in the un-averaged model during validation before the first update, which corrupted validation metrics when averaging was delayed ([#21724](https://github.com/Lightning-AI/pytorch-lightning/issues/21724))
+
 - Fixed non-zero process exits in `CombinedLoader.reset()` with large tensors and persistent spawned workers by avoiding explicit `_shutdown_workers()` calls and relying on iterator cleanup via `del` [#21708](https://github.com/Lightning-AI/pytorch-lightning/issues/21708)
 
 - Fixed `SIGTERMException` producing a zero exit code instead of 143 (128 + SIGTERM) ([#21623](https://github.com/Lightning-AI/pytorch-lightning/issues/21623))

--- a/src/lightning/pytorch/callbacks/weight_averaging.py
+++ b/src/lightning/pytorch/callbacks/weight_averaging.py
@@ -223,7 +223,7 @@ class WeightAveraging(Callback):
             pl_module: The current :class:`~lightning.pytorch.core.LightningModule` instance.
 
         """
-        if self._average_model is not None:
+        if self._should_swap_models():
             self._swap_models(pl_module)
 
     @override
@@ -237,7 +237,7 @@ class WeightAveraging(Callback):
             pl_module: The current :class:`~lightning.pytorch.core.LightningModule` instance.
 
         """
-        if self._average_model is not None:
+        if self._should_swap_models():
             self._swap_models(pl_module)
 
     @override
@@ -333,6 +333,19 @@ class WeightAveraging(Callback):
                 "initialized with state_dict."
             )
             self._average_model.module.load_state_dict(deepcopy(checkpoint["state_dict"]), strict=False)
+
+    def _should_swap_models(self) -> bool:
+        """Whether validation should swap in the :class:`AveragedModel` parameters.
+
+        Before the first update, the :class:`AveragedModel` is only an (un-averaged) copy of the
+        initial model created in ``setup()``, so swapping it in during validation would report
+        metrics for un-averaged weights. Only swap once at least one update has happened. The same
+        condition is used in both ``on_validation_epoch_start`` and ``on_validation_epoch_end`` so
+        that the swap is always symmetric and the current model is never left holding the averaged
+        weights after validation.
+
+        """
+        return self._average_model is not None and int(self._average_model.n_averaged) > 0
 
     def _swap_models(self, pl_module: "pl.LightningModule") -> None:
         """Swaps the parameter values of the current model and the :class:`AveragedModel`.

--- a/tests/tests_pytorch/callbacks/test_weight_averaging.py
+++ b/tests/tests_pytorch/callbacks/test_weight_averaging.py
@@ -385,6 +385,7 @@ def test_ema_weight_averaging_no_swap_before_first_update(tmp_path):
     Before the first ``update_parameters`` the ``AveragedModel`` is only an un-averaged copy of
     the initial model from ``setup()``, so swapping it in during validation would report metrics
     for un-averaged weights (https://github.com/Lightning-AI/pytorch-lightning/issues/21724).
+
     """
 
     class CountingEMA(EMAWeightAveraging):

--- a/tests/tests_pytorch/callbacks/test_weight_averaging.py
+++ b/tests/tests_pytorch/callbacks/test_weight_averaging.py
@@ -166,13 +166,16 @@ class SWATestCallback(WeightAveraging):
             assert self._average_model.n_averaged == 2
         else:
             assert self._average_model.n_averaged == 3
-        assert self.swap_calls == (trainer.current_epoch + 1 - self.first_epoch) * 2
+        # The first update happens at the end of epoch 3, so validation only swaps in the averaged
+        # model from epoch 4 onwards; before that it must not swap in the un-averaged copy.
+        assert self.swap_calls == max(0, trainer.current_epoch - 3) * 2
         assert self.copy_calls == 0
 
     def on_train_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
         super().on_train_end(trainer, pl_module)
         assert self._average_model.n_averaged == 3
-        assert self.swap_calls == (trainer.max_epochs - self.first_epoch) * 2
+        # Swaps only happen in epochs 4-7 (after the first update at the end of epoch 3).
+        assert self.swap_calls == (trainer.max_epochs - 4) * 2
         assert self.copy_calls == 1
 
 
@@ -374,6 +377,46 @@ def test_ema_weight_averaging_starting_step(tmp_path):
     _train(model, dataset, tmp_path, callback)
 
     assert callback._average_model is not None
+
+
+def test_ema_weight_averaging_no_swap_before_first_update(tmp_path):
+    """Validation must not swap in the averaged model before the first update.
+
+    Before the first ``update_parameters`` the ``AveragedModel`` is only an un-averaged copy of
+    the initial model from ``setup()``, so swapping it in during validation would report metrics
+    for un-averaged weights (https://github.com/Lightning-AI/pytorch-lightning/issues/21724).
+    """
+
+    class CountingEMA(EMAWeightAveraging):
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.swap_calls = 0
+
+        def _swap_models(self, *args: Any, **kwargs: Any):
+            self.swap_calls += 1
+            return super()._swap_models(*args, **kwargs)
+
+    model = TestModel()
+    dataset = RandomDataset(32, 32)
+    # Delay the first update well beyond this short run, so no update ever happens.
+    callback = CountingEMA(decay=0.999, update_every_n_steps=1, update_starting_at_step=10_000)
+    trainer = Trainer(
+        accelerator="cpu",
+        logger=False,
+        callbacks=callback,
+        max_epochs=2,
+        num_sanity_val_steps=0,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        default_root_dir=tmp_path,
+    )
+    trainer.fit(model, DataLoader(dataset, batch_size=4, shuffle=False))
+
+    # No update happened, so the averaged model was never swapped in during validation.
+    assert callback._average_model is not None
+    assert int(callback._average_model.n_averaged) == 0
+    assert callback.swap_calls == 0
 
 
 def test_ema_weight_averaging_starting_epoch(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Fixes #21724.

`WeightAveraging` (and thus `EMAWeightAveraging`) swaps the `AveragedModel` into the `LightningModule` in `on_validation_epoch_start` / `on_validation_epoch_end` whenever an `AveragedModel` exists. But before the first `update_parameters` call, the `AveragedModel` is only an un-averaged `deepcopy` of the initial model created in `setup()`. So any validation that runs **before averaging begins** — e.g. with a delayed `update_starting_at_step` / `update_starting_at_epoch` — swaps in those un-averaged weights and reports validation metrics for a model that was never trained (the reporter saw retrieval metrics near 0 before `update_starting_at_step`).

### Fix

Only swap when the `AveragedModel` has actually been updated at least once (`n_averaged > 0`), via a small `_should_swap_models()` helper used **symmetrically** in both hooks. Using the same guard on both sides matters: a one-sided guard would leave the live model holding the averaged weights after validation. Once averaging has started, behaviour is unchanged.

### Tests

- Added `test_ema_weight_averaging_no_swap_before_first_update`: with the first update delayed beyond the run, validation runs but no swap occurs and `n_averaged == 0` (fails on the previous behaviour).
- Updated `SWATestCallback`'s swap-count expectations to reflect that swaps now begin only after the first update (epoch 4 onward), rather than from epoch 0.
- Full `tests/tests_pytorch/callbacks/test_weight_averaging.py` suite passes locally (27 passed, 3 GPU/ddp skipped); `ruff format`/`ruff check` clean.

<!-- ## PR review -->

cc @ethanwharris
