### PR TITLE
docs: fix CometLogger log_model docstring example

### DIFF
--- a/src/lightning/pytorch/loggers/comet.py
+++ b/src/lightning/pytorch/loggers/comet.py
@@ -166,7 +166,7 @@ class CometLogger(Logger):
 
     .. code-block:: python
 
-        logger.experiment.log_model(name="my-model", "<path to your model>")
+        logger.experiment.log_model(name="my-model", file_or_folder="<path to your model>")
 
     See Also:
         - `Demo in Google Colab <https://tinyurl.com/22phzw5s>`__


### PR DESCRIPTION
## What does this PR do?

Fixes the broken docstring example for `log_model` in the `CometLogger`
class (`src/lightning/pytorch/loggers/comet.py`). The current example is
syntactically invalid Python — it places a positional argument after a
keyword argument, and it omits the `file_or_folder=` keyword that the
Comet SDK requires.

Before:

```python
logger.experiment.log_model(name="my-model", "<path to your model>")
```

After:

```python
logger.experiment.log_model(name="my-model", file_or_folder="<path to your model>")
```

This matches the call signature documented at
https://www.comet.com/docs/v2/api-and-sdk/python-sdk/reference/Experiment/#experimentlog_model
and the worked example in issue #20583.

Fixes #20583

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a GitHub issue? — yes, #20583, with a worked example by the reporter.
- [x] Did you read the contributor guideline?
- [x] Did you make sure your PR does only one thing? — yes, single-line docstring fix; no behavior changes.
- N/A documentation update beyond the docstring itself.
- N/A new tests — docstring-only change, nothing to test.
- [x] Did you verify new and existing tests pass locally with your changes? — `ruff check` and `ruff format --check` pass; AST parses cleanly.
- N/A breaking changes.
- N/A CHANGELOG — PR template explicitly excludes docstring fixes.

</details>

## PR review

Anyone in the community is welcome to review the PR.
