### PR TITLE
Fix GPU memory leak in ModelPruning when reused across multiple fit() calls

### DIFF
--- a/src/lightning/pytorch/callbacks/pruning.py
+++ b/src/lightning/pytorch/callbacks/pruning.py
@@ -377,11 +377,14 @@ class ModelPruning(Callback):
 
         if self._use_lottery_ticket_hypothesis:
             # group modules by id. Each entry has a copy of the initial data
-            # and a list of the associated parameter names to prune
+            # and a list of the associated parameter names to prune.
+            # The copy is moved to CPU to avoid accumulating GPU memory when
+            # the callback is reused across multiple trainer.fit() calls (#8542).
             self._original_layers = {}
             for i, (module, name) in enumerate(self._parameters_to_prune):
                 id_ = id(module)
-                self._original_layers.setdefault(id_, _LayerRef(data=deepcopy(module), names=[]))
+                copy = deepcopy(module).cpu()
+                self._original_layers.setdefault(id_, _LayerRef(data=copy, names=[]))
                 self._original_layers[id_]["names"].append((i, name))
 
     def _run_pruning(self, current_epoch: int) -> None:
@@ -415,6 +418,9 @@ class ModelPruning(Callback):
         if self._make_pruning_permanent:
             rank_zero_debug("`ModelPruning.on_train_end`. Pruning is made permanent for this checkpoint")
             self.make_pruning_permanent(pl_module)
+        # Release the original layer copies to free GPU memory when the
+        # callback is reused across multiple trainer.fit() calls (#8542).
+        self._original_layers = None
 
     def _make_pruning_permanent_on_state_dict(self, pl_module: LightningModule) -> dict[str, Any]:
         state_dict = pl_module.state_dict()

--- a/tests/tests_pytorch/callbacks/test_pruning.py
+++ b/tests/tests_pytorch/callbacks/test_pruning.py
@@ -554,10 +554,8 @@ def test_sparsity_calculation(tmp_path, caplog, pruning_amount: float, model_typ
 
 
 def test_pruning_callback_original_layers_on_cpu():
-    """Test that lottery ticket hypothesis stores original layers on CPU
-    to prevent GPU memory leaks when the callback is reused across
-    multiple trainer.fit() calls (#8542)."""
-    from lightning.pytorch import LightningModule, Trainer
+    """Test that lottery ticket hypothesis stores original layers on CPU to prevent GPU memory leaks when the callback
+    is reused across multiple trainer.fit() calls (#8542)."""
     from lightning.pytorch.callbacks.pruning import ModelPruning
     from lightning.pytorch.demos.boring_classes import BoringModel
 
@@ -578,16 +576,12 @@ def test_pruning_callback_original_layers_on_cpu():
     assert pruning._original_layers is not None
     for layer_ref in pruning._original_layers.values():
         for name, param in layer_ref["data"].named_parameters():
-            assert not param.is_cuda, (
-                f"Parameter '{name}' is on GPU. Expected CPU to prevent memory leak."
-            )
+            assert not param.is_cuda, f"Parameter '{name}' is on GPU. Expected CPU to prevent memory leak."
 
 
 def test_pruning_callback_cleanup_on_train_end():
-    """Test that _original_layers is cleaned up after on_train_end
-    to release memory when the callback is reused across multiple
-    trainer.fit() calls (#8542)."""
-    from lightning.pytorch import LightningModule
+    """Test that _original_layers is cleaned up after on_train_end to release memory when the callback is reused across
+    multiple trainer.fit() calls (#8542)."""
     from lightning.pytorch.callbacks.pruning import ModelPruning
     from lightning.pytorch.demos.boring_classes import BoringModel
 
@@ -604,15 +598,12 @@ def test_pruning_callback_cleanup_on_train_end():
     assert pruning._original_layers is not None, "Should be set after setup"
 
     pruning.on_train_end(None, model)
-    assert pruning._original_layers is None, (
-        "Should be cleaned up after on_train_end to release memory"
-    )
+    assert pruning._original_layers is None, "Should be cleaned up after on_train_end to release memory"
 
 
 def test_pruning_callback_reuse_does_not_leak():
-    """Simulate multiple trainer.fit() calls and verify that
-    GPU memory doesn't accumulate when the callback is reused."""
-    from lightning.pytorch import LightningModule
+    """Simulate multiple trainer.fit() calls and verify that GPU memory doesn't accumulate when the callback is
+    reused."""
     from lightning.pytorch.callbacks.pruning import ModelPruning
     from lightning.pytorch.demos.boring_classes import BoringModel
 
@@ -632,8 +623,6 @@ def test_pruning_callback_reuse_does_not_leak():
         # After each run, original layers should be on CPU
         for layer_ref in pruning._original_layers.values():
             for name, param in layer_ref["data"].named_parameters():
-                assert not param.is_cuda, (
-                    f"Iteration {i}: Parameter '{name}' is on GPU"
-                )
+                assert not param.is_cuda, f"Iteration {i}: Parameter '{name}' is on GPU"
         pruning.on_train_end(None, model)
         assert pruning._original_layers is None, f"Iteration {i}: should be cleaned up"

--- a/tests/tests_pytorch/callbacks/test_pruning.py
+++ b/tests/tests_pytorch/callbacks/test_pruning.py
@@ -551,3 +551,89 @@ def test_sparsity_calculation(tmp_path, caplog, pruning_amount: float, model_typ
     expected_pruned_count = int(expected_total_params * pruning_amount)
     pruned_tolerance = max(1, int(expected_total_params * 0.05))
     assert abs(pruned_count - expected_pruned_count) <= pruned_tolerance
+
+
+def test_pruning_callback_original_layers_on_cpu():
+    """Test that lottery ticket hypothesis stores original layers on CPU
+    to prevent GPU memory leaks when the callback is reused across
+    multiple trainer.fit() calls (#8542)."""
+    from lightning.pytorch import LightningModule, Trainer
+    from lightning.pytorch.callbacks.pruning import ModelPruning
+    from lightning.pytorch.demos.boring_classes import BoringModel
+
+    model = BoringModel()
+    parameters_to_prune = [(model.layer, "weight")]
+    pruning = ModelPruning(
+        pruning_fn="l1_unstructured",
+        parameters_to_prune=parameters_to_prune,
+        use_lottery_ticket_hypothesis=True,
+        amount=0.1,
+        verbose=0,
+    )
+
+    # Simulate setup (normally called by Trainer)
+    pruning.setup(None, model, "fit")
+
+    # After setup, original layers should NOT be on GPU
+    assert pruning._original_layers is not None
+    for layer_ref in pruning._original_layers.values():
+        for name, param in layer_ref["data"].named_parameters():
+            assert not param.is_cuda, (
+                f"Parameter '{name}' is on GPU. Expected CPU to prevent memory leak."
+            )
+
+
+def test_pruning_callback_cleanup_on_train_end():
+    """Test that _original_layers is cleaned up after on_train_end
+    to release memory when the callback is reused across multiple
+    trainer.fit() calls (#8542)."""
+    from lightning.pytorch import LightningModule
+    from lightning.pytorch.callbacks.pruning import ModelPruning
+    from lightning.pytorch.demos.boring_classes import BoringModel
+
+    model = BoringModel()
+    parameters_to_prune = [(model.layer, "weight")]
+    pruning = ModelPruning(
+        pruning_fn="l1_unstructured",
+        parameters_to_prune=parameters_to_prune,
+        use_lottery_ticket_hypothesis=True,
+        amount=0.1,
+    )
+
+    pruning.setup(None, model, "fit")
+    assert pruning._original_layers is not None, "Should be set after setup"
+
+    pruning.on_train_end(None, model)
+    assert pruning._original_layers is None, (
+        "Should be cleaned up after on_train_end to release memory"
+    )
+
+
+def test_pruning_callback_reuse_does_not_leak():
+    """Simulate multiple trainer.fit() calls and verify that
+    GPU memory doesn't accumulate when the callback is reused."""
+    from lightning.pytorch import LightningModule
+    from lightning.pytorch.callbacks.pruning import ModelPruning
+    from lightning.pytorch.demos.boring_classes import BoringModel
+
+    model = BoringModel()
+    parameters_to_prune = [(model.layer, "weight")]
+    pruning = ModelPruning(
+        pruning_fn="l1_unstructured",
+        parameters_to_prune=parameters_to_prune,
+        use_lottery_ticket_hypothesis=True,
+        amount=0.1,
+    )
+
+    # Simulate 3 training runs
+    for i in range(3):
+        pruning.setup(None, model, "fit")
+        assert pruning._original_layers is not None, f"Iteration {i}: should be set"
+        # After each run, original layers should be on CPU
+        for layer_ref in pruning._original_layers.values():
+            for name, param in layer_ref["data"].named_parameters():
+                assert not param.is_cuda, (
+                    f"Iteration {i}: Parameter '{name}' is on GPU"
+                )
+        pruning.on_train_end(None, model)
+        assert pruning._original_layers is None, f"Iteration {i}: should be cleaned up"


### PR DESCRIPTION
While using ModelPruning with lottery ticket hypothesis in an iterative training loop (multiple `trainer.fit()` calls with the same callback), I noticed GPU memory growing until OOM.

## Root cause

The `setup()` method deep-copies the original modules to preserve weights for lottery ticket hypothesis reset:

```python
self._original_layers.setdefault(id_, _LayerRef(data=deepcopy(module), names=[]))
```

`deepcopy(module)` copies all parameters **on the GPU**. When `setup()` is called again on the next `trainer.fit()`, the old dict is overwritten but the GPU tensors may linger in CUDA memory until the Python GC eventually runs — and by then, it's too late.

## Fix

Two changes:

1. **Move copies to CPU** in `setup()` — the original parameter data is only needed for `_copy_param()`, which already does `src.data.to(dst.device)` when restoring weights. Keeping them on CPU is safe and avoids GPU memory pressure.

2. **Clean up in `on_train_end`** — set `self._original_layers = None` to eagerly release references, giving the GC a clear signal.

## Before/After

Before: GPU memory accumulates linearly with number of `fit()` calls when lottery ticket hypothesis is enabled.

After: Original layer copies live on CPU, and are explicitly released after training ends.

Closes #8542