### PR TITLE
Add enable_device_summary flag and DeviceSummary callback to suppress…

### DIFF
--- a/src/lightning/pytorch/callbacks/__init__.py
+++ b/src/lightning/pytorch/callbacks/__init__.py
@@ -15,6 +15,7 @@ from lightning.pytorch.callbacks.batch_size_finder import BatchSizeFinder
 from lightning.pytorch.callbacks.callback import Callback
 from lightning.pytorch.callbacks.checkpoint import Checkpoint
 from lightning.pytorch.callbacks.device_stats_monitor import DeviceStatsMonitor
+from lightning.pytorch.callbacks.device_summary import DeviceSummary
 from lightning.pytorch.callbacks.early_stopping import EarlyStopping
 from lightning.pytorch.callbacks.finetuning import BackboneFinetuning, BaseFinetuning
 from lightning.pytorch.callbacks.gradient_accumulation_scheduler import GradientAccumulationScheduler
@@ -42,6 +43,7 @@ __all__ = [
     "Callback",
     "Checkpoint",
     "DeviceStatsMonitor",
+    "DeviceSummary",
     "EarlyStopping",
     "GradientAccumulationScheduler",
     "LambdaCallback",

--- a/src/lightning/pytorch/callbacks/device_summary.py
+++ b/src/lightning/pytorch/callbacks/device_summary.py
@@ -1,0 +1,104 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Device Summary
+==============
+
+Logs information about available and used devices (GPU, TPU, etc.) at the start of training.
+
+"""
+
+from typing_extensions import override
+
+import lightning.pytorch as pl
+from lightning.fabric.utilities.warnings import PossibleUserWarning
+from lightning.pytorch.accelerators import CUDAAccelerator, MPSAccelerator, XLAAccelerator
+from lightning.pytorch.callbacks.callback import Callback
+from lightning.pytorch.utilities.rank_zero import rank_zero_info, rank_zero_warn
+
+
+class DeviceSummary(Callback):
+    r"""Logs information about available and used devices at the start of training.
+
+    This callback prints the availability and usage status of GPUs (CUDA/MPS) and TPUs.
+    It also warns if a device is available but not being used.
+
+    Args:
+        show_warnings: Whether to show warnings when available devices are not used.
+            Defaults to ``True``.
+
+    Example::
+
+        >>> from lightning.pytorch import Trainer
+        >>> from lightning.pytorch.callbacks import DeviceSummary
+        >>> # Default behavior - shows device info and warnings
+        >>> trainer = Trainer(callbacks=[DeviceSummary()])
+        >>> # Suppress device availability warnings
+        >>> trainer = Trainer(callbacks=[DeviceSummary(show_warnings=False)])
+        >>> # Disable device summary completely by not including the callback
+        >>> trainer = Trainer(callbacks=[], enable_device_summary=False)
+
+    """
+
+    def __init__(self, show_warnings: bool = True) -> None:
+        self._show_warnings = show_warnings
+        self._logged = False
+
+    @override
+    def setup(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", stage: str) -> None:
+        """Log device information at the start of any training stage.
+
+        The device summary is only logged once per Trainer instance, even if setup is called multiple times (e.g., for
+        fit then test).
+
+        """
+        if self._logged:
+            return
+        self._logged = True
+        self._log_device_info(trainer)
+
+    def _log_device_info(self, trainer: "pl.Trainer") -> None:
+        """Log information about available and used devices."""
+        if CUDAAccelerator.is_available():
+            gpu_available = True
+            gpu_type = " (cuda)"
+        elif MPSAccelerator.is_available():
+            gpu_available = True
+            gpu_type = " (mps)"
+        else:
+            gpu_available = False
+            gpu_type = ""
+
+        gpu_used = isinstance(trainer.accelerator, (CUDAAccelerator, MPSAccelerator))
+        rank_zero_info(f"GPU available: {gpu_available}{gpu_type}, used: {gpu_used}")
+
+        num_tpu_cores = trainer.num_devices if isinstance(trainer.accelerator, XLAAccelerator) else 0
+        rank_zero_info(f"TPU available: {XLAAccelerator.is_available()}, using: {num_tpu_cores} TPU cores")
+
+        if not self._show_warnings:
+            return
+
+        if (
+            CUDAAccelerator.is_available()
+            and not isinstance(trainer.accelerator, CUDAAccelerator)
+            or MPSAccelerator.is_available()
+            and not isinstance(trainer.accelerator, MPSAccelerator)
+        ):
+            rank_zero_warn(
+                "GPU available but not used. You can set it by doing `Trainer(accelerator='gpu')`.",
+                category=PossibleUserWarning,
+            )
+
+        if XLAAccelerator.is_available() and not isinstance(trainer.accelerator, XLAAccelerator):
+            rank_zero_warn("TPU available but not used. You can set it by doing `Trainer(accelerator='tpu')`.")

--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -133,6 +133,7 @@ class Trainer:
         enable_autolog_hparams: bool = True,
         model_registry: Optional[str] = None,
         suggest_integrations: bool = True,
+        enable_device_summary: Optional[bool] = None,
     ) -> None:
         r"""Customize every aspect of training via flags.
 
@@ -364,6 +365,12 @@ class Trainer:
                     " Model summary can impact raw speed so it is disabled in barebones mode."
                 )
             enable_model_summary = False
+            if enable_device_summary:
+                raise ValueError(
+                    f"`Trainer(barebones=True, enable_device_summary={enable_device_summary!r})` was passed."
+                    " Device summary can impact raw speed so it is disabled in barebones mode."
+                )
+            enable_device_summary = False
             if num_sanity_val_steps is not None and num_sanity_val_steps != 0:
                 raise ValueError(
                     f"`Trainer(barebones=True, num_sanity_val_steps={num_sanity_val_steps!r})` was passed."
@@ -390,6 +397,7 @@ class Trainer:
                 " - Checkpointing: `Trainer(enable_checkpointing=True)`",
                 " - Progress bar: `Trainer(enable_progress_bar=True)`",
                 " - Model summary: `Trainer(enable_model_summary=True)`",
+                " - Device summary: `Trainer(enable_device_summary=True)`",
                 " - Logging: `Trainer(logger=True)`, `Trainer(log_every_n_steps>0)`,"
                 " `LightningModule.log(...)`, `LightningModule.log_dict(...)`",
                 " - Sanity checking: `Trainer(num_sanity_val_steps>0)`",
@@ -414,6 +422,8 @@ class Trainer:
                 log_every_n_steps = 50
             if enable_model_summary is None:
                 enable_model_summary = True
+            if enable_device_summary is None:
+                enable_device_summary = True
             if num_sanity_val_steps is None:
                 num_sanity_val_steps = 2
 
@@ -456,6 +466,7 @@ class Trainer:
             enable_progress_bar,
             default_root_dir,
             enable_model_summary,
+            enable_device_summary,
             max_time,
         )
 
@@ -490,8 +501,6 @@ class Trainer:
                 " is recommended only for model debugging."
             )
         self._detect_anomaly: bool = detect_anomaly
-
-        setup._log_device_info(self)
 
         self.should_stop = False
         self.state = TrainerState()

--- a/tests/tests_pytorch/callbacks/test_device_summary.py
+++ b/tests/tests_pytorch/callbacks/test_device_summary.py
@@ -1,0 +1,64 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from unittest.mock import MagicMock
+
+from lightning.pytorch import Trainer
+from lightning.pytorch.callbacks import DeviceSummary
+from lightning.pytorch.demos.boring_classes import BoringModel
+
+
+def test_device_summary_callback_present_trainer():
+    trainer = Trainer()
+    assert any(isinstance(cb, DeviceSummary) for cb in trainer.callbacks)
+
+    trainer = Trainer(callbacks=DeviceSummary())
+    assert any(isinstance(cb, DeviceSummary) for cb in trainer.callbacks)
+
+
+def test_device_summary_callback_with_enable_device_summary_false():
+    trainer = Trainer(enable_device_summary=False)
+    assert not any(isinstance(cb, DeviceSummary) for cb in trainer.callbacks)
+
+
+def test_device_summary_callback_with_enable_device_summary_true():
+    trainer = Trainer(enable_device_summary=True)
+    assert any(isinstance(cb, DeviceSummary) for cb in trainer.callbacks)
+
+
+def test_device_summary_callback_with_barebones():
+    trainer = Trainer(barebones=True)
+    assert not any(isinstance(cb, DeviceSummary) for cb in trainer.callbacks)
+
+
+def test_device_summary_callback_with_barebones_error():
+    with pytest.raises(ValueError, match="Device summary can impact raw speed"):
+        Trainer(barebones=True, enable_device_summary=True)
+
+
+def test_device_summary_callback_logging(tmp_path):
+    model = BoringModel()
+    trainer = MagicMock()
+    callback = DeviceSummary(show_warnings=True)
+
+    # Mock accelerator
+    trainer.accelerator = MagicMock()
+    trainer.num_devices = 1
+
+    # Call setup
+    callback.setup(trainer, model, "fit")
+    assert callback._logged is True
+
+    # Call again to verify it is only logged once
+    callback.setup(trainer, model, "fit")

--- a/tests/tests_pytorch/callbacks/test_device_summary.py
+++ b/tests/tests_pytorch/callbacks/test_device_summary.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import DeviceSummary


### PR DESCRIPTION
## What does this PR do?

This PR introduces an `enable_device_summary` Trainer keyword argument to allow suppressing or configuring the device availability logging during training initialization, addressing issue #13378. The logging has been moved from the Trainer constructor to a dedicated `DeviceSummary` callback.

Fixes #13378

## PR review

- Added `enable_device_summary: Optional[bool] = None` flag to Trainer.
- Created `DeviceSummary` callback in `src/lightning/pytorch/callbacks/device_summary.py` and exported it in `__init__.py`.
- Updated `callback_connector.py` to append the callback by default if the flag is enabled.
- Handled interactions with `barebones` mode.
- Added 6 comprehensive unit tests in `tests/tests_pytorch/callbacks/test_device_summary.py`.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? Yes, fixes #13378.
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you write any new necessary tests?
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you list all the breaking changes introduced by this pull request? (None)
</details>