### PR TITLE
Fix stateful dataloader state not restored on resume after `estimated_stepping_batches`

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -48,6 +48,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed arbitrary code execution in `load_from_checkpoint` by restricting the `_instantiator` hyperparameter to an allowlist of trusted instantiators ([#21832](https://github.com/Lightning-AI/pytorch-lightning/pull/21832))
 
+- Fixed stateful dataloaders not restoring their state from a checkpoint when `trainer.estimated_stepping_batches` is accessed in `configure_optimizers` ([#20550](https://github.com/Lightning-AI/pytorch-lightning/issues/20550))
+
 ---
 
 ## [2.6.4] - 2026-05-20

--- a/src/lightning/pytorch/loops/fit_loop.py
+++ b/src/lightning/pytorch/loops/fit_loop.py
@@ -224,6 +224,13 @@ class _FitLoop(_Loop):
 
     def setup_data(self) -> None:
         if self._combined_loader is not None and not self._should_reload_train_dl:
+            # the dataloaders may have been set up before the checkpoint was loaded, e.g., if the user accessed
+            # `trainer.estimated_stepping_batches` in `configure_optimizers`. in that case, restore the dataloader
+            # states now and recreate the iterator so the restored states take effect
+            if self.restarting and self._combined_loader_states_to_load:
+                self._load_combined_loader_states()
+                assert self._data_fetcher is not None
+                iter(self._data_fetcher)  # creates the iterator inside the fetcher
             return
 
         trainer = self.trainer

--- a/tests/tests_pytorch/loops/test_loops.py
+++ b/tests/tests_pytorch/loops/test_loops.py
@@ -1248,8 +1248,9 @@ class StatefulIterable(NotStatefulIterable):
         ),
     ],
 )
+@pytest.mark.parametrize("access_estimated_stepping_batches", [False, True])
 def test_fit_loop_save_and_restore_dataloaders(
-    train_dataloader_factory, has_state, batches_before, batches_after, tmp_path
+    train_dataloader_factory, has_state, batches_before, batches_after, access_estimated_stepping_batches, tmp_path
 ):
     """Test that the CheckpointConnector saves the state of stateful dataloaders."""
 
@@ -1257,6 +1258,12 @@ def test_fit_loop_save_and_restore_dataloaders(
         def __init__(self):
             super().__init__()
             self.seen_data = []
+
+        def configure_optimizers(self):
+            if access_estimated_stepping_batches:
+                # sets up the dataloaders before the loop state gets restored from the checkpoint (#20550)
+                _ = int(self.trainer.estimated_stepping_batches)
+            return super().configure_optimizers()
 
         def training_step(self, batch, batch_idx):
             self.seen_data.append(batch)
@@ -1276,8 +1283,9 @@ def test_fit_loop_save_and_restore_dataloaders(
     }
 
     # Train for 2 steps
+    # `max_epochs` is set so that `estimated_stepping_batches` cannot take the infinite-training shortcut
     model = DummyModel()
-    trainer = Trainer(**trainer_kwargs, max_steps=2)
+    trainer = Trainer(**trainer_kwargs, max_steps=2, max_epochs=10)
     trainer.fit(model)
     assert model.seen_data == batches_before
 
@@ -1291,6 +1299,6 @@ def test_fit_loop_save_and_restore_dataloaders(
 
     # Restore training from step 2 and continue 2 more steps
     model = DummyModel()
-    trainer = Trainer(**trainer_kwargs, max_steps=4)
+    trainer = Trainer(**trainer_kwargs, max_steps=4, max_epochs=10)
     trainer.fit(model, ckpt_path=(tmp_path / "checkpoint.ckpt"))
     assert model.seen_data == batches_after


### PR DESCRIPTION
## What does this PR do?

Fixes #20550.

Stateful dataloader states saved in a checkpoint are silently dropped on resume when
`configure_optimizers` accesses `trainer.estimated_stepping_batches`. Building on the analysis in
the issue: the first `setup_data()` runs during `strategy.setup()`, *before*
`restore_training_state()`, so when `_FitLoop.on_load_checkpoint` later stashes the checkpoint's
dataloader states into `_combined_loader_states_to_load`, the second `setup_data()` early-returns
(`_combined_loader` already exists) and `_load_combined_loader_states()` never runs.

This PR loads the pending states in that early-return branch and re-creates the data-fetcher
iterator. The re-iteration matters: the existing iterator was created before the restore, so
loaders that snapshot their position at `iter()` time (torchdata `StatefulDataLoader`-style) — or
a `_PrefetchDataFetcher` that already prefetched a batch — would otherwise keep stale pre-restore
state. A states-only variant passes the issue's repro but fails an eager-iterator one; loading
then re-iterating matches the order of the normal resume path. The new branch is guarded on
`restarting` plus pending states, so it is a no-op everywhere else.

Testing: parametrized `test_fit_loop_save_and_restore_dataloaders` with a flag that accesses
`estimated_stepping_batches` in `configure_optimizers` — the stateful variants fail on master and
pass with this change. `tests_pytorch/loops/`,
`trainer/properties/test_estimated_stepping_batches.py`, and
`utilities/test_combined_loader.py` pass locally (CPU). CHANGELOG updated.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>
