### PR TITLE
fix: Handle None weight/bias in SyncBatchNorm revert when affine=False (closes #21755)

### DIFF
--- a/src/lightning/pytorch/plugins/layer_sync.py
+++ b/src/lightning/pytorch/plugins/layer_sync.py
@@ -80,6 +80,9 @@ class TorchSyncBatchNorm(LayerSync):
                 with torch.no_grad():
                     converted_module.weight = model.weight
                     converted_module.bias = model.bias
+            elif hasattr(model, 'weight'):
+                converted_module.weight = None
+                converted_module.bias = None
             converted_module.running_mean = model.running_mean
             converted_module.running_var = model.running_var
             converted_module.num_batches_tracked = model.num_batches_tracked

--- a/src/lightning/pytorch/plugins/layer_sync.py
+++ b/src/lightning/pytorch/plugins/layer_sync.py
@@ -80,7 +80,7 @@ class TorchSyncBatchNorm(LayerSync):
                 with torch.no_grad():
                     converted_module.weight = model.weight
                     converted_module.bias = model.bias
-            elif hasattr(model, 'weight'):
+            elif hasattr(model, "weight"):
                 converted_module.weight = None
                 converted_module.bias = None
             converted_module.running_mean = model.running_mean


### PR DESCRIPTION
## What
When reverting a SyncBatchNorm layer that was created with `affine=False`, the weight and bias attributes are `None`. The current code unconditionally assigns these None values to the converted module, causing errors when the module later tries to use them.

## Fix
Move the weight and bias assignment inside the `if model.affine:` block, and explicitly set them to None when affine is False to match the original layer's state.

Closes #21755