### PR TITLE
fix(cuda): call set_device before _check_cuda_matmul_precision to prevent spurious GPU 0 init

### DIFF
--- a/src/lightning/fabric/accelerators/cuda.py
+++ b/src/lightning/fabric/accelerators/cuda.py
@@ -34,8 +34,8 @@ class CUDAAccelerator(Accelerator):
         """
         if device.type != "cuda":
             raise ValueError(f"Device should be CUDA, got {device} instead.")
-        _check_cuda_matmul_precision(device)
         torch.cuda.set_device(device)
+        _check_cuda_matmul_precision(device)
 
     @override
     def teardown(self) -> None:

--- a/src/lightning/pytorch/accelerators/cuda.py
+++ b/src/lightning/pytorch/accelerators/cuda.py
@@ -43,8 +43,8 @@ class CUDAAccelerator(Accelerator):
         """
         if device.type != "cuda":
             raise MisconfigurationException(f"Device should be GPU, got {device} instead")
-        _check_cuda_matmul_precision(device)
         torch.cuda.set_device(device)
+        _check_cuda_matmul_precision(device)
 
     @override
     def setup(self, trainer: "pl.Trainer") -> None:

--- a/tests/tests_fabric/accelerators/test_cuda.py
+++ b/tests/tests_fabric/accelerators/test_cuda.py
@@ -74,6 +74,7 @@ def test_set_cuda_device_calls_set_device_before_matmul_check(set_device_mock, m
     which triggers ``torch.cuda._lazy_init`` and initialises the CUDA context on
     device 0, even when the requested device is different.  ``set_device`` must
     be called first so the context is initialised on the correct device.
+
     """
     call_order = []
     set_device_mock.side_effect = lambda _: call_order.append("set_device")

--- a/tests/tests_fabric/accelerators/test_cuda.py
+++ b/tests/tests_fabric/accelerators/test_cuda.py
@@ -65,6 +65,28 @@ def test_set_cuda_device(_, set_device_mock):
     set_device_mock.assert_called_once_with(device)
 
 
+@mock.patch("lightning.fabric.accelerators.cuda._check_cuda_matmul_precision")
+@mock.patch("torch.cuda.set_device")
+def test_set_cuda_device_calls_set_device_before_matmul_check(set_device_mock, matmul_check_mock):
+    """Regression test for #21725.
+
+    ``_check_cuda_matmul_precision`` calls ``torch.cuda.get_device_capability``
+    which triggers ``torch.cuda._lazy_init`` and initialises the CUDA context on
+    device 0, even when the requested device is different.  ``set_device`` must
+    be called first so the context is initialised on the correct device.
+    """
+    call_order = []
+    set_device_mock.side_effect = lambda _: call_order.append("set_device")
+    matmul_check_mock.side_effect = lambda _: call_order.append("matmul_check")
+
+    device = torch.device("cuda", 3)
+    CUDAAccelerator().setup_device(device)
+
+    assert call_order == ["set_device", "matmul_check"], (
+        f"set_device must be called before _check_cuda_matmul_precision, got order: {call_order}"
+    )
+
+
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_force_nvml_based_cuda_check():
     """Test that we force PyTorch to use the NVML-based CUDA checks."""


### PR DESCRIPTION
Fixes #21725.

**Problem**

`setup_device` called `_check_cuda_matmul_precision(device)` before `torch.cuda.set_device(device)`. `_check_cuda_matmul_precision` calls `torch.cuda.get_device_capability`, which triggers `torch.cuda._lazy_init` and initialises the CUDA context on the current device — which defaults to GPU 0 if `set_device` hasn't been called yet. So when you request device 3, GPU 0 gets a CUDA context first.

**Fix**

Swap the two lines so `set_device` is called first. Applied to both `lightning.fabric.accelerators.cuda` and `lightning.pytorch.accelerators.cuda`.

**Test**

Added `test_set_cuda_device_calls_set_device_before_matmul_check` — records call order via side effects and asserts `set_device` comes before `_check_cuda_matmul_precision`.