### PR TITLE
fix: preserve stateful dataloader state around estimated_stepping_batches

### DIFF
--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -1686,6 +1686,11 @@ class Trainer:
         if self.max_epochs == -1:
             return float("inf") if self.max_steps == -1 else self.max_steps
 
+        # Save the combined loader states from the checkpoint so they can be restored
+        # after the estimation, allowing stateful dataloaders to properly load their
+        # state during the actual fit loop
+        saved_combined_loader_states = self.fit_loop._combined_loader_states_to_load.copy()
+
         if self.train_dataloader is None:
             rank_zero_info("Loading `train_dataloader` to estimate number of stepping batches.")
             self.fit_loop.setup_data()
@@ -1694,10 +1699,21 @@ class Trainer:
 
         # iterable dataset
         if total_batches == float("inf"):
-            return self.max_steps
+            max_estimated_steps = self.max_steps
+        else:
+            assert self.max_epochs is not None
+            max_estimated_steps = math.ceil(total_batches / self.accumulate_grad_batches) * max(self.max_epochs, 1)
+            max_estimated_steps = min(max_estimated_steps, self.max_steps) if self.max_steps != -1 else max_estimated_steps
 
-        assert self.max_epochs is not None
-        max_estimated_steps = math.ceil(total_batches / self.accumulate_grad_batches) * max(self.max_epochs, 1)
+        # Reset the data structures so that stateful dataloader states from checkpoints
+        # are properly restored during the actual fit loop. The estimation iteration
+        # may have advanced stateful dataloaders, so we need to tear down and allow
+        # setup_data() to be called fresh when fit() runs.
+        if self.fit_loop._data_fetcher is not None:
+            self.fit_loop._data_fetcher.teardown()
+        self.fit_loop._combined_loader = None
+        # Restore the combined loader states that may have been consumed during setup_data()
+        # so they can be loaded again when fit() properly initializes the data loader
+        self.fit_loop._combined_loader_states_to_load = saved_combined_loader_states
 
-        max_estimated_steps = min(max_estimated_steps, self.max_steps) if self.max_steps != -1 else max_estimated_steps
         return max_estimated_steps


### PR DESCRIPTION
Resolves #20550

When trainer.estimated_stepping_batches is called, it iterates the dataloader to count batches, which advances stateful dataloaders. This caused the dataloader state from checkpoints to not be properly restored. The fix saves the dataloader state before estimation iteration and restores it afterward.

Signed-off-by: KartavyaDikshit <kartavyaniraj.dikshit2021@vitstudent.ac.in>