### PR TITLE
fix(loops): increment batch_progress.completed before on_train_batch_end hooks

### DIFF
--- a/src/lightning/pytorch/loops/training_epoch_loop.py
+++ b/src/lightning/pytorch/loops/training_epoch_loop.py
@@ -372,11 +372,14 @@ class _TrainingEpochLoop(loops._Loop):
             # update `is_last_batch` again after dataloader_iter was fetched in `training_step()`
             self.batch_progress.is_last_batch = data_fetcher.done
 
+        # Increment batch progress before firing on_train_batch_end hooks so that
+        # callbacks (e.g. ModelCheckpoint) that save a checkpoint inside the hook
+        # snapshot the correct completed count. See GH #18060.
+        self.batch_progress.increment_completed()
+
         call._call_callback_hooks(trainer, "on_train_batch_end", batch_output, batch, batch_idx)
         call._call_lightning_module_hook(trainer, "on_train_batch_end", batch_output, batch, batch_idx)
         trainer._logger_connector.on_batch_end()
-
-        self.batch_progress.increment_completed()
 
         # -----------------------------------------
         # SAVE METRICS TO LOGGERS AND PROGRESS_BAR


### PR DESCRIPTION
## What does this PR do?

Fixes #18060.

Moves `self.batch_progress.increment_completed()` to execute **before** the `on_train_batch_end` callback and module hooks, rather than after.

### Root cause

`ModelCheckpoint` (and any other callback) that saves a checkpoint inside `on_train_batch_end` snapshots the loop state at that point. Because `batch_progress.completed` was incremented **after** the hooks, saved checkpoints ended up with `completed == processed - 1` instead of `completed == processed`. On resume this caused `batch_idx` to be one step behind `global_step` and downstream checkpoint filenames to carry incorrect step numbers.

### Fix

Move `self.batch_progress.increment_completed()` to before the hook calls in `advance()`. A comment explains the invariant.

### Backward compatibility

The existing `RESTARTED_ON_TRAIN_BATCH_END` detection in `update_restart_stage()` + the `increment_completed()` call in `reset()` (line 204) already compensates for the off-by-one when loading **old** checkpoints written before this fix. That code path is preserved unchanged, so existing checkpoints continue to load correctly.

### Checklist

- [x] PR is a bug fix
- [ ] Tests added (reproducer in #18060 can be converted to a test — happy to add if maintainers prefer it in this PR)