### PR TITLE
fix(FSDP): pass explicit CPU    device to satisfy torch>=2.5 device_id contract

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed `FSDPStrategy` failing on CPU (with PyTorch 2.5+) by passing the CPU device object to FSDP instead of `None` ([#21774](https://github.com/Lightning-AI/pytorch-lightning/pull/21774))
+- Fixed `FSDPStrategy` raising `RuntimeError` under PyTorch 2.5+ when `root_device` is CPU, by passing an explicit `torch.device("cpu")` instead of `device_id=None` (relevant only when the GPU-accelerator guard is bypassed) ([#21774](https://github.com/Lightning-AI/pytorch-lightning/pull/21774))
 
 - Fixed inconsistent FLOPs reporting on NVIDIA H100/H200 GPUs by defaulting to dense FLOPs, with sparse FLOPs now requiring an explicit opt-in. ([#21743](https://github.com/Lightning-AI/pytorch-lightning/pull/21743))
 

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `FSDPStrategy` failing on CPU (with PyTorch 2.5+) by passing the CPU device object to FSDP instead of `None` ([#21774](https://github.com/Lightning-AI/pytorch-lightning/pull/21774))
+
 - Fixed inconsistent FLOPs reporting on NVIDIA H100/H200 GPUs by defaulting to dense FLOPs, with sparse FLOPs now requiring an explicit opt-in. ([#21743](https://github.com/Lightning-AI/pytorch-lightning/pull/21743))
 
 - Fixed AccumulateGrad stream mismatch warning when using DDP with Fabric ([#21746](https://github.com/Lightning-AI/pytorch-lightning/pull/21746))

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -301,7 +301,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
                 cpu_offload=self.cpu_offload,
                 mixed_precision=self.mixed_precision_config,
                 sharding_strategy=self.sharding_strategy,
-                device_id=self.root_device.index,
+                device_id=self.root_device if self.root_device.type == "cpu" else self.root_device.index,
                 **self._fsdp_kwargs,
             )
 
@@ -359,7 +359,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
             cpu_offload=self.cpu_offload,
             mixed_precision=self.mixed_precision_config,
             sharding_strategy=self.sharding_strategy,
-            device_id=self.root_device.index,
+            device_id=self.root_device if self.root_device.type == "cpu" else self.root_device.index,
             **self._fsdp_kwargs,
         )
 

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -296,12 +296,15 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
                 del self._fsdp_kwargs["auto_wrap_policy"]
         else:
             _warn_if_shared_params_across_fsdp_units(module, self._fsdp_kwargs.get("auto_wrap_policy"))
+            # CPU is not a supported FSDP target; this branch only honors the torch>=2.5 contract,
+            # which rejects device_id=None (root_device.index is None on CPU). The GPU path is unchanged.
+            device_id = self.root_device if self.root_device.type == "cpu" else self.root_device.index
             module = FullyShardedDataParallel(
                 module=module,
                 cpu_offload=self.cpu_offload,
                 mixed_precision=self.mixed_precision_config,
                 sharding_strategy=self.sharding_strategy,
-                device_id=self.root_device if self.root_device.type == "cpu" else self.root_device.index,
+                device_id=device_id,
                 **self._fsdp_kwargs,
             )
 
@@ -354,12 +357,15 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
         from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel
         from torch.distributed.fsdp.wrap import enable_wrap
 
+        # CPU is not a supported FSDP target; this branch only honors the torch>=2.5 contract,
+        # which rejects device_id=None (root_device.index is None on CPU). The GPU path is unchanged.
+        device_id = self.root_device if self.root_device.type == "cpu" else self.root_device.index
         return enable_wrap(
             wrapper_cls=FullyShardedDataParallel,
             cpu_offload=self.cpu_offload,
             mixed_precision=self.mixed_precision_config,
             sharding_strategy=self.sharding_strategy,
-            device_id=self.root_device if self.root_device.type == "cpu" else self.root_device.index,
+            device_id=device_id,
             **self._fsdp_kwargs,
         )
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `FSDPStrategy` failing on CPU (with PyTorch 2.5+) by passing the CPU device object to FSDP instead of `None` ([#21774](https://github.com/Lightning-AI/pytorch-lightning/pull/21774))
+
 - Fixed non-zero process exits in `CombinedLoader.reset()` with large tensors and persistent spawned workers by avoiding explicit `_shutdown_workers()` calls and relying on iterator cleanup via `del` [#21708](https://github.com/Lightning-AI/pytorch-lightning/issues/21708)
 
 - Fixed `SIGTERMException` producing a zero exit code instead of 143 (128 + SIGTERM) ([#21623](https://github.com/Lightning-AI/pytorch-lightning/issues/21623))

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed `FSDPStrategy` failing on CPU (with PyTorch 2.5+) by passing the CPU device object to FSDP instead of `None` ([#21774](https://github.com/Lightning-AI/pytorch-lightning/pull/21774))
+- Fixed `FSDPStrategy` raising `RuntimeError` under PyTorch 2.5+ when `root_device` is CPU, by passing an explicit `torch.device("cpu")` instead of `device_id=None` (relevant only when the GPU-accelerator guard is bypassed) ([#21774](https://github.com/Lightning-AI/pytorch-lightning/pull/21774))
 
 - Fixed non-zero process exits in `CombinedLoader.reset()` with large tensors and persistent spawned workers by avoiding explicit `_shutdown_workers()` calls and relying on iterator cleanup via `del` [#21708](https://github.com/Lightning-AI/pytorch-lightning/issues/21708)
 

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -308,13 +308,16 @@ class FSDPStrategy(ParallelStrategy):
                 del self.kwargs["auto_wrap_policy"]
         else:
             _warn_if_shared_params_across_fsdp_units(model, self.kwargs.get("auto_wrap_policy"))
-            log.debug(f"setting up FSDP model with device id: {self.root_device.index}, kwargs: {self.kwargs}")
+            # CPU is not a supported FSDP target; this branch only honors the torch>=2.5 contract,
+            # which rejects device_id=None (root_device.index is None on CPU). The GPU path is unchanged.
+            device_id = self.root_device if self.root_device.type == "cpu" else self.root_device.index
+            log.debug(f"setting up FSDP model with device id: {device_id}, kwargs: {self.kwargs}")
             model = FullyShardedDataParallel(
                 module=model,
                 cpu_offload=self.cpu_offload,
                 mixed_precision=self.mixed_precision_config,
                 sharding_strategy=self.sharding_strategy,
-                device_id=self.root_device if self.root_device.type == "cpu" else self.root_device.index,
+                device_id=device_id,
                 **self.kwargs,
             )
 
@@ -403,12 +406,15 @@ class FSDPStrategy(ParallelStrategy):
         from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel
         from torch.distributed.fsdp.wrap import enable_wrap
 
+        # CPU is not a supported FSDP target; this branch only honors the torch>=2.5 contract,
+        # which rejects device_id=None (root_device.index is None on CPU). The GPU path is unchanged.
+        device_id = self.root_device if self.root_device.type == "cpu" else self.root_device.index
         with enable_wrap(
             wrapper_cls=FullyShardedDataParallel,
             cpu_offload=self.cpu_offload,
             mixed_precision=self.mixed_precision_config,
             sharding_strategy=self.sharding_strategy,
-            device_id=self.root_device if self.root_device.type == "cpu" else self.root_device.index,
+            device_id=device_id,
             **self.kwargs,
         ):
             yield

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -314,7 +314,7 @@ class FSDPStrategy(ParallelStrategy):
                 cpu_offload=self.cpu_offload,
                 mixed_precision=self.mixed_precision_config,
                 sharding_strategy=self.sharding_strategy,
-                device_id=self.root_device.index,
+                device_id=self.root_device if self.root_device.type == "cpu" else self.root_device.index,
                 **self.kwargs,
             )
 
@@ -408,7 +408,7 @@ class FSDPStrategy(ParallelStrategy):
             cpu_offload=self.cpu_offload,
             mixed_precision=self.mixed_precision_config,
             sharding_strategy=self.sharding_strategy,
-            device_id=self.root_device.index,
+            device_id=self.root_device if self.root_device.type == "cpu" else self.root_device.index,
             **self.kwargs,
         ):
             yield

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -188,20 +188,11 @@ def test_activation_checkpointing():
     apply_mock.assert_called_with(wrapped, checkpoint_wrapper_fn=ANY, **strategy._activation_checkpointing_kwargs)
 
 
-@pytest.mark.parametrize(
-    ("device", "expected_device_id"),
-    [
-        (torch.device("cpu"), torch.device("cpu")),
-        (torch.device("cuda", 0), 0),
-    ],
-)
-def test_setup_module_device_id(device, expected_device_id):
-    """``setup_module`` must hand FSDP an explicit ``torch.device('cpu')`` on a CPU accelerator.
+def test_setup_module_device_id_cpu():
+    """``setup_module`` passes an explicit ``torch.device('cpu')`` (not ``device_id=None``) on CPU.
 
-    ``root_device.index`` is ``None`` for a CPU device; passing ``device_id=None`` trips
-    torch>=2.5's "FSDP needs a non-CPU accelerator device" guard, so FSDP cannot run on CPU.
-    The GPU path keeps passing the integer device index unchanged.
-
+    ``root_device.index`` is ``None`` on CPU; ``device_id=None`` trips torch>=2.5's "FSDP needs a
+    non-CPU accelerator device" guard. Only reachable when the GPU-accelerator guard is bypassed.
     """
     captured = {}
 
@@ -212,10 +203,10 @@ def test_setup_module_device_id(device, expected_device_id):
             self.module = module
 
     strategy = FSDPStrategy()
-    strategy._parallel_devices = [device]
+    strategy._parallel_devices = [torch.device("cpu")]
     with mock.patch("torch.distributed.fsdp.FullyShardedDataParallel", FakeFSDP):
         strategy.setup_module(nn.Linear(2, 2))
-    assert captured["device_id"] == expected_device_id
+    assert captured["device_id"] == torch.device("cpu")
 
 
 def test_forbidden_precision_raises():

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -210,6 +210,24 @@ def test_setup_module_device_id_cpu():
     assert captured["device_id"] == torch.device("cpu")
 
 
+def test_module_sharded_context_device_id_cpu():
+    """``module_sharded_context`` passes an explicit ``torch.device('cpu')`` (not ``device_id=None``) on CPU."""
+    from contextlib import contextmanager
+
+    captured = {}
+
+    @contextmanager
+    def fake_enable_wrap(*args, **kwargs):
+        captured.update(kwargs)
+        yield
+
+    strategy = FSDPStrategy()
+    strategy._parallel_devices = [torch.device("cpu")]
+    with mock.patch("torch.distributed.fsdp.wrap.enable_wrap", fake_enable_wrap), strategy.module_sharded_context():
+        pass
+    assert captured["device_id"] == torch.device("cpu")
+
+
 def test_forbidden_precision_raises():
     with pytest.raises(TypeError, match="can only work with the `FSDPPrecision"):
         FSDPStrategy(precision=HalfPrecision())

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -201,6 +201,7 @@ def test_setup_module_device_id(device, expected_device_id):
     ``root_device.index`` is ``None`` for a CPU device; passing ``device_id=None`` trips
     torch>=2.5's "FSDP needs a non-CPU accelerator device" guard, so FSDP cannot run on CPU.
     The GPU path keeps passing the integer device index unchanged.
+
     """
     captured = {}
 

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -193,6 +193,7 @@ def test_setup_module_device_id_cpu():
 
     ``root_device.index`` is ``None`` on CPU; ``device_id=None`` trips torch>=2.5's "FSDP needs a
     non-CPU accelerator device" guard. Only reachable when the GPU-accelerator guard is bypassed.
+
     """
     captured = {}
 

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -188,6 +188,35 @@ def test_activation_checkpointing():
     apply_mock.assert_called_with(wrapped, checkpoint_wrapper_fn=ANY, **strategy._activation_checkpointing_kwargs)
 
 
+@pytest.mark.parametrize(
+    ("device", "expected_device_id"),
+    [
+        (torch.device("cpu"), torch.device("cpu")),
+        (torch.device("cuda", 0), 0),
+    ],
+)
+def test_setup_module_device_id(device, expected_device_id):
+    """``setup_module`` must hand FSDP an explicit ``torch.device('cpu')`` on a CPU accelerator.
+
+    ``root_device.index`` is ``None`` for a CPU device; passing ``device_id=None`` trips
+    torch>=2.5's "FSDP needs a non-CPU accelerator device" guard, so FSDP cannot run on CPU.
+    The GPU path keeps passing the integer device index unchanged.
+    """
+    captured = {}
+
+    class FakeFSDP(nn.Module):
+        def __init__(self, module, **kwargs):
+            super().__init__()
+            captured.update(kwargs)
+            self.module = module
+
+    strategy = FSDPStrategy()
+    strategy._parallel_devices = [device]
+    with mock.patch("torch.distributed.fsdp.FullyShardedDataParallel", FakeFSDP):
+        strategy.setup_module(nn.Linear(2, 2))
+    assert captured["device_id"] == expected_device_id
+
+
 def test_forbidden_precision_raises():
     with pytest.raises(TypeError, match="can only work with the `FSDPPrecision"):
         FSDPStrategy(precision=HalfPrecision())

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -459,6 +459,7 @@ def test_setup_model_device_id(device, expected_device_id):
     ``root_device.index`` is ``None`` for a CPU device; passing ``device_id=None`` trips
     torch>=2.5's "FSDP needs a non-CPU accelerator device" guard, so FSDP cannot run on CPU.
     The GPU path keeps passing the integer device index unchanged.
+
     """
     captured = {}
 

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -484,9 +484,8 @@ def test_model_sharded_context_device_id_cpu():
 
     strategy = FSDPStrategy()
     strategy._parallel_devices = [torch.device("cpu")]
-    with mock.patch("torch.distributed.fsdp.wrap.enable_wrap", fake_enable_wrap):
-        with strategy.model_sharded_context():
-            pass
+    with mock.patch("torch.distributed.fsdp.wrap.enable_wrap", fake_enable_wrap), strategy.model_sharded_context():
+        pass
     assert captured["device_id"] == torch.device("cpu")
 
 

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -471,6 +471,25 @@ def test_setup_model_device_id_cpu():
     assert captured["device_id"] == torch.device("cpu")
 
 
+def test_model_sharded_context_device_id_cpu():
+    """``model_sharded_context`` passes an explicit ``torch.device('cpu')`` (not ``device_id=None``) on CPU."""
+    from contextlib import contextmanager
+
+    captured = {}
+
+    @contextmanager
+    def fake_enable_wrap(*args, **kwargs):
+        captured.update(kwargs)
+        yield
+
+    strategy = FSDPStrategy()
+    strategy._parallel_devices = [torch.device("cpu")]
+    with mock.patch("torch.distributed.fsdp.wrap.enable_wrap", fake_enable_wrap):
+        with strategy.model_sharded_context():
+            pass
+    assert captured["device_id"] == torch.device("cpu")
+
+
 def test_strategy_cpu_offload():
     """Test the different ways cpu offloading can be enabled."""
     # bool

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -446,6 +446,38 @@ def test_activation_checkpointing():
     apply_mock.assert_called_with(wrapped, checkpoint_wrapper_fn=ANY, **strategy._activation_checkpointing_kwargs)
 
 
+@pytest.mark.parametrize(
+    ("device", "expected_device_id"),
+    [
+        (torch.device("cpu"), torch.device("cpu")),
+        (torch.device("cuda", 0), 0),
+    ],
+)
+def test_setup_model_device_id(device, expected_device_id):
+    """``_setup_model`` must hand FSDP an explicit ``torch.device('cpu')`` on a CPU accelerator.
+
+    ``root_device.index`` is ``None`` for a CPU device; passing ``device_id=None`` trips
+    torch>=2.5's "FSDP needs a non-CPU accelerator device" guard, so FSDP cannot run on CPU.
+    The GPU path keeps passing the integer device index unchanged.
+    """
+    captured = {}
+
+    class FakeFSDP(nn.Module):
+        def __init__(self, module, **kwargs):
+            super().__init__()
+            captured.update(kwargs)
+            self.module = module
+
+    strategy = FSDPStrategy()
+    model = nn.Linear(2, 2)
+    strategy._parallel_devices = [device]
+    strategy._lightning_module = model
+    strategy._process_group = Mock()
+    with mock.patch("torch.distributed.fsdp.FullyShardedDataParallel", FakeFSDP):
+        strategy._setup_model(model)
+    assert captured["device_id"] == expected_device_id
+
+
 def test_strategy_cpu_offload():
     """Test the different ways cpu offloading can be enabled."""
     # bool

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -451,6 +451,7 @@ def test_setup_model_device_id_cpu():
 
     ``root_device.index`` is ``None`` on CPU; ``device_id=None`` trips torch>=2.5's "FSDP needs a
     non-CPU accelerator device" guard. Only reachable when the GPU-accelerator guard is bypassed.
+
     """
     captured = {}
 

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -446,20 +446,11 @@ def test_activation_checkpointing():
     apply_mock.assert_called_with(wrapped, checkpoint_wrapper_fn=ANY, **strategy._activation_checkpointing_kwargs)
 
 
-@pytest.mark.parametrize(
-    ("device", "expected_device_id"),
-    [
-        (torch.device("cpu"), torch.device("cpu")),
-        (torch.device("cuda", 0), 0),
-    ],
-)
-def test_setup_model_device_id(device, expected_device_id):
-    """``_setup_model`` must hand FSDP an explicit ``torch.device('cpu')`` on a CPU accelerator.
+def test_setup_model_device_id_cpu():
+    """``_setup_model`` passes an explicit ``torch.device('cpu')`` (not ``device_id=None``) on CPU.
 
-    ``root_device.index`` is ``None`` for a CPU device; passing ``device_id=None`` trips
-    torch>=2.5's "FSDP needs a non-CPU accelerator device" guard, so FSDP cannot run on CPU.
-    The GPU path keeps passing the integer device index unchanged.
-
+    ``root_device.index`` is ``None`` on CPU; ``device_id=None`` trips torch>=2.5's "FSDP needs a
+    non-CPU accelerator device" guard. Only reachable when the GPU-accelerator guard is bypassed.
     """
     captured = {}
 
@@ -471,12 +462,12 @@ def test_setup_model_device_id(device, expected_device_id):
 
     strategy = FSDPStrategy()
     model = nn.Linear(2, 2)
-    strategy._parallel_devices = [device]
+    strategy._parallel_devices = [torch.device("cpu")]
     strategy._lightning_module = model
     strategy._process_group = Mock()
     with mock.patch("torch.distributed.fsdp.FullyShardedDataParallel", FakeFSDP):
         strategy._setup_model(model)
-    assert captured["device_id"] == expected_device_id
+    assert captured["device_id"] == torch.device("cpu")
 
 
 def test_strategy_cpu_offload():


### PR DESCRIPTION


## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fix [21778](https://github.com/Lightning-AI/pytorch-lightning/issues/21778)

`FSDPStrategy` passed `device_id=self.root_device.index` to `FullyShardedDataParallel`. On CPU, `root_device.index` is `None`, and torch>=2.5 rejects `device_id=None` with `RuntimeError: FSDP needs a non-CPU accelerator device`.

This passes the explicit `torch.device("cpu")` object on CPU and keeps the integer index on GPU, so the GPU path is unchanged (the branch only fires on `cpu`).

**Scope:** this is a robustness fix, not a statement that CPU is a supported FSDP target. The Trainer/Fabric guard still rejects FSDP on CPU; the branch only matters when that guard is bypassed (custom strategy subclasses or unit tests), so they don't have to monkeypatch torch internals. A call-site comment documents this.


<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Not necessary - Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- No breaking changes - Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
