### PR TITLE
Profile dataloader initialization in FitLoop and update outdated docs

### DIFF
--- a/docs/source-pytorch/tuning/profiler_basic.rst
+++ b/docs/source-pytorch/tuning/profiler_basic.rst
@@ -80,7 +80,7 @@ Once the **.fit()** function has completed, you'll see an output like this:
 
     Profiler Report
 
-    Profile stats for: get_train_batch
+    Profile stats for: run_training_epoch
             4869394 function calls (4863767 primitive calls) in 18.893 seconds
     Ordered by: cumulative time
     List reduced from 76 to 10 due to restriction <10>

--- a/docs/source-pytorch/tuning/profiler_basic.rst
+++ b/docs/source-pytorch/tuning/profiler_basic.rst
@@ -35,6 +35,7 @@ Once the **.fit()** function has completed, you'll see an output like this:
     |  Action                                          |  Mean duration (s) |  Total time (s) |
     -------------------------------------------------------------------------------------------
     |  [LightningModule]BoringModel.prepare_data       |  10.0001           |  20.00          |
+    |  setup_train_dataloader                          |  2.893             |  2.893          |
     |  run_training_epoch                              |  6.1558            |  6.1558         |
     |  run_training_batch                              |  0.0022506         |  0.015754       |
     |  [LightningModule]BoringModel.optimizer_step     |  0.0017477         |  0.012234       |
@@ -80,21 +81,21 @@ Once the **.fit()** function has completed, you'll see an output like this:
 
     Profiler Report
 
-    Profile stats for: run_training_epoch
-            4869394 function calls (4863767 primitive calls) in 18.893 seconds
+    Profile stats for: run_training_batch
+            9400 function calls (9200 primitive calls) in 0.019 seconds
     Ordered by: cumulative time
     List reduced from 76 to 10 due to restriction <10>
     ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-    3752/1876    0.011    0.000   18.887    0.010 {built-in method builtins.next}
-        1876     0.008    0.000   18.877    0.010 dataloader.py:344(__next__)
-        1876     0.074    0.000   18.869    0.010 dataloader.py:383(_next_data)
-        1875     0.012    0.000   18.721    0.010 fetch.py:42(fetch)
-        1875     0.084    0.000   18.290    0.010 fetch.py:44(<listcomp>)
-        60000    1.759    0.000   18.206    0.000 mnist.py:80(__getitem__)
-        60000    0.267    0.000   13.022    0.000 transforms.py:68(__call__)
-        60000    0.182    0.000    7.020    0.000 transforms.py:93(__call__)
-        60000    1.651    0.000    6.839    0.000 functional.py:42(to_tensor)
-        60000    0.260    0.000    5.734    0.000 transforms.py:167(__call__)
+       100    0.001    0.000    0.018    0.000 automatic.py:163(run)
+       100    0.001    0.000    0.014    0.000 automatic.py:245(_optimizer_step)
+       100    0.002    0.000    0.012    0.000 call.py:155(_call_lightning_module_hook)
+       100    0.000    0.000    0.007    0.000 contextlib.py:136(__enter__)
+       100    0.000    0.000    0.007    0.000 {built-in method builtins.next}
+       100    0.000    0.000    0.007    0.000 profiler.py:57(profile)
+       100    0.001    0.000    0.007    0.000 advanced.py:74(start)
+      3100    0.006    0.000    0.006    0.000 {method 'disable' of '_lsprof.Profiler' objects}
+       100    0.001    0.000    0.003    0.000 automatic.py:199(_make_closure)
+       100    0.001    0.000    0.002    0.000 module.py:1971(__setattr__)
 
 If the profiler report becomes too long, you can stream the report to a file:
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed PyTorch Lightning profiler not capturing dataloader worker initialization time ([#21771](https://github.com/Lightning-AI/pytorch-lightning/issues/21771))
+
 - Fixed non-zero process exits in `CombinedLoader.reset()` with large tensors and persistent spawned workers by avoiding explicit `_shutdown_workers()` calls and relying on iterator cleanup via `del` [#21708](https://github.com/Lightning-AI/pytorch-lightning/issues/21708)
 
 - Fixed `SIGTERMException` producing a zero exit code instead of 143 (128 + SIGTERM) ([#21623](https://github.com/Lightning-AI/pytorch-lightning/issues/21623))

--- a/src/lightning/pytorch/loops/fit_loop.py
+++ b/src/lightning/pytorch/loops/fit_loop.py
@@ -272,7 +272,8 @@ class _FitLoop(_Loop):
 
         self._data_fetcher = _select_data_fetcher(trainer, RunningStage.TRAINING)
         self._data_fetcher.setup(combined_loader)
-        iter(self._data_fetcher)  # creates the iterator inside the fetcher
+        with trainer.profiler.profile("setup_train_dataloader"):
+            iter(self._data_fetcher)  # creates the iterator inside the fetcher
         max_batches = sized_len(combined_loader)
         self.max_batches = max_batches if max_batches is not None else float("inf")
         has_len_all_ranks_ = has_len_all_ranks(combined_loader, trainer.strategy, allow_zero_length)

--- a/tests/tests_pytorch/profilers/test_profiler.py
+++ b/tests/tests_pytorch/profilers/test_profiler.py
@@ -735,11 +735,9 @@ def test_profiler_invalid_table_kwargs(tmp_path):
 
 def test_setup_train_dataloader_profiled_actions(tmp_path):
     """Ensure that the 'setup_train_dataloader' action is successfully recorded in the profiler."""
-    profiler = AdvancedProfiler(dirpath=tmp_path, filename="profiler")
+    profiler = SimpleProfiler(dirpath=tmp_path, filename="profiler")
     model = BoringModel()
     trainer = Trainer(default_root_dir=tmp_path, fast_dev_run=2, profiler=profiler)
     trainer.fit(model)
 
-    # Read the profiler output file directly, as `profiler.teardown()` clears `profiler.profiled_actions`.
-    path = profiler.dirpath / f"fit-{profiler.filename}.txt"
-    assert "setup_train_dataloader" in path.read_text()
+    assert "setup_train_dataloader" in profiler.recorded_durations

--- a/tests/tests_pytorch/profilers/test_profiler.py
+++ b/tests/tests_pytorch/profilers/test_profiler.py
@@ -740,4 +740,6 @@ def test_setup_train_dataloader_profiled_actions(tmp_path):
     trainer = Trainer(default_root_dir=tmp_path, fast_dev_run=2, profiler=profiler)
     trainer.fit(model)
 
-    assert "setup_train_dataloader" in profiler.profiled_actions
+    # Read the profiler output file directly, as `profiler.teardown()` clears `profiler.profiled_actions`.
+    path = profiler.dirpath / f"fit-{profiler.filename}.txt"
+    assert "setup_train_dataloader" in path.read_text()

--- a/tests/tests_pytorch/profilers/test_profiler.py
+++ b/tests/tests_pytorch/profilers/test_profiler.py
@@ -731,3 +731,13 @@ def test_profiler_invalid_table_kwargs(tmp_path):
         with pytest.raises(KeyError) as exc_info:
             PyTorchProfiler(table_kwargs={key: None}, dirpath=tmp_path, filename="profile")
         assert exc_info.value.args[0].startswith(f"Found invalid table_kwargs key: {key}.")
+
+
+def test_setup_train_dataloader_profiled_actions(tmp_path):
+    """Ensure that the 'setup_train_dataloader' action is successfully recorded in the profiler."""
+    profiler = AdvancedProfiler(dirpath=tmp_path, filename="profiler")
+    model = BoringModel()
+    trainer = Trainer(default_root_dir=tmp_path, fast_dev_run=2, profiler=profiler)
+    trainer.fit(model)
+
+    assert "setup_train_dataloader" in profiler.profiled_actions


### PR DESCRIPTION
## What does this PR do?

Fixes #21771
This PR addresses the issue where the PyTorch Lightning profiler fails to capture the latency spike during dataloader worker initialization and early prefetching. 

Specifically, this PR:
1. **Adds a profiling hook:** Wraps `iter(self._data_fetcher)` in `_FitLoop.setup_data()` with the action name `"setup_train_dataloader"`. This ensures that worker spawn and initialization times appear in the standard Fit Profiler Report.
2. **Updates documentation:** Removes the outdated reference to `get_train_batch` (which was deprecated during the 2021 loops refactor) in the `AdvancedProfiler` documentation and replaces it with `setup_train_dataloader`.
3. **Adds unit tests:** Includes a new test `test_setup_train_dataloader_profiled_actions` using `BoringModel` to assert that the `"setup_train_dataloader"` action is correctly recorded in `profiler.profiled_actions`.

- [ ] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
