### PR TITLE
fix: AdvancedProfiler no longer crashes when stop() is called after teardown

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `AdvancedProfiler` crashing when an active profiling context exits after teardown ([#21790](https://github.com/Lightning-AI/pytorch-lightning/pull/21790))
+
 - Fixed `LightningCLI` emitting `jsonargparse` deprecation warnings ([#21900](https://github.com/Lightning-AI/pytorch-lightning/issues/21900))
 
 - Fixed `RichProgressBar` showing a nonsensical negative epoch total (e.g. `Epoch 5/-2`) when `Trainer(max_epochs=-1)` (unlimited epochs) is used and training stops via another condition ([#21925](https://github.com/Lightning-AI/pytorch-lightning/issues/21925))

--- a/src/lightning/pytorch/profilers/advanced.py
+++ b/src/lightning/pytorch/profilers/advanced.py
@@ -82,7 +82,7 @@ class AdvancedProfiler(Profiler):
     def stop(self, action_name: str) -> None:
         pr = self.profiled_actions.get(action_name)
         if pr is None:
-            raise ValueError(f"Attempting to stop recording an action ({action_name}) which was never started.")
+            return
         pr.disable()
 
     def _dump_stats(self, action_name: str, profile: cProfile.Profile) -> None:
@@ -116,6 +116,8 @@ class AdvancedProfiler(Profiler):
     @override
     def teardown(self, stage: Optional[str]) -> None:
         super().teardown(stage=stage)
+        for pr in self.profiled_actions.values():
+            pr.disable()
         self.profiled_actions.clear()
 
     def __reduce__(self) -> tuple:

--- a/src/lightning/pytorch/profilers/advanced.py
+++ b/src/lightning/pytorch/profilers/advanced.py
@@ -61,10 +61,6 @@ class AdvancedProfiler(Profiler):
                 or a decimal fraction between 0.0 and 1.0 inclusive (to select a percentage of lines)
 
             dump_stats: Whether to save raw profiler results. When ``True`` then ``dirpath`` must be provided.
-
-        Raises:
-            ValueError:
-                If you attempt to stop recording an action which was never started.
         """
         super().__init__(dirpath=dirpath, filename=filename)
         self.profiled_actions: dict[str, cProfile.Profile] = defaultdict(cProfile.Profile)
@@ -82,7 +78,7 @@ class AdvancedProfiler(Profiler):
     def stop(self, action_name: str) -> None:
         pr = self.profiled_actions.get(action_name)
         if pr is None:
-            raise ValueError(f"Attempting to stop recording an action ({action_name}) which was never started.")
+            return
         pr.disable()
 
     def _dump_stats(self, action_name: str, profile: cProfile.Profile) -> None:
@@ -116,6 +112,8 @@ class AdvancedProfiler(Profiler):
     @override
     def teardown(self, stage: Optional[str]) -> None:
         super().teardown(stage=stage)
+        for pr in self.profiled_actions.values():
+            pr.disable()
         self.profiled_actions.clear()
 
     def __reduce__(self) -> tuple:

--- a/tests/tests_pytorch/profilers/test_profiler.py
+++ b/tests/tests_pytorch/profilers/test_profiler.py
@@ -384,6 +384,7 @@ def test_advanced_profiler_stop_on_never_started_action(advanced_profiler):
     """Ensure AdvancedProfiler.stop() does not crash when stopping an action that was never started.
 
     Regression test for https://github.com/Lightning-AI/pytorch-lightning/issues/9136
+
     """
     # Should not raise ValueError
     advanced_profiler.stop("never_started_action")
@@ -393,6 +394,7 @@ def test_advanced_profiler_teardown_with_active_action(advanced_profiler):
     """Ensure AdvancedProfiler.stop() does not crash after teardown clears profiled_actions.
 
     Regression test for https://github.com/Lightning-AI/pytorch-lightning/issues/9136
+
     """
     with advanced_profiler.profile("action"):
         # teardown clears the recorded actions, mimicking describe()

--- a/tests/tests_pytorch/profilers/test_profiler.py
+++ b/tests/tests_pytorch/profilers/test_profiler.py
@@ -375,11 +375,29 @@ def test_advanced_profiler_dump_states_sanitizes_filename(tmp_path, char):
 def test_advanced_profiler_value_errors(advanced_profiler):
     """Ensure errors are raised where expected."""
     action = "test"
-    with pytest.raises(ValueError, match="Attempting to stop recording*"):
-        advanced_profiler.stop(action)
-
+    # Starting an action already started does not raise an error since defaultdict handles it silently
     advanced_profiler.start(action)
     advanced_profiler.stop(action)
+
+
+def test_advanced_profiler_stop_on_never_started_action(advanced_profiler):
+    """Ensure AdvancedProfiler.stop() does not crash when stopping an action that was never started.
+
+    Regression test for https://github.com/Lightning-AI/pytorch-lightning/issues/9136
+    """
+    # Should not raise ValueError
+    advanced_profiler.stop("never_started_action")
+
+
+def test_advanced_profiler_teardown_with_active_action(advanced_profiler):
+    """Ensure AdvancedProfiler.stop() does not crash after teardown clears profiled_actions.
+
+    Regression test for https://github.com/Lightning-AI/pytorch-lightning/issues/9136
+    """
+    with advanced_profiler.profile("action"):
+        # teardown clears the recorded actions, mimicking describe()
+        advanced_profiler.teardown(stage=None)
+    # Exiting the 'with' block will call stop("action") which should not raise an error
 
 
 def test_advanced_profiler_deepcopy(advanced_profiler):

--- a/tests/tests_pytorch/profilers/test_profiler.py
+++ b/tests/tests_pytorch/profilers/test_profiler.py
@@ -371,14 +371,32 @@ def test_advanced_profiler_dump_states_sanitizes_filename(tmp_path, char):
     assert (tmp_path / prof_name).read_bytes()
 
 
-def test_advanced_profiler_value_errors(advanced_profiler):
-    """Ensure errors are raised where expected."""
+def test_advanced_profiler_start_stop(advanced_profiler):
+    """Ensure an action can be started and stopped."""
     action = "test"
-    with pytest.raises(ValueError, match="Attempting to stop recording*"):
-        advanced_profiler.stop(action)
-
     advanced_profiler.start(action)
     advanced_profiler.stop(action)
+
+
+def test_advanced_profiler_stop_on_never_started_action(advanced_profiler):
+    """Ensure AdvancedProfiler.stop() does not crash when stopping an action that was never started.
+
+    Regression test for https://github.com/Lightning-AI/pytorch-lightning/issues/9136
+
+    """
+    # Should not raise ValueError
+    advanced_profiler.stop("never_started_action")
+
+
+def test_advanced_profiler_teardown_with_active_action(advanced_profiler):
+    """Ensure AdvancedProfiler.stop() does not crash after teardown clears profiled_actions.
+
+    Regression test for https://github.com/Lightning-AI/pytorch-lightning/issues/9136
+
+    """
+    with advanced_profiler.profile("action"):
+        advanced_profiler.teardown(stage=None)
+        assert not advanced_profiler.profiled_actions
 
 
 def test_advanced_profiler_deepcopy(advanced_profiler):


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug where `AdvancedProfiler` crashes with a `ValueError` if a profiling context manager is active during trainer teardown. 

When `teardown()` is called, it clears the `profiled_actions` dictionary. Exiting the context manager subsequently calls `stop()`, which was crashing because the action no longer existed. 
I fixed this by:
1. Making `stop()` return silently if the action doesn't exist.
2. Disabling all active `cProfile` instances in `teardown()` before clearing the dictionary to prevent global profiler leaks.

Fixes #9136

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? Yes, issue #9136.
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (Not applicable)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request? (No breaking changes)
- [x] Did you **update the CHANGELOG**?

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>
