### PR TITLE
feat: add `dtype` option to `LightningModule.load_from_checkpoint`

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added support for remote storage (fsspec URLs) when saving and loading distributed checkpoints with `ModelParallelStrategy` ([#21797](https://github.com/Lightning-AI/pytorch-lightning/issues/21797))
 
+- Added a `dtype` argument to `LightningModule.load_from_checkpoint` to cast the loaded model's floating-point parameters at load time ([#20833](https://github.com/Lightning-AI/pytorch-lightning/issues/20833))
+
 ### Changed
 
 -

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -1729,6 +1729,7 @@ class LightningModule(
         hparams_file: Optional[_PATH] = None,
         strict: Optional[bool] = None,
         weights_only: Optional[bool] = None,
+        dtype: Optional[torch.dtype] = None,
         **kwargs: Any,
     ) -> Self:
         r"""Primary way of loading a model from a checkpoint. When Lightning saves a checkpoint it stores the arguments
@@ -1767,6 +1768,11 @@ class LightningModule(
                 ``weights_only=False``. If loading checkpoint from an untrusted source, we recommend using
                 ``weights_only=True``. For more information, please refer to the
                 `PyTorch Developer Notes on Serialization Semantics <https://docs.pytorch.org/docs/main/notes/serialization.html#id3>`_.
+            dtype: If provided, cast the loaded model's floating-point parameters and buffers to this
+                :class:`torch.dtype` (e.g. ``torch.float16``), equivalent to calling ``.to(dtype)`` on the
+                returned model. Non-floating-point tensors (such as integer buffers) are left unchanged.
+                Defaults to ``None``, which keeps the dtype stored in the checkpoint. Note that downcasting
+                (e.g. from ``float32`` to ``float16``) reduces numerical precision.
             \**kwargs: Any extra keyword args needed to init the model. Can also be used to override saved
                 hyperparameter values.
 
@@ -1823,6 +1829,7 @@ class LightningModule(
             hparams_file,
             strict,
             weights_only,
+            dtype=dtype,
             **kwargs,
         )
         return cast(Self, loaded)

--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -63,6 +63,7 @@ def _load_from_checkpoint(
     hparams_file: Optional[_PATH] = None,
     strict: Optional[bool] = None,
     weights_only: Optional[bool] = None,
+    dtype: Optional["torch.dtype"] = None,
     **kwargs: Any,
 ) -> Union["pl.LightningModule", "pl.LightningDataModule"]:
     map_location = map_location or _default_map_location
@@ -104,6 +105,10 @@ def _load_from_checkpoint(
 
         device = next((t for t in state_dict.values() if isinstance(t, torch.Tensor)), torch.tensor(0)).device
         assert isinstance(model, pl.LightningModule)
+        if dtype is not None:
+            # cast floating-point parameters/buffers to the requested dtype;
+            # `torch.nn.Module.to` leaves non-floating-point tensors untouched
+            return model.to(device=device, dtype=dtype)
         return model.to(device)
 
     raise NotImplementedError(f"Unsupported {cls}")

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -122,6 +122,20 @@ def test_load_from_checkpoint_warn_on_empty_state_dict(tmp_path):
     assert model.device.type == "cpu"
 
 
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float64])
+def test_load_from_checkpoint_dtype(dtype, tmp_path):
+    """Test that `load_from_checkpoint` casts floating-point parameters to the requested dtype."""
+    create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cpu")
+
+    # default: dtype is preserved as stored in the checkpoint (float32)
+    model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt")
+    assert all(p.dtype == torch.float32 for p in model.parameters())
+
+    # explicit dtype casts floating-point parameters
+    model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", dtype=dtype)
+    assert all(p.dtype == dtype for p in model.parameters())
+
+
 @pytest.mark.parametrize(
     ("strict", "strict_loading", "expected"),
     [


### PR DESCRIPTION
## What does this PR do?

Adds an optional `dtype` argument to `LightningModule.load_from_checkpoint`
(plumbed through the internal `_load_from_checkpoint`) so that the restored
model's floating-point parameters and buffers can be cast to a target
`torch.dtype` at load time — for example loading an fp32/bf16-trained model
directly as `float16` for faster inference/sampling, without a separate manual
`.to(dtype)` call. This mirrors how the existing `map_location` argument controls
device placement.

The change is strictly opt-in:

- `dtype` defaults to `None`, which preserves the current behavior exactly.
- When provided, the cast is applied via `torch.nn.Module.to(device=..., dtype=...)`,
  which only casts floating-point tensors and leaves integer buffers unchanged.
- It is added for `LightningModule` only; `LightningDataModule` carries no
  tensors to cast.

Downcasting (e.g. `float32` -> `float16`) reduces numerical precision, so the
behavior is documented in the docstring and left entirely to the user's choice.

Fixes #20833

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? Yes — requested in #20833.
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (docstring updated)
- [x] Did you write any **new necessary tests**? (`test_load_from_checkpoint_dtype`, CPU-only)
- [ ] Did you verify new and **existing tests pass** locally with your changes? `ruff check`/`ruff format --check` pass locally; the full pytest suite was not run in my environment (no GPU/torch dev install) and is left to CI.
- [x] Did you list all the **breaking changes** introduced by this pull request? None — additive, default `None`.
- [x] Did you **update the CHANGELOG**?

</details>

## PR review

Anyone in the community is welcome to review the PR.

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>
