### PR TITLE
Enhance DDP unused-parameters error with offending parameter names

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added `log_key_prefix` parameter to `LearningRateMonitor` callback for prefixing logged metric names ([#21612](https://github.com/Lightning-AI/pytorch-lightning/issues/21612))
 
+- Improved the DDP unused-parameters error message to list the names of the parameters that did not receive a gradient ([#21794](https://github.com/Lightning-AI/pytorch-lightning/pull/21794))
+
 ### Changed
 
 -

--- a/src/lightning/pytorch/strategies/ddp.py
+++ b/src/lightning/pytorch/strategies/ddp.py
@@ -417,6 +417,22 @@ class DDPStrategy(ParallelStrategy):
 
     @override
     def on_exception(self, exception: BaseException) -> None:
+        unused_hint = ""
+        if self.lightning_module is not None:
+            unused_params = [
+                name
+                for name, param in self.lightning_module.named_parameters()
+                if param.requires_grad and param.grad is None
+            ]
+            if unused_params:
+                joined = "\n  ".join(unused_params)
+                unused_hint = (
+                    "\nThe following parameters did not receive a gradient (likely unused in `training_step`):"
+                    f"\n  {joined}\n"
+                    "If this is expected, either freeze them with `param.requires_grad_(False)`"
+                    " (or remove the submodule), or enable `find_unused_parameters=True`."
+                )
+
         _augment_message(
             exception,
             pattern=".*Expected to have finished reduction in the prior iteration.*",
@@ -425,6 +441,7 @@ class DDPStrategy(ParallelStrategy):
                 " by training_step. If this is intentional, you must enable the detection of unused parameters in DDP,"
                 " either by setting the string value `strategy='ddp_find_unused_parameters_true'`"
                 " or by setting the flag in the strategy with `strategy=DDPStrategy(find_unused_parameters=True)`."
+                + unused_hint
             ),
         )
 

--- a/tests/tests_pytorch/strategies/test_ddp.py
+++ b/tests/tests_pytorch/strategies/test_ddp.py
@@ -222,7 +222,7 @@ def test_ddp_dont_configure_sync_batchnorm(trainer_fn):
     assert not isinstance(trainer.strategy.model.layer, torch.nn.modules.batchnorm.SyncBatchNorm)
 
 
-@RunIf(min_cuda_gpus=2, standalone=True)
+@RunIf(min_cuda_gpus=1, standalone=True)
 def test_ddp_on_exception_lists_unused_parameters():
     """Test that the augmented DDP error message includes names of parameters that received no gradient."""
 
@@ -246,10 +246,9 @@ def test_ddp_on_exception_lists_unused_parameters():
     msg = str(exception)
     assert "unused_head.weight" in msg
     assert "unused_head.bias" in msg
-    assert "layer" not in msg
 
 
-@RunIf(min_cuda_gpus=2, standalone=True)
+@RunIf(min_cuda_gpus=1, standalone=True)
 def test_ddp_on_exception_no_unused_parameters():
     """Test that no extra hint is appended when all parameters received gradients."""
     model = BoringModel()
@@ -266,7 +265,7 @@ def test_ddp_on_exception_no_unused_parameters():
     assert "did not receive a gradient" not in msg
 
 
-@RunIf(min_cuda_gpus=2, standalone=True)
+@RunIf(min_cuda_gpus=1, standalone=True)
 def test_ddp_on_exception_ignores_frozen_parameters():
     """Test that frozen parameters (requires_grad=False) are not listed as unused."""
 

--- a/tests/tests_pytorch/strategies/test_ddp.py
+++ b/tests/tests_pytorch/strategies/test_ddp.py
@@ -220,3 +220,73 @@ def test_ddp_dont_configure_sync_batchnorm(trainer_fn):
     trainer.strategy.setup(trainer)
     # because TrainerFn is not FITTING, model is not configured with sync batchnorm
     assert not isinstance(trainer.strategy.model.layer, torch.nn.modules.batchnorm.SyncBatchNorm)
+
+
+@RunIf(min_cuda_gpus=2, standalone=True)
+def test_ddp_on_exception_lists_unused_parameters():
+    """Test that the augmented DDP error message includes names of parameters that received no gradient."""
+
+    class ModelWithUnusedHead(BoringModel):
+        def __init__(self):
+            super().__init__()
+            self.unused_head = torch.nn.Linear(5, 3)
+
+    model = ModelWithUnusedHead()
+    strategy = DDPStrategy()
+    strategy.connect(model)
+
+    # Simulate a backward pass where only the base BoringModel's layer got gradients
+    for name, param in model.named_parameters():
+        if "unused_head" not in name:
+            param.grad = torch.zeros_like(param)
+
+    exception = RuntimeError("Expected to have finished reduction in the prior iteration before starting a new one.")
+    strategy.on_exception(exception)
+
+    msg = str(exception)
+    assert "unused_head.weight" in msg
+    assert "unused_head.bias" in msg
+    assert "layer" not in msg
+
+
+@RunIf(min_cuda_gpus=2, standalone=True)
+def test_ddp_on_exception_no_unused_parameters():
+    """Test that no extra hint is appended when all parameters received gradients."""
+    model = BoringModel()
+    strategy = DDPStrategy()
+    strategy.connect(model)
+
+    for param in model.parameters():
+        param.grad = torch.zeros_like(param)
+
+    exception = RuntimeError("Expected to have finished reduction in the prior iteration before starting a new one.")
+    strategy.on_exception(exception)
+
+    msg = str(exception)
+    assert "did not receive a gradient" not in msg
+
+
+@RunIf(min_cuda_gpus=2, standalone=True)
+def test_ddp_on_exception_ignores_frozen_parameters():
+    """Test that frozen parameters (requires_grad=False) are not listed as unused."""
+
+    class ModelWithFrozenHead(BoringModel):
+        def __init__(self):
+            super().__init__()
+            self.frozen_head = torch.nn.Linear(5, 3)
+            self.frozen_head.requires_grad_(False)
+
+    model = ModelWithFrozenHead()
+    strategy = DDPStrategy()
+    strategy.connect(model)
+
+    for name, param in model.named_parameters():
+        if param.requires_grad:
+            param.grad = torch.zeros_like(param)
+
+    exception = RuntimeError("Expected to have finished reduction in the prior iteration before starting a new one.")
+    strategy.on_exception(exception)
+
+    msg = str(exception)
+    assert "frozen_head" not in msg
+    assert "did not receive a gradient" not in msg


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

Fixes #17212

When training with `DDPStrategy` and the default `find_unused_parameters=False`, a
`LightningModule` that has parameters not involved in producing the loss raises:

> RuntimeError: It looks like your LightningModule has parameters that were not used
> in producing the loss returned by training_step. [...]

The message tells the user *that* there are unused parameters, but not *which ones*.
Today, users have to rediscover the culprits themselves, either by setting
`TORCH_DISTRIBUTED_DEBUG=DETAIL` or by adding an `on_after_backward` hook that walks
`named_parameters()` looking for `grad is None`. This comes up repeatedly in #17212,
where the same manual workarounds get re-shared over and over.

This PR augments the error in `DDPStrategy.on_exception` to additionally list the
parameters that did not receive a gradient, and points the user at the two ways to
resolve it (freeze/remove the parameters, or enable `find_unused_parameters=True`):

```
The following parameters did not receive a gradient (likely unused in `training_step`):
  unused_head.weight
  unused_head.bias
If this is expected, either freeze them with `param.requires_grad_(False)`
(or remove the submodule), or enable `find_unused_parameters=True`.
```
<img width="1568" height="300" alt="ddp-unused-parameters" src="https://github.com/user-attachments/assets/2a438cd6-cdd9-45af-a0e5-5d534de05b1b" />


Parameters with `requires_grad=False` are excluded, since those are intentionally
frozen and are not the cause of the error.

This implements the enhancement requested by @carmocca https://github.com/Lightning-AI/pytorch-lightning/issues/17212#issuecomment-1753106524 & supported by other users.



## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
