### PR TITLE
Fix progress bar total under gradient accumulation with iterable datasets

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -46,6 +46,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed arbitrary code execution in `load_from_checkpoint` by restricting the `_instantiator` hyperparameter to an allowlist of trusted instantiators ([#21832](https://github.com/Lightning-AI/pytorch-lightning/pull/21832))
 
+- Fixed progress bar total showing optimizer steps instead of batches when training an iterable dataset with `max_steps` and `accumulate_grad_batches > 1` ([#21802](https://github.com/Lightning-AI/pytorch-lightning/pull/21802))
+
 ---
 
 ## [2.6.4] - 2026-05-20

--- a/src/lightning/pytorch/callbacks/progress/progress_bar.py
+++ b/src/lightning/pytorch/callbacks/progress/progress_bar.py
@@ -86,8 +86,10 @@ class ProgressBar(Callback):
 
         """
         if self.trainer.max_epochs == -1 and self.trainer.max_steps is not None and self.trainer.max_steps > 0:
+            # The progress bar counts batches, but ``max_steps``/``global_step`` count optimizer steps.
+            # With gradient accumulation, each optimizer step consumes ``accumulate_grad_batches`` batches.
             remaining_steps = self.trainer.max_steps - self.trainer.global_step
-            return min(self.trainer.num_training_batches, remaining_steps)
+            return min(self.trainer.num_training_batches, remaining_steps * self.trainer.accumulate_grad_batches)
         return self.trainer.num_training_batches
 
     @property

--- a/tests/tests_pytorch/loops/test_training_loop.py
+++ b/tests/tests_pytorch/loops/test_training_loop.py
@@ -215,7 +215,8 @@ def test_should_stop_early_stopping_conditions_met(
 
 
 @pytest.mark.parametrize("max_steps", [7, 20])
-def test_tqdm_total_steps_with_iterator_no_length(tmp_path, max_steps):
+@pytest.mark.parametrize("accumulate_grad_batches", [1, 4])
+def test_tqdm_total_steps_with_iterator_no_length(tmp_path, max_steps, accumulate_grad_batches):
     """Test trainer with infinite iterator (no __len__)"""
 
     batch_size = 4
@@ -230,6 +231,7 @@ def test_tqdm_total_steps_with_iterator_no_length(tmp_path, max_steps):
         max_steps=max_steps,
         max_epochs=-1,
         limit_val_batches=0,
+        accumulate_grad_batches=accumulate_grad_batches,
         enable_progress_bar=True,
         enable_model_summary=False,
         accelerator="cpu",
@@ -240,8 +242,14 @@ def test_tqdm_total_steps_with_iterator_no_length(tmp_path, max_steps):
     pbar = trainer.progress_bar_callback
     trainer.fit(model)
 
-    # assert progress bar callback uses correct total steps
-    assert pbar.train_progress_bar.total == max_steps
+    # The bar total and the per-batch counter must share units: with gradient accumulation,
+    # each of the max_steps optimizer steps consumes accumulate_grad_batches batches.
+    assert pbar.train_progress_bar.total == max_steps * accumulate_grad_batches
+    # tqdm exposes the counter as `.n`, rich as `.completed`
+    completed = getattr(pbar.train_progress_bar, "n", None)
+    if completed is None:
+        completed = pbar.train_progress_bar.completed
+    assert completed == max_steps * accumulate_grad_batches
 
 
 @pytest.mark.parametrize("max_steps", [10, 15])


### PR DESCRIPTION
## What does this PR do?

Follow-up to #20869. That PR made `ProgressBar.total_train_batches` fall back to `max_steps - global_step` for infinite (no-`__len__`) dataloaders, so the progress bar shows a finite total instead of `?`.

The problem: that quantity is in **optimizer steps**, but the bar's counter advances **per batch**. With `accumulate_grad_batches=N`, each optimizer step consumes N batches, so over a full run the bar reads e.g. `500000/100000` (5× overshoot at N=5) and the ETA is wrong. The regression slipped through because the tests added in #20869 leave `accumulate_grad_batches` at its default of `1`, where steps and batches coincide.

**Fix:** convert the remaining-step count to batch units (`* accumulate_grad_batches`) before the `min()` with `num_training_batches`. Behavior is unchanged when `accumulate_grad_batches=1` and for finite dataloaders (where `num_training_batches` wins the `min`).

**Test:** parametrized the existing `test_tqdm_total_steps_with_iterator_no_length` over `accumulate_grad_batches=[1, 4]`, asserting both the bar total and the final counter (tqdm `.n` / rich `.completed`).

Follow-up to #20869; fixes the gradient-accumulation case of #20124.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (#20124)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (CHANGELOG updated)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request? (none)
- [x] Did you **update the CHANGELOG**?

</details>