### PR TITLE
Fix FSDP CPU offloading when shards are already on CPU

### DIFF
--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -911,8 +911,13 @@ def _get_full_state_dict_context(
     from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
     from torch.distributed.fsdp.api import FullOptimStateDictConfig
 
-    state_dict_config = FullStateDictConfig(offload_to_cpu=True, rank0_only=rank0_only)
-    optim_state_dict_config = FullOptimStateDictConfig(offload_to_cpu=True, rank0_only=rank0_only)
+    # TODO: This can be cleaned up once PyTorch Lightning picks up the PyTorch version containing
+    # the fix https://github.com/pytorch/pytorch/pull/188990 as the root cause is in PyTorch.
+    # Offloading to CPU when FSDP is on CPU triggers a use-after-free in PyTorch's FlatParamHandle.to_cpu().
+    param = next(module.parameters(), None)
+    offload_to_cpu = param is None or param.device.type != "cpu"
+    state_dict_config = FullStateDictConfig(offload_to_cpu=offload_to_cpu, rank0_only=rank0_only)
+    optim_state_dict_config = FullOptimStateDictConfig(offload_to_cpu=offload_to_cpu, rank0_only=rank0_only)
     state_dict_type_context = FSDP.state_dict_type(
         module=module,
         state_dict_type=StateDictType.FULL_STATE_DICT,

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -433,17 +433,24 @@ def test_set_timeout(init_process_group_mock):
 
 @mock.patch("torch.distributed.fsdp.fully_sharded_data_parallel.FullyShardedDataParallel.set_state_dict_type")
 def test_get_full_state_dict_context_offload(set_type_mock, monkeypatch):
-    """Test that the state dict context manager handles CPU offloading."""
-
-    with _get_full_state_dict_context(module=Mock(spec=FullyShardedDataParallel), world_size=1):
+    """Test that the state dict context manager only offloads to CPU when the shards live on an accelerator."""
+    # Shards on accelerator: offload to CPU.
+    accelerator_param = Mock()
+    accelerator_param.device = torch.device("cuda", 0)
+    module = Mock(spec=FullyShardedDataParallel)
+    module.parameters = Mock(return_value=iter([accelerator_param]))
+    with _get_full_state_dict_context(module=module, world_size=4):
         assert set_type_mock.call_args_list[0][0][2].offload_to_cpu  # model config
         assert set_type_mock.call_args_list[0][0][3].offload_to_cpu  # optim config
 
     set_type_mock.reset_mock()
 
-    with _get_full_state_dict_context(module=Mock(spec=FullyShardedDataParallel), world_size=4):
-        assert set_type_mock.call_args_list[0][0][2].offload_to_cpu  # model config
-        assert set_type_mock.call_args_list[0][0][3].offload_to_cpu  # optim config
+    # Shards on CPU: do not offload (prevents PyTorch use-after-free).
+    module = Mock(spec=FullyShardedDataParallel)
+    module.parameters = Mock(return_value=iter([torch.nn.Parameter(torch.zeros(1))]))
+    with _get_full_state_dict_context(module=module, world_size=4):
+        assert not set_type_mock.call_args_list[0][0][2].offload_to_cpu  # model config
+        assert not set_type_mock.call_args_list[0][0][3].offload_to_cpu  # optim config
 
 
 def test_device_mesh_type_annotation():


### PR DESCRIPTION


## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes https://github.com/Lightning-AI/pytorch-lightning/issues/21804

Offloading to CPU when FSDP is on CPU triggers a use-after-free in PyTorch's FlatParamHandle.to_cpu(). This change checks if the parameters are on CPU and disables `offload_to_cpu` if they are.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
