### PR TITLE
feat: add num_nodes() to ClusterEnvironment

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -29,7 +29,7 @@ sphinx:
   fail_on_warning: true
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
   apt_packages:

--- a/src/lightning/fabric/plugins/environments/cluster_environment.py
+++ b/src/lightning/fabric/plugins/environments/cluster_environment.py
@@ -61,6 +61,10 @@ class ClusterEnvironment(ABC):
     def node_rank(self) -> int:
         """The rank (index) of the node on which the current process runs."""
 
+    @abstractmethod
+    def num_nodes(self) -> int:
+        """The total number of nodes in the cluster."""
+
     def validate_settings(self, num_devices: int, num_nodes: int) -> None:
         """Validates settings configured in the script against the environment, and raises an exception if there is an
         inconsistency."""

--- a/src/lightning/fabric/plugins/environments/kubeflow.py
+++ b/src/lightning/fabric/plugins/environments/kubeflow.py
@@ -76,3 +76,7 @@ class KubeflowEnvironment(ClusterEnvironment):
     @override
     def node_rank(self) -> int:
         return self.global_rank()
+
+    @override
+    def num_nodes(self) -> int:
+        return self.world_size()

--- a/src/lightning/fabric/plugins/environments/lightning.py
+++ b/src/lightning/fabric/plugins/environments/lightning.py
@@ -100,6 +100,10 @@ class LightningEnvironment(ClusterEnvironment):
         return int(os.environ.get("NODE_RANK", group_rank))
 
     @override
+    def num_nodes(self) -> int:
+        return 1
+
+    @override
     def teardown(self) -> None:
         if "WORLD_SIZE" in os.environ:
             del os.environ["WORLD_SIZE"]

--- a/src/lightning/fabric/plugins/environments/lsf.py
+++ b/src/lightning/fabric/plugins/environments/lsf.py
@@ -135,6 +135,12 @@ class LSFEnvironment(ClusterEnvironment):
         ``LSB_DJOB_RANKFILE``."""
         return self._node_rank
 
+    @override
+    def num_nodes(self) -> int:
+        """The total number of nodes in the cluster based on the unique hosts in ``LSB_DJOB_RANKFILE``."""
+        hosts = self._read_hosts()
+        return len(set(hosts))
+
     def _get_node_rank(self) -> int:
         """A helper method for getting the node rank.
 

--- a/src/lightning/fabric/plugins/environments/mpi.py
+++ b/src/lightning/fabric/plugins/environments/mpi.py
@@ -44,6 +44,7 @@ class MPIEnvironment(ClusterEnvironment):
         self._comm_world = MPI.COMM_WORLD
         self._comm_local: Optional[MPI.Comm] = None
         self._node_rank: Optional[int] = None
+        self._num_nodes: Optional[int] = None
         self._main_address: Optional[str] = None
         self._main_port: Optional[int] = None
 
@@ -114,6 +115,13 @@ class MPIEnvironment(ClusterEnvironment):
         assert self._node_rank is not None
         return self._node_rank
 
+    @override
+    def num_nodes(self) -> int:
+        if self._num_nodes is None:
+            self._init_comm_local()
+        assert self._num_nodes is not None
+        return self._num_nodes
+
     def _get_main_address(self) -> str:
         return self._comm_world.bcast(socket.gethostname(), root=0)
 
@@ -128,4 +136,5 @@ class MPIEnvironment(ClusterEnvironment):
         unique_hosts = self._comm_world.bcast(unique_hosts, root=0)
         # find the index for this host in the list of hosts:
         self._node_rank = unique_hosts.index(hostname)
+        self._num_nodes = len(unique_hosts)
         self._comm_local = self._comm_world.Split(color=self._node_rank)

--- a/src/lightning/fabric/plugins/environments/slurm.py
+++ b/src/lightning/fabric/plugins/environments/slurm.py
@@ -155,6 +155,10 @@ class SLURMEnvironment(ClusterEnvironment):
         return int(os.environ["SLURM_NODEID"])
 
     @override
+    def num_nodes(self) -> int:
+        return int(os.environ["SLURM_NNODES"])
+
+    @override
     def validate_settings(self, num_devices: int, num_nodes: int) -> None:
         if _is_slurm_interactive_mode():
             return

--- a/src/lightning/fabric/plugins/environments/torchelastic.py
+++ b/src/lightning/fabric/plugins/environments/torchelastic.py
@@ -85,6 +85,12 @@ class TorchElasticEnvironment(ClusterEnvironment):
         return int(os.environ.get("GROUP_RANK", 0))
 
     @override
+    def num_nodes(self) -> int:
+        if "GROUP_WORLD_SIZE" in os.environ:
+            return int(os.environ["GROUP_WORLD_SIZE"])
+        return self.world_size() // int(os.environ["LOCAL_WORLD_SIZE"])
+
+    @override
     def validate_settings(self, num_devices: int, num_nodes: int) -> None:
         if num_devices * num_nodes != self.world_size():
             raise ValueError(

--- a/src/lightning/fabric/plugins/environments/xla.py
+++ b/src/lightning/fabric/plugins/environments/xla.py
@@ -133,3 +133,17 @@ class XLAEnvironment(ClusterEnvironment):
         from torch_xla.utils.utils import getenv_as
 
         return getenv_as(xenv.HOST_ORDINAL, int, 0)
+
+    @override
+    @functools.lru_cache(maxsize=1)
+    def num_nodes(self) -> int:
+        """The total number of hosts (nodes) in the cluster.
+
+        The output is cached for performance.
+
+        """
+        if _XLA_GREATER_EQUAL_2_1:
+            from torch_xla import runtime as xr
+
+            return xr.host_count()
+        return 1

--- a/tests/tests_fabric/plugins/environments/test_kubeflow.py
+++ b/tests/tests_fabric/plugins/environments/test_kubeflow.py
@@ -60,6 +60,7 @@ def test_attributes_from_environment_variables(caplog):
     assert env.global_rank() == 1
     assert env.local_rank() == 0
     assert env.node_rank() == 1
+    assert env.num_nodes() == 20
     # setter should be no-op
     with caplog.at_level(logging.DEBUG, logger="lightning.fabric.plugins.environments"):
         env.set_global_rank(100)

--- a/tests/tests_fabric/plugins/environments/test_lightning.py
+++ b/tests/tests_fabric/plugins/environments/test_lightning.py
@@ -29,6 +29,7 @@ def test_default_attributes():
     assert env.world_size() == 1
     assert env.local_rank() == 0
     assert env.node_rank() == 0
+    assert env.num_nodes() == 1
 
 
 @mock.patch.dict(os.environ, {"MASTER_ADDR": "1.2.3.4", "MASTER_PORT": "500", "LOCAL_RANK": "2", "NODE_RANK": "3"})

--- a/tests/tests_fabric/plugins/environments/test_lsf.py
+++ b/tests/tests_fabric/plugins/environments/test_lsf.py
@@ -98,6 +98,7 @@ def test_node_rank(tmp_path):
     with mock.patch.dict(os.environ, environ), mock.patch("socket.gethostname", return_value="10.10.10.2"):
         env = LSFEnvironment()
         assert env.node_rank() == 2
+        assert env.num_nodes() == 4
 
 
 def test_detect():

--- a/tests/tests_fabric/plugins/environments/test_mpi.py
+++ b/tests/tests_fabric/plugins/environments/test_mpi.py
@@ -84,12 +84,15 @@ def test_init_local_comm(monkeypatch):
         env._comm_world.gather.return_value = ["host1", "host2"]
         env._comm_world.bcast.return_value = ["host1", "host2"]
         assert env.node_rank() == 0
+        assert env.num_nodes() == 2
 
         env._node_rank = None
+        env._num_nodes = None
         hostname_mock.return_value = "host2"
         env._comm_world.gather.return_value = None
         env._comm_world.bcast.return_value = ["host1", "host2"]
         assert env.node_rank() == 1
+        assert env.num_nodes() == 2
 
         assert env._comm_local is not None
         env._comm_local.Get_rank.return_value = 33

--- a/tests/tests_fabric/plugins/environments/test_slurm.py
+++ b/tests/tests_fabric/plugins/environments/test_slurm.py
@@ -56,6 +56,7 @@ def test_default_attributes():
         "SLURM_LOCALID": "2",
         "SLURM_PROCID": "1",
         "SLURM_NODEID": "3",
+        "SLURM_NNODES": "2",
         "SLURM_JOB_NAME": "JOB",
     },
 )
@@ -70,6 +71,7 @@ def test_attributes_from_environment_variables(caplog):
     assert env.global_rank() == 1
     assert env.local_rank() == 2
     assert env.node_rank() == 3
+    assert env.num_nodes() == 2
     assert env.job_name() == "JOB"
     # setter should be no-op
     with caplog.at_level(logging.DEBUG, logger="lightning.fabric.plugins.environments"):

--- a/tests/tests_fabric/plugins/environments/test_torchelastic.py
+++ b/tests/tests_fabric/plugins/environments/test_torchelastic.py
@@ -45,7 +45,9 @@ def test_default_attributes():
         "WORLD_SIZE": "20",
         "RANK": "1",
         "LOCAL_RANK": "2",
+        "LOCAL_WORLD_SIZE": "5",
         "GROUP_RANK": "3",
+        "GROUP_WORLD_SIZE": "4",
     },
 )
 def test_attributes_from_environment_variables(caplog):
@@ -57,6 +59,7 @@ def test_attributes_from_environment_variables(caplog):
     assert env.global_rank() == 1
     assert env.local_rank() == 2
     assert env.node_rank() == 3
+    assert env.num_nodes() == 4
     # setter should be no-op
     with caplog.at_level(logging.DEBUG, logger="lightning.fabric.plugins.environments"):
         env.set_global_rank(100)
@@ -92,3 +95,16 @@ def test_validate_user_settings():
     env.validate_settings(num_devices=4, num_nodes=2)
     with pytest.raises(ValueError, match=re.escape("the product (2 * 2) does not match the world size (8)")):
         env.validate_settings(num_devices=2, num_nodes=2)
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "WORLD_SIZE": "20",
+        "LOCAL_WORLD_SIZE": "5",
+    },
+)
+def test_num_nodes_fallback_to_local_world_size():
+    """Test that num_nodes falls back to WORLD_SIZE / LOCAL_WORLD_SIZE when GROUP_WORLD_SIZE is not set."""
+    env = TorchElasticEnvironment()
+    assert env.num_nodes() == 4

--- a/tests/tests_fabric/plugins/environments/test_xla.py
+++ b/tests/tests_fabric/plugins/environments/test_xla.py
@@ -49,6 +49,8 @@ def test_default_attributes(monkeypatch):
     assert env.global_rank() == 0
     assert env.local_rank() == 0
     assert env.node_rank() == 1
+    # num_nodes() returns 1 when not using XLA >= 2.1
+    assert env.num_nodes() == 1
 
     with pytest.raises(NotImplementedError):
         _ = env.main_address
@@ -158,3 +160,16 @@ def test_setters_readonly_when_xla_runtime_greater_2_1(xla_available):
 
         env.set_global_rank(100)
         assert env.global_rank() == 2
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
+@mock.patch("lightning.fabric.accelerators.xla._XLA_GREATER_EQUAL_2_1", True)
+@mock.patch("lightning.fabric.plugins.environments.xla._XLA_GREATER_EQUAL_2_1", True)
+def test_num_nodes_from_xla_runtime_greater_2_1(xla_available):
+    """Test that num_nodes uses torch_xla.runtime.host_count when XLA >= 2.1."""
+    env = XLAEnvironment()
+
+    with mock.patch("torch_xla.runtime.host_count", return_value=8) as mock_host_count:
+        env.num_nodes.cache_clear()
+        assert env.num_nodes() == 8
+        mock_host_count.assert_called_once()

--- a/tests/tests_pytorch/strategies/test_ddp_integration.py
+++ b/tests/tests_pytorch/strategies/test_ddp_integration.py
@@ -340,6 +340,9 @@ def test_configure_launcher_create_processes_externally():
         def node_rank(self):
             return 0
 
+        def num_nodes(self):
+            return 1
+
     ddp_strategy = DDPStrategy(cluster_environment=MyClusterEnvironment(), parallel_devices=[torch.device("cpu")])
     assert ddp_strategy.launcher is None
     ddp_strategy._configure_launcher()


### PR DESCRIPTION
Fixes #7361

## What does this PR do?

Adds num_nodes() abstract method to ClusterEnvironment and implements it in all concrete subclasses.

## Motivation

As discussed in #7361, the number of nodes is generally known in a cluster environment and should be obtainable from ClusterEnvironment rather than requiring the user to always specify it manually.

## Test Plan

Added assertions for num_nodes() in all existing subclass tests. Added dedicated tests for TorchElastic fallback path and XLA runtime path.