### PR TITLE
fix: prevent ModelCheckpoint from deleting remote checkpoints from previous runs

### DIFF
--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -1009,14 +1009,17 @@ class ModelCheckpoint(Checkpoint):
 
         A checkpoint won't be deleted if any of the cases apply:
         - The previous checkpoint is the same as the current checkpoint (means the old was already overwritten by new)
-        - The previous checkpoint is not in the current checkpoint directory and the filesystem is local
-        - The previous checkpoint is the checkpoint the Trainer resumed from and the filesystem is local
+        - The previous checkpoint is not in the current checkpoint directory
+        - The previous checkpoint is the checkpoint the Trainer resumed from
 
         """
         if previous == current:
             return False
         if not _is_local_file_protocol(previous):
-            return True
+            if trainer.ckpt_path is not None and previous == trainer.ckpt_path:
+                return False
+            assert self.dirpath is not None
+            return previous.startswith(self.dirpath.rstrip("/") + "/")
         previous = Path(previous).absolute()
         resume_path = Path(trainer.ckpt_path).absolute() if trainer.ckpt_path is not None else None
         if resume_path is not None and previous == resume_path:


### PR DESCRIPTION
Resolves #21813

<details>

Signed-off-by: KartavyaDikshit <kartavyaniraj.dikshit2021@vitstudent.ac.in>