### PR TITLE
Preserve leafless hyperparameter values in `_flatten_dict`

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `_flatten_dict` silently dropping hyperparameters whose value holds no leaves, such as `[]`, `{}` or `[{}]` ([#21830](https://github.com/Lightning-AI/pytorch-lightning/pull/21830))
 
+- Fixed `_flatten_dict` hardcoding `/` for the list index of a list of dictionaries instead of using the requested `delimiter` ([#21830](https://github.com/Lightning-AI/pytorch-lightning/pull/21830))
+
 - Fixed DeepSpeed checkpoint path validation rejecting remote filesystem URIs (S3, GCS, HDFS) ([#21636](https://github.com/Lightning-AI/pytorch-lightning/pull/21636))
 
 - Fixed `FSDPStrategy` raising `RuntimeError` under PyTorch 2.5+ when `root_device` is CPU, by passing an explicit `torch.device("cpu")` instead of `device_id=None` (relevant only when the GPU-accelerator guard is bypassed) ([#21774](https://github.com/Lightning-AI/pytorch-lightning/pull/21774))

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed type checking for the `BitsandbytesPrecision` plugin and raised the supported `bitsandbytes` ceiling to `<0.50` (compatible with 0.48/0.49) ([#21858](https://github.com/Lightning-AI/pytorch-lightning/pull/21858))
 
+- Fixed `_flatten_dict` silently dropping hyperparameters whose value holds no leaves, such as `[]`, `{}` or `[{}]` ([#21830](https://github.com/Lightning-AI/pytorch-lightning/pull/21830))
+
 - Fixed DeepSpeed checkpoint path validation rejecting remote filesystem URIs (S3, GCS, HDFS) ([#21636](https://github.com/Lightning-AI/pytorch-lightning/pull/21636))
 
 - Fixed `FSDPStrategy` raising `RuntimeError` under PyTorch 2.5+ when `root_device` is CPU, by passing an explicit `torch.device("cpu")` instead of `device_id=None` (relevant only when the GPU-accelerator guard is bypassed) ([#21774](https://github.com/Lightning-AI/pytorch-lightning/pull/21774))

--- a/src/lightning/fabric/utilities/logger.py
+++ b/src/lightning/fabric/utilities/logger.py
@@ -93,6 +93,8 @@ def _flatten_dict(params: MutableMapping[Any, Any], delimiter: str = "/", parent
         {'5/a': 123}
         >>> _flatten_dict({"dl": [{"a": 1, "c": 3}, {"b": 2, "d": 5}], "l": [1, 2, 3, 4]})
         {'dl/0/a': 1, 'dl/0/c': 3, 'dl/1/b': 2, 'dl/1/d': 5, 'l': [1, 2, 3, 4]}
+        >>> _flatten_dict({"dl": [{"a": 1}]}, delimiter=".")
+        {'dl.0.a': 1}
         >>> _flatten_dict({"a": [], "b": 5})
         {'a': [], 'b': 5}
         >>> _flatten_dict({"a": {}, "b": [{}]})
@@ -113,7 +115,7 @@ def _flatten_dict(params: MutableMapping[Any, Any], delimiter: str = "/", parent
         elif isinstance(v, list) and all(isinstance(item, MutableMapping) for item in v):
             flat = {}
             for i, item in enumerate(v):
-                flat.update(_flatten_dict(item, parent_key=f"{new_key}/{i}", delimiter=delimiter))
+                flat.update(_flatten_dict(item, parent_key=f"{new_key}{delimiter}{i}", delimiter=delimiter))
         else:
             result[new_key] = v
             continue

--- a/src/lightning/fabric/utilities/logger.py
+++ b/src/lightning/fabric/utilities/logger.py
@@ -93,6 +93,10 @@ def _flatten_dict(params: MutableMapping[Any, Any], delimiter: str = "/", parent
         {'5/a': 123}
         >>> _flatten_dict({"dl": [{"a": 1, "c": 3}, {"b": 2, "d": 5}], "l": [1, 2, 3, 4]})
         {'dl/0/a': 1, 'dl/0/c': 3, 'dl/1/b': 2, 'dl/1/d': 5, 'l': [1, 2, 3, 4]}
+        >>> _flatten_dict({"a": [], "b": 5})
+        {'a': [], 'b': 5}
+        >>> _flatten_dict({"a": {}, "b": [{}]})
+        {'a': {}, 'b': [{}]}
 
     """
     result: dict[str, Any] = {}
@@ -104,13 +108,19 @@ def _flatten_dict(params: MutableMapping[Any, Any], delimiter: str = "/", parent
             v = vars(v)
 
         if isinstance(v, MutableMapping):
-            result = {**result, **_flatten_dict(v, parent_key=new_key, delimiter=delimiter)}
+            flat = _flatten_dict(v, parent_key=new_key, delimiter=delimiter)
         # Also handle the case where v is a list of dictionaries
         elif isinstance(v, list) and all(isinstance(item, MutableMapping) for item in v):
+            flat = {}
             for i, item in enumerate(v):
-                result = {**result, **_flatten_dict(item, parent_key=f"{new_key}/{i}", delimiter=delimiter)}
+                flat.update(_flatten_dict(item, parent_key=f"{new_key}/{i}", delimiter=delimiter))
         else:
             result[new_key] = v
+            continue
+
+        # a value holding no leaves (``{}``, ``[]``, ``[{}]``) flattens to nothing, so keep it as a
+        # leaf rather than letting the key disappear from the logged hyperparameters
+        result.update(flat or {new_key: v})
     return result
 
 

--- a/tests/tests_fabric/utilities/test_logger.py
+++ b/tests/tests_fabric/utilities/test_logger.py
@@ -70,6 +70,14 @@ def test_flatten_dict():
 
     assert params == {"dl/0/a": 1, "dl/0/c": 3, "dl/1/b": 2, "dl/1/d": 5, "l": [1, 2, 3, 4]}
 
+    # Test that values holding no leaves are preserved instead of being silently dropped
+    assert _flatten_dict({"a": [], "b": 5}) == {"a": [], "b": 5}
+    assert _flatten_dict({"a": [{}], "b": 5}) == {"a": [{}], "b": 5}
+    assert _flatten_dict({"a": [{}, {}], "b": 5}) == {"a": [{}, {}], "b": 5}
+    assert _flatten_dict({"a": {}, "b": 5}) == {"a": {}, "b": 5}
+    assert _flatten_dict({"a": {"b": {}}}) == {"a/b": {}}
+    assert _flatten_dict({"a": Namespace()}) == {"a": {}}
+
     # Test flattening of argparse Namespace
     params = Namespace(a=1, b=2)
     wrapping_dict = {"params": params}

--- a/tests/tests_fabric/utilities/test_logger.py
+++ b/tests/tests_fabric/utilities/test_logger.py
@@ -70,6 +70,10 @@ def test_flatten_dict():
 
     assert params == {"dl/0/a": 1, "dl/0/c": 3, "dl/1/b": 2, "dl/1/d": 5, "l": [1, 2, 3, 4]}
 
+    # The list index has to use the requested delimiter too, not a hardcoded slash
+    assert _flatten_dict({"dl": [{"a": 1}]}, delimiter=".") == {"dl.0.a": 1}
+    assert _flatten_dict({"dl": [{"x": {"y": 1}}]}, delimiter="--") == {"dl--0--x--y": 1}
+
     # Test that values holding no leaves are preserved instead of being silently dropped
     assert _flatten_dict({"a": [], "b": 5}) == {"a": [], "b": 5}
     assert _flatten_dict({"a": [{}], "b": 5}) == {"a": [{}], "b": 5}


### PR DESCRIPTION
## What does this PR do?

`_flatten_dict` (in `src/lightning/fabric/utilities/logger.py`) is the shared helper every logger uses to flatten hyperparameters before logging. It silently drops any hyperparameter whose value holds no leaves.

Both recursive branches merge their result straight into `result`, so a value that flattens to nothing contributes no key at all:

```python
if isinstance(v, MutableMapping):
    result = {**result, **_flatten_dict(v, parent_key=new_key, delimiter=delimiter)}
# Also handle the case where v is a list of dictionaries
elif isinstance(v, list) and all(isinstance(item, MutableMapping) for item in v):
    for i, item in enumerate(v):
        result = {**result, **_flatten_dict(item, parent_key=f"{new_key}/{i}", delimiter=delimiter)}
```

Three shapes hit that on `master`:

```python
>>> _flatten_dict({"a": [], "b": 5})        # all() is vacuously True, loop runs zero times
{'b': 5}
>>> _flatten_dict({"a": [{}], "b": 5})      # each item flattens to {}
{'b': 5}
>>> _flatten_dict({"a": {}, "b": 5})        # the mapping branch recurses to {}
{'b': 5}
```

So a user who calls `save_hyperparameters()` with an empty-collection argument (for example `layers=[]` or `overrides={}`) has that hyperparameter disappear from the logged hparams, while the non-empty form of the very same argument is preserved.

## Fix

Flatten into a local dict first, and fall back to the original value when the recursion produced no leaves. One guard covers all three shapes:

```python
if isinstance(v, MutableMapping):
    flat = _flatten_dict(v, parent_key=new_key, delimiter=delimiter)
# Also handle the case where v is a list of dictionaries
elif isinstance(v, list) and all(isinstance(item, MutableMapping) for item in v):
    flat = {}
    for i, item in enumerate(v):
        flat.update(_flatten_dict(item, parent_key=f"{new_key}/{i}", delimiter=delimiter))
else:
    result[new_key] = v
    continue

result.update(flat or {new_key: v})
```

```
{"a": [],       "b": 5} -> {'a': [],       'b': 5}
{"a": [{}],     "b": 5} -> {'a': [{}],     'b': 5}
{"a": [{}, {}], "b": 5} -> {'a': [{}, {}], 'b': 5}
{"a": {},       "b": 5} -> {'a': {},       'b': 5}
{"a": {"b": {}}}        -> {'a/b': {}}
```

Every existing case is unchanged: non-empty lists of dicts still expand, plain lists such as `[1, 2, 3, 4]` are still kept as-is, and the nested / dataclass / `Namespace` paths flatten identically.

Keeping a container as a leaf is safe at both call sites: `TensorBoardLogger` passes the result through `_sanitize_params`, which stringifies anything that is not `bool/int/float/str/Tensor`, and `MLFlowLogger` does `str(v)[:250]`.

A mixed list such as `{"a": [{"x": 1}, {}]}` is left as-is, it still yields `{'a/0/x': 1}` with no `a/1` key. That value does produce leaves, so the hyperparameter is still represented in the log, and synthesising a per-item entry is a separate change from the drop fixed here.

## Testing

Extended `test_flatten_dict` with the empty-list, list-of-empty-dicts, empty-mapping, nested-empty-mapping and empty-`Namespace` cases, and added matching doctests. The new cases fail on `master` (keys dropped) and pass with the fix.
