### PR TITLE
fix(checkpoint): prevent arbitrary code execution via `_instantiator` in `load_from_checkpoint`

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -44,6 +44,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `LightningModule.toggle_optimizer` / `untoggle_optimizer` breaking under `torch.compile` by disabling Dynamo tracing on these bookkeeping helpers ([#21513](https://github.com/Lightning-AI/pytorch-lightning/issues/21513))
 
+- Fixed arbitrary code execution in `load_from_checkpoint` by restricting the `_instantiator` hyperparameter to an allowlist of trusted instantiators ([#21832](https://github.com/Lightning-AI/pytorch-lightning/pull/21832))
+
 ---
 
 ## [2.6.4] - 2026-05-20

--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -49,6 +49,12 @@ log = logging.getLogger(__name__)
 # the older shall be on the top
 CHECKPOINT_PAST_HPARAMS_KEYS = ("hparams", "module_arguments")  # used in 0.7.6
 
+# instantiator import paths trusted to resolve from a checkpoint, to prevent code execution (#21822)
+_ALLOWED_INSTANTIATORS = {
+    "lightning.pytorch.cli.instantiate_module",
+    "pytorch_lightning.cli.instantiate_module",
+}
+
 
 def _load_from_checkpoint(
     cls: Union[type["pl.LightningModule"], type["pl.LightningDataModule"]],
@@ -156,7 +162,12 @@ def _load_state(
     instantiator = None
     instantiator_path = _cls_kwargs.pop("_instantiator", None)
     if instantiator_path is not None:
-        # import custom instantiator
+        if instantiator_path not in _ALLOWED_INSTANTIATORS:
+            raise ValueError(
+                f"The instantiator {instantiator_path!r} from the checkpoint is not in the allowlist of trusted"
+                " instantiators and was blocked to prevent arbitrary code execution. If you trust this checkpoint,"
+                " add the path to `lightning.pytorch.core.saving._ALLOWED_INSTANTIATORS` before loading."
+            )
         module_path, name = instantiator_path.rsplit(".", 1)
         instantiator = getattr(__import__(module_path, fromlist=[name]), name)
 

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -154,3 +154,38 @@ def test_load_from_checkpoint_strict(strict, strict_loading, expected, tmp_path)
     else:
         model = LoadingModel.load_from_checkpoint(tmp_path / "checkpoint.ckpt", strict=strict)
         model.load_state_dict.assert_called_once_with(ANY, strict=expected)
+
+
+def test_load_from_checkpoint_blocks_untrusted_instantiator(tmp_path):
+    """A checkpoint pointing ``_instantiator`` at an arbitrary import target must be rejected, not executed."""
+    checkpoint = {
+        "state_dict": {},
+        "hyper_parameters": {"_instantiator": "os.system"},
+        "pytorch-lightning_version": pl.__version__,
+    }
+    ckpt_path = tmp_path / "malicious.ckpt"
+    torch.save(checkpoint, ckpt_path)
+
+    with pytest.raises(ValueError, match="not in the allowlist of trusted instantiators"):
+        BoringModel.load_from_checkpoint(ckpt_path, strict=False)
+
+
+def test_load_from_checkpoint_allows_lightning_instantiator(tmp_path, monkeypatch):
+    """An allowlisted instantiator is still resolved and used to build the model."""
+    import lightning.pytorch.cli as cli
+
+    instantiator = Mock(side_effect=lambda cls, kwargs: cls())
+    monkeypatch.setattr(cli, "instantiate_module", instantiator)
+
+    checkpoint = {
+        "state_dict": {},
+        "hyper_parameters": {"_instantiator": "lightning.pytorch.cli.instantiate_module"},
+        "pytorch-lightning_version": pl.__version__,
+    }
+    ckpt_path = tmp_path / "checkpoint.ckpt"
+    torch.save(checkpoint, ckpt_path)
+
+    # the allowlisted path resolves without raising and the instantiator is used to build the model
+    model = BoringModel.load_from_checkpoint(ckpt_path, strict=False)
+    assert isinstance(model, BoringModel)
+    instantiator.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Fixes #21822. 

A checkpoint's `_instantiator` hyperparameter was imported and called directly, allowing arbitrary code execution when loading an untrusted checkpoint — even under `torch.load(weights_only=True)`. 

This pr restricts `_instantiator` resolution to an allowlist of trusted instantiators, so legitimate CLI checkpoints keep working while malicious paths are rejected before any import happens.
