### PR TITLE
ci: add pytorch 2.12 and 2.13 to cpu tests

### DIFF
--- a/.github/workflows/ci-tests-fabric.yml
+++ b/.github/workflows/ci-tests-fabric.yml
@@ -40,6 +40,7 @@ jobs:
       matrix:
         os: [macOS-14, ubuntu-22.04, windows-2022]
         config:
+          # TODO: follow-up - prune the oldest PyTorch minors (2.1-2.5) now that we test up to 2.13
           # Test unified "lightning" package with PyTorch 2.1-2.5
           - { pkg-name: "lightning", python-version: "3.10", pytorch-version: "2.1" }
           - { pkg-name: "lightning", python-version: "3.11", pytorch-version: "2.2.2" }
@@ -47,17 +48,21 @@ jobs:
           - { pkg-name: "lightning", python-version: "3.12.7", pytorch-version: "2.4.1" }
           - { pkg-name: "lightning", python-version: "3.12.7", pytorch-version: "2.5.1" }
 
-          # Test "fabric" package with PyTorch 2.6-2.11
+          # Test "fabric" package with PyTorch 2.6-2.13
           - { pkg-name: "fabric", python-version: "3.12.7", pytorch-version: "2.6" }
           - { pkg-name: "fabric", python-version: "3.12", pytorch-version: "2.7" }
           - { pkg-name: "fabric", python-version: "3.12", pytorch-version: "2.8" }
           - { pkg-name: "fabric", python-version: "3.12", pytorch-version: "2.9" }
           - { pkg-name: "fabric", python-version: "3.12", pytorch-version: "2.10" }
           - { pkg-name: "fabric", python-version: "3.12", pytorch-version: "2.11" }
+          - { pkg-name: "fabric", python-version: "3.12", pytorch-version: "2.12" }
+          - { pkg-name: "fabric", python-version: "3.12", pytorch-version: "2.13" }
           - { pkg-name: "fabric", python-version: "3.13", pytorch-version: "2.8" }
           - { pkg-name: "fabric", python-version: "3.13", pytorch-version: "2.9" }
           - { pkg-name: "fabric", python-version: "3.13", pytorch-version: "2.10" }
           - { pkg-name: "fabric", python-version: "3.13", pytorch-version: "2.11" }
+          - { pkg-name: "fabric", python-version: "3.13", pytorch-version: "2.12" }
+          - { pkg-name: "fabric", python-version: "3.13", pytorch-version: "2.13" }
 
           # Test minimum supported versions (oldest)
           - { pkg-name: "fabric", pytorch-version: "2.1", requires: "oldest" }

--- a/.github/workflows/ci-tests-pytorch.yml
+++ b/.github/workflows/ci-tests-pytorch.yml
@@ -44,6 +44,7 @@ jobs:
       matrix:
         os: [macOS-14, ubuntu-22.04, windows-2022]
         config:
+          # TODO: follow-up - prune the oldest PyTorch minors (2.1-2.5) now that we test up to 2.13
           # Test unified "lightning" package with PyTorch 2.1-2.5
           - { pkg-name: "lightning", python-version: "3.10", pytorch-version: "2.1" }
           - { pkg-name: "lightning", python-version: "3.11", pytorch-version: "2.2.2" }
@@ -51,17 +52,21 @@ jobs:
           - { pkg-name: "lightning", python-version: "3.12.7", pytorch-version: "2.4.1" }
           - { pkg-name: "lightning", python-version: "3.12.7", pytorch-version: "2.5.1" }
 
-          # Test "pytorch" package with PyTorch 2.6-2.11
+          # Test "pytorch" package with PyTorch 2.6-2.13
           - { pkg-name: "pytorch", python-version: "3.12.7", pytorch-version: "2.6" }
           - { pkg-name: "pytorch", python-version: "3.12", pytorch-version: "2.7" }
           - { pkg-name: "pytorch", python-version: "3.12", pytorch-version: "2.8" }
           - { pkg-name: "pytorch", python-version: "3.12", pytorch-version: "2.9" }
           - { pkg-name: "pytorch", python-version: "3.12", pytorch-version: "2.10" }
           - { pkg-name: "pytorch", python-version: "3.12", pytorch-version: "2.11" }
+          - { pkg-name: "pytorch", python-version: "3.12", pytorch-version: "2.12" }
+          - { pkg-name: "pytorch", python-version: "3.12", pytorch-version: "2.13" }
           - { pkg-name: "pytorch", python-version: "3.13", pytorch-version: "2.8" }
           - { pkg-name: "pytorch", python-version: "3.13", pytorch-version: "2.9" }
           - { pkg-name: "pytorch", python-version: "3.13", pytorch-version: "2.10" }
           - { pkg-name: "pytorch", python-version: "3.13", pytorch-version: "2.11" }
+          - { pkg-name: "pytorch", python-version: "3.13", pytorch-version: "2.12" }
+          - { pkg-name: "pytorch", python-version: "3.13", pytorch-version: "2.13" }
 
           # Test minimum supported versions (oldest)
           - { pkg-name: "pytorch", pytorch-version: "2.1", requires: "oldest" }

--- a/tests/tests_fabric/utilities/test_distributed.py
+++ b/tests/tests_fabric/utilities/test_distributed.py
@@ -247,13 +247,9 @@ def test_init_dist_connection_registers_destruction_handler(_, atexit_mock):
 
 def test_get_default_process_group_backend_for_device(monkeypatch):
     """Test that each device type maps to its correct default process group backend."""
-    # register a custom backend for the test WITHOUT mutating global torch state:
-    # `rename_privateuse1_backend` is process-global and irreversible, so doing it here
-    # leaks a dangling "pcu" device into every subsequent test in the same worker, which
-    # breaks tensor-moving code paths on newer PyTorch. Patch the map instead.
-    backend_map = dict(torch.distributed.Backend.default_device_backend_map)
-    backend_map["pcu"] = "pccl"
-    monkeypatch.setattr(torch.distributed.Backend, "default_device_backend_map", backend_map)
+    # patch the map instead of registering a real backend: `rename_privateuse1_backend` is irreversible
+    # and would leak a dangling "pcu" device into subsequent tests
+    monkeypatch.setitem(torch.distributed.Backend.default_device_backend_map, "pcu", "pccl")
 
     # test that the default backend is correctly set for each device
     devices = [torch.device("cpu"), torch.device("cuda:0"), Mock(type="pcu")]

--- a/tests/tests_fabric/utilities/test_distributed.py
+++ b/tests/tests_fabric/utilities/test_distributed.py
@@ -245,22 +245,18 @@ def test_init_dist_connection_registers_destruction_handler(_, atexit_mock):
     atexit_mock.register.assert_not_called()
 
 
-def test_get_default_process_group_backend_for_device():
+def test_get_default_process_group_backend_for_device(monkeypatch):
     """Test that each device type maps to its correct default process group backend."""
-    # register a custom backend for test
-    torch.utils.rename_privateuse1_backend("pcu")
-
-    def mock_backend(store, group_rank, group_size, timeout):
-        pass
-
-    torch.distributed.Backend.register_backend(
-        "pccl",
-        lambda store, group_rank, group_size, timeout: mock_backend(store, group_rank, group_size, timeout),
-        devices=["pcu"],
-    )
+    # register a custom backend for the test WITHOUT mutating global torch state:
+    # `rename_privateuse1_backend` is process-global and irreversible, so doing it here
+    # leaks a dangling "pcu" device into every subsequent test in the same worker, which
+    # breaks tensor-moving code paths on newer PyTorch. Patch the map instead.
+    backend_map = dict(torch.distributed.Backend.default_device_backend_map)
+    backend_map["pcu"] = "pccl"
+    monkeypatch.setattr(torch.distributed.Backend, "default_device_backend_map", backend_map)
 
     # test that the default backend is correctly set for each device
-    devices = [torch.device("cpu"), torch.device("cuda:0"), torch.device("pcu:0")]
+    devices = [torch.device("cpu"), torch.device("cuda:0"), Mock(type="pcu")]
     backends = ["gloo", "nccl", "pccl"]
     for device, backend in zip(devices, backends):
         assert _get_default_process_group_backend_for_device(device) == backend


### PR DESCRIPTION
## What does this PR do?

Adds PyTorch 2.12 and 2.13 to the CPU test matrices for `fabric` and `pytorch`, on Python 3.12 and 3.13 — extending what #21679 did for 2.11.

One test needed fixing to pass on the new versions — `test_get_default_process_group_backend_for_device`:

- **Cause:** it called `torch.utils.rename_privateuse1_backend("pcu")`, which is process-global and irreversible, leaking a dangling `pcu` device into every later test in the same xdist worker.
- **Why it only shows up now:** on 2.12/2.13 the tensor-moving paths consult the privateuse1 backend, so unrelated CPU-only tests started failing with `RuntimeError: Device 'pcu' does not have a corresponding module registered as 'torch.pcu'`.
- **Fix:** used `monkeypatch.setitem` on `Backend.default_device_backend_map` instead, which has no global side effects.

The other blocker here was `torch.compile` + `self.log()` crashing on 2.12/2.13; that was split out and merged separately in #21837.

## Follow-up

Both matrices now carry a `TODO` about pruning the oldest minors (2.1–2.5), best done in its own PR.
