### PR TITLE
Disable compile tracing at the LightningModule.log boundary

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `torch.compile`d `LightningModule` crashing on `self.log()` with PyTorch 2.12/2.13 by disabling compile tracing at the `LightningModule.log` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
+
 - Fixed PyTorch Lightning profiler not capturing dataloader worker initialization time ([#21771](https://github.com/Lightning-AI/pytorch-lightning/issues/21771))
 
 - Fixed `FSDPStrategy` raising `RuntimeError` under PyTorch 2.5+ when `root_device` is CPU, by passing an explicit `torch.device("cpu")` instead of `device_id=None` (relevant only when the GPU-accelerator guard is bypassed) ([#21774](https://github.com/Lightning-AI/pytorch-lightning/pull/21774))

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed `torch.compile`d `LightningModule` crashing on `self.log()` with PyTorch 2.12/2.13 by disabling compile tracing at the `LightningModule.log` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
+- Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
 
 - Fixed PyTorch Lightning profiler not capturing dataloader worker initialization time ([#21771](https://github.com/Lightning-AI/pytorch-lightning/issues/21771))
 

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -410,11 +410,10 @@ class LightningModule(
         The default behavior per hook is documented here: :ref:`extensions/logging:Automatic Logging`.
 
         .. note::
-            This method is decorated with :func:`torch.compiler.disable` so that it runs as regular Python when
-            called from a :func:`torch.compile`-wrapped ``training_step``. Logging is bookkeeping that does not
-            belong in the compiled graph, and tracing it fails on newer PyTorch versions (the signature
-            introspection it performs is not supported by Dynamo). Disabling the compiler keeps behavior identical
-            for eager users.
+            This method is decorated with :func:`torch.compiler.disable` so that it is executed as regular
+            Python when the ``LightningModule`` is wrapped with :func:`torch.compile`. Logging is bookkeeping
+            that does not belong in the compiled graph, and tracing the signature introspection it performs
+            fails under Dynamo on newer PyTorch versions. Disabling the compiler leaves eager behavior unchanged.
 
         Args:
             name: key to log. Must be identical across all processes if using DDP or any other distributed strategy.

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -383,6 +383,7 @@ class LightningModule(
             else:
                 print(*args, **kwargs)
 
+    @torch.compiler.disable
     def log(
         self,
         name: str,
@@ -407,6 +408,13 @@ class LightningModule(
             self.log('train_loss', loss)
 
         The default behavior per hook is documented here: :ref:`extensions/logging:Automatic Logging`.
+
+        .. note::
+            This method is decorated with :func:`torch.compiler.disable` so that it runs as regular Python when
+            called from a :func:`torch.compile`-wrapped ``training_step``. Logging is bookkeeping that does not
+            belong in the compiled graph, and tracing it fails on newer PyTorch versions (the signature
+            introspection it performs is not supported by Dynamo). Disabling the compiler keeps behavior identical
+            for eager users.
 
         Args:
             name: key to log. Must be identical across all processes if using DDP or any other distributed strategy.


### PR DESCRIPTION
## What does this PR do?

Fixes #21836

A `torch.compile`d `LightningModule` that calls `self.log()` in `training_step` crashes on PyTorch 2.12/2.13:

```
torch._dynamo.exc.InternalTorchDynamoError: AttributeError: 'method' object has no attribute '__dict__'
```

`self.log()` inspects the step signature with `inspect.getfullargspec` (via `is_param_in_hook_signature`). 

PyTorch 2.12 started inlining that call into the graph, and Dynamo fails to trace it on a bound method. Older versions graph-broke on `inspect` and ran it eagerly, so it never surfaced.

Logging is eager-only bookkeeping, so this pr decorates `LightningModule.log` with `@torch.compiler.disable`, the same approach already used for `_ResultCollection.log` and `toggle_optimizer`. Eager behavior is unchanged.

This unblocks #21835, which adds PyTorch 2.12/2.13 to CI and currently fails on `test_trainer_compiled_model_that_logs`.

## Notes

- Upstream created bug over PyTorch: pytorch/pytorch#190171
- Failing CI run: [test_trainer_compiled_model_that_logs (2.12 job)](https://github.com/Lightning-AI/pytorch-lightning/actions/runs/29397385484/job/87294150264)