### PR TITLE
docs: clarify sync_dist warning is a false positive for TorchMetrics-derived values

### DIFF
--- a/docs/source-pytorch/accelerators/accelerator_prepare.rst
+++ b/docs/source-pytorch/accelerators/accelerator_prepare.rst
@@ -154,6 +154,21 @@ needed; the metric synchronizes itself when it is logged.
 
 This is the recommended option for any classification, retrieval, or ranking metric.
 
+.. note::
+    Lightning only recognizes a value as "already synced by TorchMetrics" when the
+    :class:`~torchmetrics.Metric` object itself is passed to ``self.log``, as in the example
+    above. If you instead call ``.compute()`` yourself — for example to pick one entry out of a
+    ``MetricCollection`` dict, or to call ``.item()`` on the result — you pass a plain tensor or
+    float, which Lightning cannot tell apart from any other logged value. You will still see the
+    ``It is recommended to use self.log(..., sync_dist=True)`` warning in that case, even though
+    ``.compute()`` already performed TorchMetrics' own distributed reduction and the value is
+    already identical, and correct, on every rank. The warning is a known false positive here:
+    it is safe to ignore. Adding ``sync_dist=True`` is **not** required to fix it — since the
+    value is already the same on every rank, Lightning's own mean-reduce across ranks just
+    reproduces that value at the cost of extra communication. Prefer logging the metric object
+    directly whenever possible so Lightning can detect this automatically; if you must log a
+    derived value, ignoring the warning is the correct response, not adding ``sync_dist=True``.
+
 .. _manual-all-gather:
 
 Manual ``all_gather``
@@ -228,6 +243,11 @@ Common pitfalls
   rank. Put the guard around ``self.log``, not around the gather.
 - **Passing** ``rank_zero_only=True`` **to** ``self.log`` **without synchronizing first.** Rank 0
   logs its local value only, which is the ``1 / world_size`` problem this section opens with.
+- **Reacting to the** ``sync_dist=True`` **warning by adding it, when logging a value derived
+  from TorchMetrics** (e.g. ``metric.compute().item()``, or one entry out of a
+  ``MetricCollection`` dict) **instead of the metric object.** The warning fires because
+  Lightning can't tell the value came from TorchMetrics, but the value is already correctly
+  synced. Ignore the warning, or log the metric object directly instead.
 
 See also: the `TorchMetrics distributed evaluation guide
 <https://lightning.ai/docs/torchmetrics/stable/pages/overview.html#metrics-and-distributed-training-ddp>`_


### PR DESCRIPTION
## What does this PR do?

Closes #20153

Clarifies the "Synchronize validation and test logging" section of
`docs/source-pytorch/accelerators/accelerator_prepare.rst` to explain a
specific case of confusion reported in the issue: users who log a value
*derived from* a TorchMetrics `Metric` (via `.compute()`, `.item()`, or by
pulling one entry out of a `MetricCollection` dict) still see Lightning's
"It is recommended to use `self.log(..., sync_dist=True)`" warning, even
though TorchMetrics already performed its own distributed reduction.

## Why

Reading `_ResultMetric` in
`src/lightning/pytorch/trainer/connectors/logger_connector/result.py`
confirms the mechanism: Lightning only recognizes a value as "already
synced by TorchMetrics" via `isinstance(value, Tensor)` — i.e. only when
the `Metric` object itself is passed to `self.log`. Passing anything else
(a `.compute()`/`.item()` result, or a dict entry) is indistinguishable
from a plain manually-tracked value, so the generic sync_dist warning
fires — this is a false positive in that case, not a bug in the warning
logic itself.

Several issue commenters (including a TorchMetrics/Lightning maintainer)
converged on this explanation over the course of the thread, but it wasn't
written down anywhere in the docs. This PR adds it in two places:

- A `.. note::` in the TorchMetrics subsection explaining the
  object-vs-derived-value distinction and why the warning is a false
  positive for derived values.
- A bullet in "Common pitfalls" so it's easy to find: don't react to the
  warning by adding `sync_dist=True` — since the derived value is already
  identical on every rank, Lightning's own mean-reduce just reproduces the
  same value at the cost of extra communication; the correct response is
  to ignore the warning (or, better, log the metric object directly so
  Lightning can detect it automatically).

## Files changed

- `docs/source-pytorch/accelerators/accelerator_prepare.rst` (docs only, no code changes)

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? — this PR *is* the documentation update.
- Did you write any **new necessary tests**? — not applicable, docs-only change.
- [x] Did you verify new and **existing tests pass** locally with your changes? — no code changed; no tests affected.
- Did you list all the **breaking changes** introduced by this pull request? — none.
- Did you **update the CHANGELOG**? — not required per CONTRIBUTING.md ("not for typos, docs, test updates, or minor internal changes").

</details>

> **Note:** Claude Code was used to assist in drafting this documentation change (including
> tracing the `_ResultMetric` sync logic in `result.py` to verify the technical claims above).
> The change was reviewed by the submitter before opening this PR.
