### PR TITLE
Fix ModelCheckpoint manual-opt pre-step snapshot not applied when save is deferred to validation

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -48,6 +48,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed arbitrary code execution in `load_from_checkpoint` by restricting the `_instantiator` hyperparameter to an allowlist of trusted instantiators ([#21832](https://github.com/Lightning-AI/pytorch-lightning/pull/21832))
 
+- Fixed `ModelCheckpoint` saving the live, post-optimization weights instead of the pre-optimization snapshot when manual optimization defers the save to `on_validation_end` (validation-only monitored metric) ([#21843](https://github.com/Lightning-AI/pytorch-lightning/pull/21843))
+
 ---
 
 ## [2.6.4] - 2026-05-20

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -336,6 +336,72 @@ class ModelCheckpoint(Checkpoint):
     def on_train_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
         self._last_time_checked = time.monotonic()
 
+    def _save_checkpoint_with_manual_opt_state(
+        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", monitor_candidates: dict[str, Tensor]
+    ) -> None:
+        """Save a checkpoint under manual optimization, using the pre-optimization-step model state captured in
+        ``training_step`` (via ``pl_module.saved_models``) if available, so the saved checkpoint reflects the state
+        that actually produced the monitored metric rather than the state after subsequent optimizer steps.
+
+        Shared between the immediate save path (``on_train_batch_end``, when the monitored metric is already
+        available) and the deferred save path (``on_validation_end``, when the monitored metric is validation-only
+        and only becomes available after ``training_step`` has already advanced past the step being saved).
+        """
+        if (
+            hasattr(pl_module, "saved_models")
+            and isinstance(pl_module.saved_models, dict)
+            and pl_module.saved_models
+            and hasattr(pl_module, "layer")
+            and isinstance(pl_module.layer, torch.nn.Module)
+        ):
+            saved_models = pl_module.saved_models
+            latest_step = max(saved_models.keys())
+            # Save the checkpoint with the pre-optimization state
+            with torch.no_grad():
+                # Save the current state
+                original_state = {k: v.detach().clone() for k, v in pl_module.layer.state_dict().items()}
+                try:
+                    # Restore the pre-optimization state
+                    saved_state = saved_models[latest_step]
+                    if not isinstance(saved_state, dict):
+                        raise TypeError("Saved model state must be a dictionary")
+
+                    pl_module.layer.load_state_dict(saved_state)
+                    # Save the checkpoint
+                    self._save_topk_checkpoint(trainer, monitor_candidates)
+                    self._save_last_checkpoint(trainer, monitor_candidates)
+                    self._last_time_checked = time.monotonic()
+                finally:
+                    # Restore the original state
+                    pl_module.layer.load_state_dict(original_state)
+        else:
+            # Fallback to default behavior if no saved state is available
+            if trainer.is_global_zero:
+                rank_zero_warn(
+                    "Using ModelCheckpoint with manual optimization and every_n_train_steps, but no "
+                    "pre-optimization state was saved. The checkpoint will contain the model state "
+                    "AFTER optimization. To save the pre-optimization state, save the model state in "
+                    "training_step before "
+                    "optimizer.step(). "
+                    "Example:\n"
+                    "def training_step(self, batch, batch_idx):\n"
+                    "    # ... forward pass, loss calculation, backward pass ...\n"
+                    "    # Save model state before optimization\n"
+                    "    if not hasattr(self, 'saved_models'):\n"
+                    "        self.saved_models = {}\n"
+                    "    self.saved_models[batch_idx] = {\n"
+                    "        k: v.detach().clone() for k, v in self.layer.state_dict().items()\n"
+                    "    }\n"
+                    "    # Then perform optimization\n"
+                    "    optimizer.zero_grad()\n"
+                    "    self.manual_backward(loss)\n"
+                    "    optimizer.step()",
+                    category=UserWarning,
+                )
+            self._save_topk_checkpoint(trainer, monitor_candidates)
+            self._save_last_checkpoint(trainer, monitor_candidates)
+            self._last_time_checked = time.monotonic()
+
     @override
     def on_train_batch_end(
         self,
@@ -362,66 +428,7 @@ class ModelCheckpoint(Checkpoint):
                 self._defer_save_until_validation = True
                 return
 
-            # For manual optimization, we save the model state that was captured in training_step
-            # before the optimizer step. The test case saves this state in model.saved_models.
-            if (
-                hasattr(pl_module, "saved_models")
-                and isinstance(pl_module.saved_models, dict)
-                and pl_module.saved_models
-                and hasattr(pl_module, "layer")
-                and isinstance(pl_module.layer, torch.nn.Module)
-            ):
-                # Get the latest saved state
-                saved_models = pl_module.saved_models
-                if not saved_models:  # Check if dictionary is not empty
-                    return
-
-                latest_step = max(saved_models.keys())
-                # Save the checkpoint with the pre-optimization state
-                with torch.no_grad():
-                    # Save the current state
-                    original_state = {k: v.detach().clone() for k, v in pl_module.layer.state_dict().items()}
-                    try:
-                        # Restore the pre-optimization state
-                        saved_state = saved_models[latest_step]
-                        if not isinstance(saved_state, dict):
-                            raise TypeError("Saved model state must be a dictionary")
-
-                        pl_module.layer.load_state_dict(saved_state)
-                        # Save the checkpoint
-                        self._save_topk_checkpoint(trainer, monitor_candidates)
-                        self._save_last_checkpoint(trainer, monitor_candidates)
-                        self._last_time_checked = time.monotonic()
-                    finally:
-                        # Restore the original state
-                        pl_module.layer.load_state_dict(original_state)
-            else:
-                # Fallback to default behavior if no saved state is available
-                if not pl_module.automatic_optimization and trainer.is_global_zero:
-                    rank_zero_warn(
-                        "Using ModelCheckpoint with manual optimization and every_n_train_steps, but no "
-                        "pre-optimization state was saved. The checkpoint will contain the model state "
-                        "AFTER optimization. To save the pre-optimization state, save the model state in "
-                        "training_step before "
-                        "optimizer.step(). "
-                        "Example:\n"
-                        "def training_step(self, batch, batch_idx):\n"
-                        "    # ... forward pass, loss calculation, backward pass ...\n"
-                        "    # Save model state before optimization\n"
-                        "    if not hasattr(self, 'saved_models'):\n"
-                        "        self.saved_models = {}\n"
-                        "    self.saved_models[batch_idx] = {\n"
-                        "        k: v.detach().clone() for k, v in self.layer.state_dict().items()\n"
-                        "    }\n"
-                        "    # Then perform optimization\n"
-                        "    optimizer.zero_grad()\n"
-                        "    self.manual_backward(loss)\n"
-                        "    optimizer.step()",
-                        category=UserWarning,
-                    )
-                self._save_topk_checkpoint(trainer, monitor_candidates)
-                self._save_last_checkpoint(trainer, monitor_candidates)
-                self._last_time_checked = time.monotonic()
+            self._save_checkpoint_with_manual_opt_state(trainer, pl_module, monitor_candidates)
             return
 
         # Original logic for automatic optimization
@@ -505,8 +512,14 @@ class ModelCheckpoint(Checkpoint):
             # If a step/time-triggered save was deferred due to a missing monitored metric,
             # perform the save now that validation metrics are available.
             if self._defer_save_until_validation:
-                self._save_topk_checkpoint(trainer, monitor_candidates)
-                self._save_last_checkpoint(trainer, monitor_candidates)
+                if not pl_module.automatic_optimization:
+                    # Use the same pre-optimization-state swap as the immediate save path in
+                    # on_train_batch_end, otherwise this would save the live, fully-trained weights
+                    # instead of the state that actually produced the monitored metric.
+                    self._save_checkpoint_with_manual_opt_state(trainer, pl_module, monitor_candidates)
+                else:
+                    self._save_topk_checkpoint(trainer, monitor_candidates)
+                    self._save_last_checkpoint(trainer, monitor_candidates)
                 self._defer_save_until_validation = False
                 return
 

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -346,6 +346,7 @@ class ModelCheckpoint(Checkpoint):
         Shared between the immediate save path (``on_train_batch_end``, when the monitored metric is already
         available) and the deferred save path (``on_validation_end``, when the monitored metric is validation-only
         and only becomes available after ``training_step`` has already advanced past the step being saved).
+
         """
         if (
             hasattr(pl_module, "saved_models")

--- a/tests/tests_pytorch/callbacks/test_model_checkpoint_manual_opt.py
+++ b/tests/tests_pytorch/callbacks/test_model_checkpoint_manual_opt.py
@@ -120,8 +120,8 @@ def test_model_checkpoint_manual_opt():
 
 
 class SimpleModuleValMonitor(LightningModule):
-    """Like SimpleModule, but the monitored metric is validation-only, so the save is deferred to
-    on_validation_end instead of being handled immediately in on_train_batch_end."""
+    """Like SimpleModule, but the monitored metric is validation-only, so the save is deferred to on_validation_end
+    instead of being handled immediately in on_train_batch_end."""
 
     def __init__(self):
         super().__init__()
@@ -154,9 +154,8 @@ class SimpleModuleValMonitor(LightningModule):
 
 
 def test_model_checkpoint_manual_opt_deferred_validation():
-    """The pre-optimization-step snapshot must also be used when the monitored metric is validation-only
-    and the save is deferred to on_validation_end, not just when it's handled immediately in
-    on_train_batch_end."""
+    """The pre-optimization-step snapshot must also be used when the monitored metric is validation-only and the save
+    is deferred to on_validation_end, not just when it's handled immediately in on_train_batch_end."""
     with cleanup_after_test(), tempfile.TemporaryDirectory() as tmpdir:
         dataset = FakeDataset()
         train_dataloader = DataLoader(dataset, batch_size=1)

--- a/tests/tests_pytorch/callbacks/test_model_checkpoint_manual_opt.py
+++ b/tests/tests_pytorch/callbacks/test_model_checkpoint_manual_opt.py
@@ -119,6 +119,91 @@ def test_model_checkpoint_manual_opt():
             )
 
 
+class SimpleModuleValMonitor(LightningModule):
+    """Like SimpleModule, but the monitored metric is validation-only, so the save is deferred to
+    on_validation_end instead of being handled immediately in on_train_batch_end."""
+
+    def __init__(self):
+        super().__init__()
+        self.layer = torch.nn.Linear(3, 1)
+        self.automatic_optimization = False
+        self.fake_val_losses = [
+            torch.tensor(1.0),
+            torch.tensor(1.0),
+            torch.tensor(0.0),
+            torch.tensor(1.0),
+        ]
+        self.saved_models = {}
+
+    def training_step(self, batch, batch_idx):
+        out = self.layer(batch[0])
+        loss = torch.nn.functional.binary_cross_entropy_with_logits(out, batch[1].float())
+        # Save model before optimization
+        save_model(self.layer, batch_idx, self.saved_models)
+        optimizer = self.optimizers()
+        optimizer.zero_grad()
+        self.manual_backward(loss)
+        optimizer.step()
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        self.log("val_loss", self.fake_val_losses[batch_idx], on_step=False, on_epoch=True, logger=True)
+
+    def configure_optimizers(self):
+        return torch.optim.SGD(self.parameters(), lr=0.01)
+
+
+def test_model_checkpoint_manual_opt_deferred_validation():
+    """The pre-optimization-step snapshot must also be used when the monitored metric is validation-only
+    and the save is deferred to on_validation_end, not just when it's handled immediately in
+    on_train_batch_end."""
+    with cleanup_after_test(), tempfile.TemporaryDirectory() as tmpdir:
+        dataset = FakeDataset()
+        train_dataloader = DataLoader(dataset, batch_size=1)
+        val_dataloader = DataLoader(dataset, batch_size=1)
+        model = SimpleModuleValMonitor()
+        trainer = Trainer(
+            max_epochs=1,
+            callbacks=[
+                ModelCheckpoint(
+                    save_top_k=1,
+                    monitor="val_loss",
+                    dirpath=tmpdir,
+                    mode="min",
+                    save_last=False,
+                    every_n_train_steps=1,
+                    train_time_interval=None,
+                    every_n_epochs=0,
+                    save_on_train_epoch_end=False,
+                    save_weights_only=True,
+                )
+            ],
+            num_sanity_val_steps=0,
+            logger=False,  # Disable logging to prevent creating lightning_logs
+        )
+        try:
+            trainer.fit(model, train_dataloader, val_dataloader)
+        finally:
+            trainer._teardown()
+
+        best_ckpt_path = trainer.checkpoint_callback.best_model_path
+        best_ckpt = torch.load(best_ckpt_path, weights_only=True)["state_dict"]
+
+        # The checkpoint must match one of the pre-optimization snapshots captured during training_step,
+        # never the live, fully-trained, post-optimization weights.
+        live_weights = model.layer.cpu().state_dict()
+        matches_live = all(
+            torch.equal(live_weights[name.removeprefix("layer.")], value) for name, value in best_ckpt.items()
+        )
+        assert not matches_live, "Checkpoint saved the live, post-optimization weights instead of a pre-opt snapshot"
+
+        matches_any_snapshot = any(
+            all(torch.equal(snapshot[name.removeprefix("layer.")], value) for name, value in best_ckpt.items())
+            for snapshot in model.saved_models.values()
+        )
+        assert matches_any_snapshot, "Checkpoint doesn't match any pre-optimization snapshot"
+
+
 def test_model_checkpoint_manual_opt_warning():
     """Test that a warning is raised when using manual optimization without saving the state."""
 


### PR DESCRIPTION
Fixes #21842.

## What does this PR do?

`ModelCheckpoint`'s manual-optimization support (added in #21239 for #20947) saves the pre-optimization-step model state captured in `pl_module.saved_models`, so the checkpoint reflects the state that actually produced the monitored metric rather than whatever the weights happen to be after later `optimizer.step()` calls.

That swap only happened in `on_train_batch_end`, the immediate-save path. When the monitored metric is validation-only (`monitor="val_loss"` and similar, the common case for this feature since manual-optimization training loops rarely log training-time metrics they'd want to checkpoint on), the save gets deferred to `on_validation_end` instead, via `_defer_save_until_validation`. That deferred path saved with no swap at all, dumping the live, fully-trained, post-optimization weights, silently defeating the entire point of the feature for its most common use case.

This is a regression of #20947, reintroduced by #21239's own fix, since that PR's test only monitors a training-step metric (`monitor="loss"`), which is always available in `on_train_batch_end` and therefore never exercises the `_defer_save_until_validation` branch.

## Fix

Extracted the swap-save-restore logic (previously inline in `on_train_batch_end`) into `_save_checkpoint_with_manual_opt_state`, called from both `on_train_batch_end` and `on_validation_end`'s deferred branch, so the two call sites can't diverge again. `on_validation_end` only takes this path when `not pl_module.automatic_optimization`, automatic-optimization checkpointing is untouched since the live weights are already the correct state to save there.

## Testing

Added `test_model_checkpoint_manual_opt_deferred_validation` in `tests/tests_pytorch/callbacks/test_model_checkpoint_manual_opt.py`, right next to the existing `test_model_checkpoint_manual_opt`. It monitors `val_loss` (validation-only) instead of `loss` (training-step), so it exercises the previously-broken deferred path.

Confirmed red/green:
- Against the pre-fix code: **fails** with `AssertionError: Checkpoint saved the live, post-optimization weights instead of a pre-opt snapshot`.
- Against the fix: **passes**.

Ran the full manual-opt and step-interval-val-metric suites plus the broader `ModelCheckpoint` test files:
```
tests/tests_pytorch/callbacks/test_model_checkpoint_manual_opt.py: 3 passed
tests/tests_pytorch/callbacks/test_model_checkpoint_step_interval_val_metric.py: 1 passed
tests/tests_pytorch/checkpointing/test_model_checkpoint.py
tests/tests_pytorch/callbacks/test_model_checkpoint_additional_cases.py
tests/tests_pytorch/callbacks/test_model_checkpoint_edge_cases.py: 135 passed, 2 skipped
```
The remaining 7 failures in the broader run (`test_model_checkpoint_path`, `test_model_checkpoint_save_last[link]`, `test_model_checkpoint_link_checkpoint*`, `test_checkpoint_repeated_strategy_extended`) are pre-existing environment issues in my local setup (missing `tensorboard`/`tensorboardX`, and Windows without symlink privileges for the `save_last="link"` tests), confirmed by reproducing the exact same failures against unpatched `master` before making any change.
