### PR TITLE
Add enable_device_summary flag to Trainer

### DIFF
--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -116,6 +116,7 @@ class Trainer:
         enable_checkpointing: Optional[bool] = None,
         enable_progress_bar: Optional[bool] = None,
         enable_model_summary: Optional[bool] = None,
+        enable_device_summary: bool = True,
         accumulate_grad_batches: int = 1,
         gradient_clip_val: Optional[Union[int, float]] = None,
         gradient_clip_algorithm: Optional[str] = None,
@@ -237,6 +238,9 @@ class Trainer:
                 Default: ``True``.
 
             enable_model_summary: Whether to enable model summarization by default.
+                Default: ``True``.
+
+            enable_device_summary: Whether to print device summary.
                 Default: ``True``.
 
             accumulate_grad_batches: Accumulates gradients over k batches before stepping the optimizer.
@@ -491,7 +495,9 @@ class Trainer:
             )
         self._detect_anomaly: bool = detect_anomaly
 
-        setup._log_device_info(self)
+        self.enable_device_summary = enable_device_summary
+        if self.enable_device_summary:
+            setup._log_device_info(self)
 
         self.should_stop = False
         self.state = TrainerState()


### PR DESCRIPTION
Fixes #13378. Added `enable_device_summary` to `Trainer.__init__` to allow users to disable the device printout during initialization, which is useful when calling predict in a loop.

Signed-off-by: Kartavya Dikshit <kartavyaniraj.dikshit2021@vitstudent.ac.in>