### PR TITLE
Adopt typing_extensions.override across codebase (#18695)

### DIFF
--- a/src/lightning/fabric/_graveyard/tpu.py
+++ b/src/lightning/fabric/_graveyard/tpu.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import sys
 from typing import Any
+
+from typing_extensions import override
 
 import lightning.fabric as fabric
 from lightning.fabric.accelerators import XLAAccelerator

--- a/src/lightning/fabric/_graveyard/tpu.py
+++ b/src/lightning/fabric/_graveyard/tpu.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import sys
 from typing import Any
 
@@ -43,6 +44,7 @@ class SingleTPUStrategy(SingleDeviceXLAStrategy):
         super().__init__(*args, **kwargs)
 
     @classmethod
+    @override
     def register_strategies(cls, strategy_registry: _StrategyRegistry) -> None:
         if "single_tpu" not in strategy_registry:
             strategy_registry.register("single_tpu", cls, description="Legacy class. Use `single_xla` instead.")

--- a/src/lightning/fabric/accelerators/registry.py
+++ b/src/lightning/fabric/accelerators/registry.py
@@ -111,6 +111,7 @@ class _AcceleratorRegistry(dict):
         """Returns a set of registered accelerators."""
         return set(self.keys())
 
+    @override
     def __str__(self) -> str:
         return "Registered Accelerators: {}".format(", ".join(self.available_accelerators()))
 

--- a/src/lightning/fabric/loggers/csv_logs.py
+++ b/src/lightning/fabric/loggers/csv_logs.py
@@ -76,8 +76,8 @@ class CSVLogger(Logger):
         self._experiment: Optional[_ExperimentWriter] = None
         self._flush_logs_every_n_steps = flush_logs_every_n_steps
 
-    @property
     @override
+    @property
     def name(self) -> str:
         """Gets the name of the experiment.
 
@@ -87,8 +87,8 @@ class CSVLogger(Logger):
         """
         return self._name
 
-    @property
     @override
+    @property
     def version(self) -> Union[int, str]:
         """Gets the version of the experiment.
 
@@ -100,14 +100,14 @@ class CSVLogger(Logger):
             self._version = self._get_next_version()
         return self._version
 
-    @property
     @override
+    @property
     def root_dir(self) -> str:
         """Gets the save directory where the versioned CSV experiments are saved."""
         return self._root_dir
 
-    @property
     @override
+    @property
     def log_dir(self) -> str:
         """The log directory for this run.
 

--- a/src/lightning/fabric/loggers/tensorboard.py
+++ b/src/lightning/fabric/loggers/tensorboard.py
@@ -108,8 +108,8 @@ class TensorBoardLogger(Logger):
         self._experiment: Optional[SummaryWriter] = None
         self._kwargs = kwargs
 
-    @property
     @override
+    @property
     def name(self) -> str:
         """Get the name of the experiment.
 
@@ -119,8 +119,8 @@ class TensorBoardLogger(Logger):
         """
         return self._name
 
-    @property
     @override
+    @property
     def version(self) -> Union[int, str]:
         """Get the experiment version.
 
@@ -132,8 +132,8 @@ class TensorBoardLogger(Logger):
             self._version = self._get_next_version()
         return self._version
 
-    @property
     @override
+    @property
     def root_dir(self) -> str:
         """Gets the save directory where the TensorBoard experiments are saved.
 
@@ -143,8 +143,8 @@ class TensorBoardLogger(Logger):
         """
         return self._root_dir
 
-    @property
     @override
+    @property
     def log_dir(self) -> str:
         """The directory for this run's tensorboard checkpoint.
 
@@ -328,6 +328,7 @@ class TensorBoardLogger(Logger):
         # logging of arrays with dimension > 1 is not supported, sanitize as string
         return {k: str(v) if hasattr(v, "ndim") and v.ndim > 1 else v for k, v in params.items()}
 
+    @override
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
         state["_experiment"] = None

--- a/src/lightning/fabric/plugins/collectives/single_device.py
+++ b/src/lightning/fabric/plugins/collectives/single_device.py
@@ -14,13 +14,13 @@ class SingleDeviceCollective(Collective):
 
     """
 
-    @property
     @override
+    @property
     def rank(self) -> int:
         return 0
 
-    @property
     @override
+    @property
     def world_size(self) -> int:
         return 1
 

--- a/src/lightning/fabric/plugins/collectives/torch_collective.py
+++ b/src/lightning/fabric/plugins/collectives/torch_collective.py
@@ -32,21 +32,21 @@ class TorchCollective(Collective):
             raise RuntimeError("Torch distributed is not available.")
         super().__init__()
 
-    @property
     @override
+    @property
     def group(self) -> CollectibleGroup:
         if self._group is None:
             self._group = dist.GroupMember.WORLD
         return super().group
 
-    @property
     @override
+    @property
     def rank(self) -> int:
         # local rank
         return dist.get_rank(self.group)  # type: ignore[arg-type]
 
-    @property
     @override
+    @property
     def world_size(self) -> int:
         return dist.get_world_size(self.group)  # type: ignore[arg-type]
 

--- a/src/lightning/fabric/plugins/environments/kubeflow.py
+++ b/src/lightning/fabric/plugins/environments/kubeflow.py
@@ -33,18 +33,18 @@ class KubeflowEnvironment(ClusterEnvironment):
 
     """
 
-    @property
     @override
+    @property
     def creates_processes_externally(self) -> bool:
         return True
 
-    @property
     @override
+    @property
     def main_address(self) -> str:
         return os.environ["MASTER_ADDR"]
 
-    @property
     @override
+    @property
     def main_port(self) -> int:
         return int(os.environ["MASTER_PORT"])
 

--- a/src/lightning/fabric/plugins/environments/lightning.py
+++ b/src/lightning/fabric/plugins/environments/lightning.py
@@ -43,8 +43,8 @@ class LightningEnvironment(ClusterEnvironment):
         self._global_rank: int = 0
         self._world_size: int = 1
 
-    @property
     @override
+    @property
     def creates_processes_externally(self) -> bool:
         """Returns whether the cluster creates the processes or not.
 
@@ -54,13 +54,13 @@ class LightningEnvironment(ClusterEnvironment):
         """
         return "LOCAL_RANK" in os.environ
 
-    @property
     @override
+    @property
     def main_address(self) -> str:
         return os.environ.get("MASTER_ADDR", "127.0.0.1")
 
-    @property
     @override
+    @property
     def main_port(self) -> int:
         if self._main_port == -1:
             self._main_port = (

--- a/src/lightning/fabric/plugins/environments/lsf.py
+++ b/src/lightning/fabric/plugins/environments/lsf.py
@@ -62,21 +62,21 @@ class LSFEnvironment(ClusterEnvironment):
         os.environ["MASTER_PORT"] = str(self._main_port)
         log.debug(f"MASTER_PORT: {os.environ['MASTER_PORT']}")
 
-    @property
     @override
+    @property
     def creates_processes_externally(self) -> bool:
         """LSF creates subprocesses, i.e., PyTorch Lightning does not need to spawn them."""
         return True
 
-    @property
     @override
+    @property
     def main_address(self) -> str:
         """The main address is read from an OpenMPI host rank file in the environment variable
         ``LSB_DJOB_RANKFILE``."""
         return self._main_address
 
-    @property
     @override
+    @property
     def main_port(self) -> int:
         """The main port is calculated from the LSF job ID."""
         return self._main_port

--- a/src/lightning/fabric/plugins/environments/mpi.py
+++ b/src/lightning/fabric/plugins/environments/mpi.py
@@ -47,20 +47,20 @@ class MPIEnvironment(ClusterEnvironment):
         self._main_address: Optional[str] = None
         self._main_port: Optional[int] = None
 
-    @property
     @override
+    @property
     def creates_processes_externally(self) -> bool:
         return True
 
-    @property
     @override
+    @property
     def main_address(self) -> str:
         if self._main_address is None:
             self._main_address = self._get_main_address()
         return self._main_address
 
-    @property
     @override
+    @property
     def main_port(self) -> int:
         if self._main_port is None:
             self._main_port = self._get_main_port()

--- a/src/lightning/fabric/plugins/environments/slurm.py
+++ b/src/lightning/fabric/plugins/environments/slurm.py
@@ -53,13 +53,13 @@ class SLURMEnvironment(ClusterEnvironment):
         self._validate_srun_used()
         self._validate_srun_variables()
 
-    @property
     @override
+    @property
     def creates_processes_externally(self) -> bool:
         return True
 
-    @property
     @override
+    @property
     def main_address(self) -> str:
         root_node = os.environ.get("MASTER_ADDR")
         if root_node is None:
@@ -70,8 +70,8 @@ class SLURMEnvironment(ClusterEnvironment):
         log.debug(f"MASTER_ADDR: {os.environ['MASTER_ADDR']}")
         return root_node
 
-    @property
     @override
+    @property
     def main_port(self) -> int:
         # -----------------------
         # SLURM JOB = PORT number

--- a/src/lightning/fabric/plugins/environments/torchelastic.py
+++ b/src/lightning/fabric/plugins/environments/torchelastic.py
@@ -27,13 +27,13 @@ log = logging.getLogger(__name__)
 class TorchElasticEnvironment(ClusterEnvironment):
     """Environment for fault-tolerant and elastic training with `torchelastic <https://pytorch.org/elastic/>`_"""
 
-    @property
     @override
+    @property
     def creates_processes_externally(self) -> bool:
         return True
 
-    @property
     @override
+    @property
     def main_address(self) -> str:
         if "MASTER_ADDR" not in os.environ:
             rank_zero_warn("MASTER_ADDR environment variable is not defined. Set as localhost")
@@ -41,8 +41,8 @@ class TorchElasticEnvironment(ClusterEnvironment):
         log.debug(f"MASTER_ADDR: {os.environ['MASTER_ADDR']}")
         return os.environ["MASTER_ADDR"]
 
-    @property
     @override
+    @property
     def main_port(self) -> int:
         if "MASTER_PORT" not in os.environ:
             rank_zero_warn("MASTER_PORT environment variable is not defined. Set as 12910")

--- a/src/lightning/fabric/plugins/environments/xla.py
+++ b/src/lightning/fabric/plugins/environments/xla.py
@@ -36,19 +36,19 @@ class XLAEnvironment(ClusterEnvironment):
             raise ModuleNotFoundError(str(_XLA_AVAILABLE))
         super().__init__(*args, **kwargs)
 
-    @property
     @override
+    @property
     def creates_processes_externally(self) -> bool:
         return False
 
-    @property
     @override
+    @property
     def main_address(self) -> str:
         # unused by lightning
         raise NotImplementedError
 
-    @property
     @override
+    @property
     def main_port(self) -> int:
         # unused by lightning
         raise NotImplementedError

--- a/src/lightning/fabric/strategies/ddp.py
+++ b/src/lightning/fabric/strategies/ddp.py
@@ -79,8 +79,8 @@ class DDPStrategy(ParallelStrategy):
         self._backward_sync_control = _DDPBackwardSyncControl()
         self._ddp_kwargs = kwargs
 
-    @property
     @override
+    @property
     def root_device(self) -> torch.device:
         assert self.parallel_devices is not None
         return self.parallel_devices[self.local_rank]
@@ -98,8 +98,8 @@ class DDPStrategy(ParallelStrategy):
     def num_processes(self) -> int:
         return len(self.parallel_devices) if self.parallel_devices is not None else 0
 
-    @property
     @override
+    @property
     def distributed_sampler_kwargs(self) -> dict[str, Any]:
         return {"num_replicas": (self.num_nodes * self.num_processes), "rank": self.global_rank}
 

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -324,8 +324,8 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
         zero_optimization = self.config.get("zero_optimization")
         return zero_optimization is not None and zero_optimization.get("stage") == 3
 
-    @property
     @override
+    @property
     def distributed_sampler_kwargs(self) -> dict[str, int]:
         return {"num_replicas": self.world_size, "rank": self.global_rank}
 

--- a/src/lightning/fabric/strategies/dp.py
+++ b/src/lightning/fabric/strategies/dp.py
@@ -47,14 +47,14 @@ class DataParallelStrategy(ParallelStrategy):
             precision=precision,
         )
 
-    @property
     @override
+    @property
     def root_device(self) -> torch.device:
         assert self.parallel_devices is not None
         return self.parallel_devices[0]
 
-    @property
     @override
+    @property
     def distributed_sampler_kwargs(self) -> None:
         return None
 

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -135,6 +135,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
 
     """
 
+    @override
     def __init__(
         self,
         accelerator: Optional[Accelerator] = None,
@@ -181,18 +182,18 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
         self.cpu_offload = _init_cpu_offload(cpu_offload)
         self.mixed_precision = mixed_precision
 
-    @property
     @override
+    @property
     def checkpoint_io(self) -> CheckpointIO:
         raise NotImplementedError(f"The `{type(self).__name__}` does not use the `CheckpointIO` plugin interface.")
 
-    @checkpoint_io.setter
     @override
+    @checkpoint_io.setter
     def checkpoint_io(self, io: CheckpointIO) -> None:
         raise NotImplementedError(f"The `{type(self).__name__}` does not support setting a `CheckpointIO` plugin.")
 
-    @property
     @override
+    @property
     def root_device(self) -> torch.device:
         assert self.parallel_devices is not None
         return self.parallel_devices[self.local_rank]
@@ -209,8 +210,8 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
     def num_processes(self) -> int:
         return len(self.parallel_devices) if self.parallel_devices is not None else 0
 
-    @property
     @override
+    @property
     def distributed_sampler_kwargs(self) -> dict[str, Any]:
         return {"num_replicas": (self.num_nodes * self.num_processes), "rank": self.global_rank}
 
@@ -218,6 +219,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
     def process_group_backend(self) -> Optional[str]:
         return self._process_group_backend
 
+    @override
     @property
     def mixed_precision_config(self) -> Optional["MixedPrecision"]:
         if self.mixed_precision:
@@ -227,8 +229,8 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
             return plugin.mixed_precision_config
         return None
 
-    @property
     @override
+    @property
     def precision(self) -> FSDPPrecision:
         plugin = self._precision
         if plugin is not None:
@@ -236,8 +238,8 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
             return plugin
         return FSDPPrecision("32-true")
 
-    @precision.setter
     @override
+    @precision.setter
     def precision(self, precision: Optional[Precision]) -> None:
         if precision is not None and not isinstance(precision, FSDPPrecision):
             raise TypeError(f"The FSDP strategy can only work with the `FSDPPrecision` plugin, found {precision}")

--- a/src/lightning/fabric/strategies/launchers/multiprocessing.py
+++ b/src/lightning/fabric/strategies/launchers/multiprocessing.py
@@ -73,8 +73,8 @@ class _MultiProcessingLauncher(_Launcher):
                 f" {', '.join(mp.get_all_start_methods())}"
             )
 
-    @property
     @override
+    @property
     def is_interactive_compatible(self) -> bool:
         # The start method 'spawn' is not supported in interactive environments
         # The start method 'fork' is the only one supported in Jupyter environments, with constraints around CUDA

--- a/src/lightning/fabric/strategies/launchers/subprocess_script.py
+++ b/src/lightning/fabric/strategies/launchers/subprocess_script.py
@@ -83,8 +83,8 @@ class _SubprocessScriptLauncher(_Launcher):
         self.num_nodes = num_nodes
         self.procs: list[subprocess.Popen] = []  # launched child subprocesses, does not include the launcher
 
-    @property
     @override
+    @property
     def is_interactive_compatible(self) -> bool:
         return False
 

--- a/src/lightning/fabric/strategies/launchers/xla.py
+++ b/src/lightning/fabric/strategies/launchers/xla.py
@@ -50,8 +50,8 @@ class _XLALauncher(_Launcher):
         self._strategy = strategy
         self._start_method = "fork"
 
-    @property
     @override
+    @property
     def is_interactive_compatible(self) -> bool:
         return True
 

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -109,24 +109,25 @@ class ModelParallelStrategy(ParallelStrategy):
 
         self._device_mesh: Optional[DeviceMesh] = None
 
+    @override
     @property
     def device_mesh(self) -> "DeviceMesh":
         if self._device_mesh is None:
             raise RuntimeError("Accessing the device mesh before processes have initialized is not allowed.")
         return self._device_mesh
 
-    @property
     @override
+    @property
     def checkpoint_io(self) -> CheckpointIO:
         raise NotImplementedError(f"The `{type(self).__name__}` does not use the `CheckpointIO` plugin interface.")
 
-    @checkpoint_io.setter
     @override
+    @checkpoint_io.setter
     def checkpoint_io(self, io: CheckpointIO) -> None:
         raise NotImplementedError(f"The `{type(self).__name__}` does not support setting a `CheckpointIO` plugin.")
 
-    @property
     @override
+    @property
     def root_device(self) -> torch.device:
         assert self.parallel_devices is not None
         return self.parallel_devices[self.local_rank]
@@ -143,8 +144,8 @@ class ModelParallelStrategy(ParallelStrategy):
     def num_processes(self) -> int:
         return len(self.parallel_devices) if self.parallel_devices is not None else 0
 
-    @property
     @override
+    @property
     def distributed_sampler_kwargs(self) -> dict[str, Any]:
         assert self.device_mesh is not None
         data_parallel_mesh = self.device_mesh["data_parallel"]
@@ -339,9 +340,11 @@ class _FSDPNoSync(AbstractContextManager):
             if isinstance(mod, FSDPModule):
                 mod.set_requires_gradient_sync(requires_grad_sync, recurse=False)
 
+    @override
     def __enter__(self) -> None:
         self._set_requires_grad_sync(not self._enabled)
 
+    @override
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         self._set_requires_grad_sync(self._enabled)
 

--- a/src/lightning/fabric/strategies/parallel.py
+++ b/src/lightning/fabric/strategies/parallel.py
@@ -58,8 +58,8 @@ class ParallelStrategy(Strategy, ABC):
     def world_size(self) -> int:
         return self.cluster_environment.world_size() if self.cluster_environment is not None else 1
 
-    @property
     @override
+    @property
     def is_global_zero(self) -> bool:
         return self.global_rank == 0
 

--- a/src/lightning/fabric/strategies/registry.py
+++ b/src/lightning/fabric/strategies/registry.py
@@ -108,5 +108,6 @@ class _StrategyRegistry(dict):
         """Returns a list of registered strategies."""
         return list(self.keys())
 
+    @override
     def __str__(self) -> str:
         return "Registered Strategies: {}".format(", ".join(self.keys()))

--- a/src/lightning/fabric/strategies/single_device.py
+++ b/src/lightning/fabric/strategies/single_device.py
@@ -44,13 +44,13 @@ class SingleDeviceStrategy(Strategy):
         self.local_rank = 0
         self.world_size = 1
 
-    @property
     @override
+    @property
     def root_device(self) -> torch.device:
         return self._root_device
 
-    @property
     @override
+    @property
     def is_global_zero(self) -> bool:
         return True
 

--- a/src/lightning/fabric/strategies/single_xla.py
+++ b/src/lightning/fabric/strategies/single_xla.py
@@ -28,6 +28,7 @@ from lightning.fabric.utilities.types import _DEVICE
 class SingleDeviceXLAStrategy(SingleDeviceStrategy):
     """Strategy for training on a single XLA device."""
 
+    @override
     def __init__(
         self,
         device: _DEVICE,
@@ -50,8 +51,8 @@ class SingleDeviceXLAStrategy(SingleDeviceStrategy):
             precision=precision,
         )
 
-    @property
     @override
+    @property
     def checkpoint_io(self) -> XLACheckpointIO:
         plugin = self._checkpoint_io
         if plugin is not None:
@@ -59,15 +60,15 @@ class SingleDeviceXLAStrategy(SingleDeviceStrategy):
             return plugin
         return XLACheckpointIO()
 
-    @checkpoint_io.setter
     @override
+    @checkpoint_io.setter
     def checkpoint_io(self, io: Optional[CheckpointIO]) -> None:
         if io is not None and not isinstance(io, XLACheckpointIO):
             raise TypeError(f"The XLA strategy can only work with the `XLACheckpointIO` plugin, found {io}")
         self._checkpoint_io = io
 
-    @property
     @override
+    @property
     def precision(self) -> XLAPrecision:
         plugin = self._precision
         if plugin is not None:
@@ -75,8 +76,8 @@ class SingleDeviceXLAStrategy(SingleDeviceStrategy):
             return plugin
         return XLAPrecision("32-true")
 
-    @precision.setter
     @override
+    @precision.setter
     def precision(self, precision: Optional[Precision]) -> None:
         if precision is not None and not isinstance(precision, XLAPrecision):
             raise TypeError(f"The XLA strategy can only work with the `XLAPrecision` plugin, found {precision}")

--- a/src/lightning/fabric/strategies/xla.py
+++ b/src/lightning/fabric/strategies/xla.py
@@ -59,8 +59,8 @@ class XLAStrategy(ParallelStrategy):
         self._launched = False
         self._sync_module_states = sync_module_states
 
-    @property
     @override
+    @property
     def root_device(self) -> torch.device:
         if not self._launched:
             raise RuntimeError("Accessing the XLA device before processes have spawned is not allowed.")
@@ -68,12 +68,13 @@ class XLAStrategy(ParallelStrategy):
 
         return xm.xla_device()
 
+    @override
     @property
     def num_processes(self) -> int:
         return len(self.parallel_devices) if self.parallel_devices is not None else 0
 
-    @property
     @override
+    @property
     def checkpoint_io(self) -> XLACheckpointIO:
         plugin = self._checkpoint_io
         if plugin is not None:
@@ -81,15 +82,15 @@ class XLAStrategy(ParallelStrategy):
             return plugin
         return XLACheckpointIO()
 
-    @checkpoint_io.setter
     @override
+    @checkpoint_io.setter
     def checkpoint_io(self, io: Optional[CheckpointIO]) -> None:
         if io is not None and not isinstance(io, XLACheckpointIO):
             raise TypeError(f"The XLA strategy can only work with the `XLACheckpointIO` plugin, found {io}")
         self._checkpoint_io = io
 
-    @property
     @override
+    @property
     def precision(self) -> XLAPrecision:
         plugin = self._precision
         if plugin is not None:
@@ -97,30 +98,30 @@ class XLAStrategy(ParallelStrategy):
             return plugin
         return XLAPrecision("32-true")
 
-    @precision.setter
     @override
+    @precision.setter
     def precision(self, precision: Optional[Precision]) -> None:
         if precision is not None and not isinstance(precision, XLAPrecision):
             raise TypeError(f"The XLA strategy can only work with the `XLAPrecision` plugin, found {precision}")
         self._precision = precision
 
-    @property
     @override
+    @property
     def global_rank(self) -> int:
         return super().global_rank if self._launched else 0
 
-    @property
     @override
+    @property
     def local_rank(self) -> int:
         return super().local_rank if self._launched else 0
 
-    @property
     @override
+    @property
     def node_rank(self) -> int:
         return super().node_rank if self._launched else 0
 
-    @property
     @override
+    @property
     def world_size(self) -> int:
         return super().world_size if self._launched else 1
 

--- a/src/lightning/fabric/strategies/xla_fsdp.py
+++ b/src/lightning/fabric/strategies/xla_fsdp.py
@@ -111,8 +111,8 @@ class XLAFSDPStrategy(ParallelStrategy, _Sharded):
         self._sequential_save = sequential_save
         self._launched = False
 
-    @property
     @override
+    @property
     def root_device(self) -> torch.device:
         if not self._launched:
             raise RuntimeError("Accessing the XLA device before processes have spawned is not allowed.")
@@ -120,12 +120,13 @@ class XLAFSDPStrategy(ParallelStrategy, _Sharded):
 
         return xm.xla_device()
 
+    @override
     @property
     def num_processes(self) -> int:
         return len(self.parallel_devices) if self.parallel_devices is not None else 0
 
-    @property
     @override
+    @property
     def checkpoint_io(self) -> XLACheckpointIO:
         plugin = self._checkpoint_io
         if plugin is not None:
@@ -133,15 +134,15 @@ class XLAFSDPStrategy(ParallelStrategy, _Sharded):
             return plugin
         return XLACheckpointIO()
 
-    @checkpoint_io.setter
     @override
+    @checkpoint_io.setter
     def checkpoint_io(self, io: Optional[CheckpointIO]) -> None:
         if io is not None and not isinstance(io, XLACheckpointIO):
             raise TypeError(f"The XLA strategy can only work with the `XLACheckpointIO` plugin, found {io}")
         self._checkpoint_io = io
 
-    @property
     @override
+    @property
     def precision(self) -> XLAPrecision:
         plugin = self._precision
         if plugin is not None:
@@ -149,30 +150,30 @@ class XLAFSDPStrategy(ParallelStrategy, _Sharded):
             return plugin
         return XLAPrecision("32-true")
 
-    @precision.setter
     @override
+    @precision.setter
     def precision(self, precision: Optional[Precision]) -> None:
         if precision is not None and not isinstance(precision, XLAPrecision):
             raise TypeError(f"The XLA FSDP strategy can only work with the `XLAPrecision` plugin, found {precision}")
         self._precision = precision
 
-    @property
     @override
+    @property
     def global_rank(self) -> int:
         return super().global_rank if self._launched else 0
 
-    @property
     @override
+    @property
     def local_rank(self) -> int:
         return super().local_rank if self._launched else 0
 
-    @property
     @override
+    @property
     def node_rank(self) -> int:
         return super().node_rank if self._launched else 0
 
-    @property
     @override
+    @property
     def world_size(self) -> int:
         return super().world_size if self._launched else 1
 
@@ -226,6 +227,7 @@ class XLAFSDPStrategy(ParallelStrategy, _Sharded):
     def module_to_device(self, module: Module) -> None:
         pass
 
+    @override
     def module_init_context(self, empty_init: Optional[bool] = None) -> AbstractContextManager:
         precision_init_ctx = self.precision.module_init_context()
         module_sharded_ctx = self.module_sharded_context()

--- a/src/lightning/fabric/utilities/apply_func.py
+++ b/src/lightning/fabric/utilities/apply_func.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utilities used for collections."""
 
+from typing_extensions import override
 from abc import ABC
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Union
@@ -68,6 +69,7 @@ class _TransferableDataType(ABC):
     """
 
     @classmethod
+    @override
     def __subclasshook__(cls, subclass: Any) -> Union[bool, Any]:
         if cls is _TransferableDataType:
             to = getattr(subclass, "to", None)

--- a/src/lightning/fabric/utilities/apply_func.py
+++ b/src/lightning/fabric/utilities/apply_func.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Utilities used for collections."""
 
-from typing_extensions import override
 from abc import ABC
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Union
@@ -21,6 +20,7 @@ from typing import TYPE_CHECKING, Any, Callable, Union
 import torch
 from lightning_utilities.core.apply_func import apply_to_collection
 from torch import Tensor
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _NUMPY_AVAILABLE
 from lightning.fabric.utilities.types import _DEVICE

--- a/src/lightning/fabric/utilities/data.py
+++ b/src/lightning/fabric/utilities/data.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import functools
 import inspect
 import os
@@ -24,7 +23,7 @@ from typing import Any, Callable, Optional, Union
 
 from lightning_utilities.core.inheritance import get_all_subclasses
 from torch.utils.data import BatchSampler, DataLoader, IterableDataset, Sampler
-from typing_extensions import TypeGuard
+from typing_extensions import TypeGuard, override
 
 from lightning.fabric.utilities.enums import LightningEnum
 from lightning.fabric.utilities.exceptions import MisconfigurationException

--- a/src/lightning/fabric/utilities/data.py
+++ b/src/lightning/fabric/utilities/data.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import functools
 import inspect
 import os
@@ -493,14 +494,17 @@ class AttributeDict(dict):
         except KeyError as e:
             raise AttributeError(f"'{type(self).__name__}' object has no attribute '{key}'") from e
 
+    @override
     def __setattr__(self, key: str, val: Any) -> None:
         self[key] = val
 
+    @override
     def __delattr__(self, item: str) -> None:
         if item not in self:
             raise KeyError(item)
         del self[item]
 
+    @override
     def __repr__(self) -> str:
         if not len(self):
             return ""

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -171,6 +171,7 @@ class _NotYetLoadedTensor:
 
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
+    @override
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({repr(self.metatensor)})"
 

--- a/src/lightning/pytorch/_graveyard/tpu.py
+++ b/src/lightning/pytorch/_graveyard/tpu.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import sys
 from typing import Any
+
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.fabric.strategies import _StrategyRegistry

--- a/src/lightning/pytorch/_graveyard/tpu.py
+++ b/src/lightning/pytorch/_graveyard/tpu.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import sys
 from typing import Any
 
@@ -44,6 +45,7 @@ class SingleTPUStrategy(SingleDeviceXLAStrategy):
         super().__init__(*args, **kwargs)
 
     @classmethod
+    @override
     def register_strategies(cls, strategy_registry: _StrategyRegistry) -> None:
         if "single_tpu" not in strategy_registry:
             strategy_registry.register("single_tpu", cls, description="Legacy class. Use `single_xla` instead.")

--- a/src/lightning/pytorch/callbacks/early_stopping.py
+++ b/src/lightning/pytorch/callbacks/early_stopping.py
@@ -149,8 +149,8 @@ class EarlyStopping(Callback):
         torch_inf = torch.tensor(torch.inf)
         self.best_score = torch_inf if self.monitor_op == torch.lt else -torch_inf
 
-    @property
     @override
+    @property
     def state_key(self) -> str:
         return self._generate_state_key(monitor=self.monitor, mode=self.mode)
 

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -308,8 +308,8 @@ class ModelCheckpoint(Checkpoint):
         self.__init_triggers(every_n_train_steps, every_n_epochs, train_time_interval)
         self.__validate_init_configuration()
 
-    @property
     @override
+    @property
     def state_key(self) -> str:
         return self._generate_state_key(
             monitor=self.monitor,
@@ -532,6 +532,7 @@ class ModelCheckpoint(Checkpoint):
             {str(exception)}, saved checkpoint to {filepath}"
         )
 
+    @override
     def on_train_end(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
         """Ensure save_last=True is applied when training ends."""
         if self.save_last and not self._last_checkpoint_saved:

--- a/src/lightning/pytorch/callbacks/progress/rich_progress.py
+++ b/src/lightning/pytorch/callbacks/progress/rich_progress.py
@@ -722,6 +722,7 @@ class RichProgressBar(ProgressBar):
             ProcessingSpeedColumn(style=self.theme.processing_speed),
         ]
 
+    @override
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         # both the console and progress object can hold thread lock objects that are not pickleable

--- a/src/lightning/pytorch/callbacks/progress/tqdm_progress.py
+++ b/src/lightning/pytorch/callbacks/progress/tqdm_progress.py
@@ -115,6 +115,7 @@ class TQDMProgressBar(ProgressBar):
         self._predict_progress_bar: Optional[_tqdm] = None
         self._leave = leave
 
+    @override
     def __getstate__(self) -> dict:
         # can't pickle the tqdm objects
         return {k: v if not isinstance(v, _tqdm) else None for k, v in vars(self).items()}

--- a/src/lightning/pytorch/callbacks/weight_averaging.py
+++ b/src/lightning/pytorch/callbacks/weight_averaging.py
@@ -387,6 +387,7 @@ class EMAWeightAveraging(WeightAveraging):
         self.update_starting_at_step = update_starting_at_step
         self.update_starting_at_epoch = update_starting_at_epoch
 
+    @override
     def should_update(self, step_idx: Optional[int] = None, epoch_idx: Optional[int] = None) -> bool:
         """Decide when to update the model weights.
 

--- a/src/lightning/pytorch/core/datamodule.py
+++ b/src/lightning/pytorch/core/datamodule.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """LightningDataModule for loading DataLoaders with ease."""
 
+from typing_extensions import override
 import inspect
 import os
 from collections.abc import Iterable, Sized
@@ -253,6 +254,7 @@ class LightningDataModule(DataHooks, HyperparametersMixin):
         )
         return cast(Self, loaded)
 
+    @override
     def __str__(self) -> str:
         """Return a string representation of the datasets that are set up.
 

--- a/src/lightning/pytorch/core/datamodule.py
+++ b/src/lightning/pytorch/core/datamodule.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """LightningDataModule for loading DataLoaders with ease."""
 
-from typing_extensions import override
 import inspect
 import os
 from collections.abc import Iterable, Sized
@@ -21,7 +20,7 @@ from typing import IO, Any, Optional, Union, cast
 
 from lightning_utilities import apply_to_collection
 from torch.utils.data import DataLoader, Dataset, IterableDataset
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 import lightning.pytorch as pl
 from lightning.fabric.utilities.types import _MAP_LOCATION_TYPE, _PATH

--- a/src/lightning/pytorch/demos/boring_classes.py
+++ b/src/lightning/pytorch/demos/boring_classes.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from collections.abc import Iterable, Iterator
 from typing import Any, Optional
 
@@ -37,6 +38,7 @@ class RandomDictDataset(Dataset):
         self.len = length
         self.data = torch.randn(length, size)
 
+    @override
     def __getitem__(self, index: int) -> dict[str, Tensor]:
         a = self.data[index]
         b = a + 2
@@ -55,6 +57,7 @@ class RandomDataset(Dataset):
         self.len = length
         self.data = torch.randn(length, size)
 
+    @override
     def __getitem__(self, index: int) -> Tensor:
         return self.data[index]
 
@@ -71,6 +74,7 @@ class RandomIterableDataset(IterableDataset):
         self.count = count
         self.size = size
 
+    @override
     def __iter__(self) -> Iterator[Tensor]:
         for _ in range(self.count):
             yield torch.randn(self.size)
@@ -85,6 +89,7 @@ class RandomIterableDatasetWithLen(IterableDataset):
         self.count = count
         self.size = size
 
+    @override
     def __iter__(self) -> Iterator[Tensor]:
         for _ in range(len(self)):
             yield torch.randn(self.size)
@@ -114,6 +119,7 @@ class BoringModel(LightningModule):
         super().__init__()
         self.layer = torch.nn.Linear(32, 2)
 
+    @override
     def forward(self, x: Tensor) -> Tensor:
         return self.layer(x)
 
@@ -127,29 +133,37 @@ class BoringModel(LightningModule):
         output = self(batch)
         return self.loss(output)
 
+    @override
     def training_step(self, batch: Any, batch_idx: int) -> STEP_OUTPUT:
         return {"loss": self.step(batch)}
 
+    @override
     def validation_step(self, batch: Any, batch_idx: int) -> STEP_OUTPUT:
         return {"x": self.step(batch)}
 
+    @override
     def test_step(self, batch: Any, batch_idx: int) -> STEP_OUTPUT:
         return {"y": self.step(batch)}
 
+    @override
     def configure_optimizers(self) -> tuple[list[torch.optim.Optimizer], list[LRScheduler]]:
         optimizer = torch.optim.SGD(self.parameters(), lr=0.1)
         lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
         return [optimizer], [lr_scheduler]
 
+    @override
     def train_dataloader(self) -> DataLoader:
         return DataLoader(RandomDataset(32, 64))
 
+    @override
     def val_dataloader(self) -> DataLoader:
         return DataLoader(RandomDataset(32, 64))
 
+    @override
     def test_dataloader(self) -> DataLoader:
         return DataLoader(RandomDataset(32, 64))
 
+    @override
     def predict_dataloader(self) -> DataLoader:
         return DataLoader(RandomDataset(32, 64))
 
@@ -163,6 +177,7 @@ class BoringDataModule(LightningDataModule):
         super().__init__()
         self.random_full = RandomDataset(32, 64 * 4)
 
+    @override
     def setup(self, stage: str) -> None:
         if stage == "fit":
             self.random_train = Subset(self.random_full, indices=range(64))
@@ -176,15 +191,19 @@ class BoringDataModule(LightningDataModule):
         if stage == "predict":
             self.random_predict = Subset(self.random_full, indices=range(64 * 3, 64 * 4))
 
+    @override
     def train_dataloader(self) -> DataLoader:
         return DataLoader(self.random_train)
 
+    @override
     def val_dataloader(self) -> DataLoader:
         return DataLoader(self.random_val)
 
+    @override
     def test_dataloader(self) -> DataLoader:
         return DataLoader(self.random_test)
 
+    @override
     def predict_dataloader(self) -> DataLoader:
         return DataLoader(self.random_predict)
 
@@ -197,6 +216,7 @@ class BoringDataModuleNoLen(LightningDataModule):
     def __init__(self) -> None:
         super().__init__()
 
+    @override
     def setup(self, stage: str) -> None:
         if stage == "fit":
             self.random_train = RandomIterableDataset(32, 512)
@@ -210,15 +230,19 @@ class BoringDataModuleNoLen(LightningDataModule):
         if stage == "predict":
             self.random_predict = RandomIterableDataset(32, 64)
 
+    @override
     def train_dataloader(self) -> DataLoader:
         return DataLoader(self.random_train)
 
+    @override
     def val_dataloader(self) -> DataLoader:
         return DataLoader(self.random_val)
 
+    @override
     def test_dataloader(self) -> DataLoader:
         return DataLoader(self.random_test)
 
+    @override
     def predict_dataloader(self) -> DataLoader:
         return DataLoader(self.random_predict)
 
@@ -227,6 +251,7 @@ class IterableBoringDataModule(LightningDataModule):
     def __init__(self) -> None:
         super().__init__()
 
+    @override
     def setup(self, stage: str) -> None:
         if stage == "fit":
             self.train_datasets = [
@@ -252,18 +277,22 @@ class IterableBoringDataModule(LightningDataModule):
                 RandomIterableDataset(4, 128),
             ]
 
+    @override
     def train_dataloader(self) -> Iterable[DataLoader]:
         combined_train = apply_to_collection(self.train_datasets, Dataset, lambda x: DataLoader(x))
         return combined_train
 
+    @override
     def val_dataloader(self) -> DataLoader:
         combined_val = apply_to_collection(self.val_datasets, Dataset, lambda x: DataLoader(x))
         return combined_val
 
+    @override
     def test_dataloader(self) -> DataLoader:
         combined_test = apply_to_collection(self.test_datasets, Dataset, lambda x: DataLoader(x))
         return combined_test
 
+    @override
     def predict_dataloader(self) -> DataLoader:
         combined_predict = apply_to_collection(self.predict_datasets, Dataset, lambda x: DataLoader(x))
         return combined_predict
@@ -278,6 +307,7 @@ class ManualOptimBoringModel(BoringModel):
         super().__init__()
         self.automatic_optimization = False
 
+    @override
     def training_step(self, batch: Any, batch_idx: int) -> STEP_OUTPUT:
         opt = self.optimizers()
         assert isinstance(opt, (Optimizer, LightningOptimizer))
@@ -298,14 +328,17 @@ class DemoModel(LightningModule):
         self.l1 = torch.nn.Linear(32, out_dim)
         self.learning_rate = learning_rate
 
+    @override
     def forward(self, x: Tensor) -> Tensor:
         return torch.relu(self.l1(x.view(x.size(0), -1)))
 
+    @override
     def training_step(self, batch: Any, batch_nb: int) -> STEP_OUTPUT:
         x = batch
         x = self(x)
         return x.sum()
 
+    @override
     def configure_optimizers(self) -> torch.optim.Optimizer:
         return torch.optim.Adam(self.parameters(), lr=self.learning_rate)
 
@@ -324,6 +357,7 @@ class Net(nn.Module):
         self.fc1 = nn.Linear(9216, 128)
         self.fc2 = nn.Linear(128, 10)
 
+    @override
     def forward(self, x: Tensor) -> Tensor:
         x = self.conv1(x)
         x = F.relu(x)

--- a/src/lightning/pytorch/demos/boring_classes.py
+++ b/src/lightning/pytorch/demos/boring_classes.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from collections.abc import Iterable, Iterator
 from typing import Any, Optional
 
@@ -23,6 +22,7 @@ from torch import Tensor
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LRScheduler
 from torch.utils.data import DataLoader, Dataset, IterableDataset, Subset
+from typing_extensions import override
 
 from lightning.pytorch import LightningDataModule, LightningModule
 from lightning.pytorch.core.optimizer import LightningOptimizer

--- a/src/lightning/pytorch/demos/lstm.py
+++ b/src/lightning/pytorch/demos/lstm.py
@@ -5,7 +5,6 @@ https://github.com/pytorch/examples/blob/main/word_language_model
 
 """
 
-from typing_extensions import override
 from collections.abc import Iterator, Sized
 from typing import Optional
 
@@ -15,6 +14,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader, Sampler
+from typing_extensions import override
 
 from lightning.pytorch.core import LightningModule
 from lightning.pytorch.demos.transformer import WikiText2

--- a/src/lightning/pytorch/demos/lstm.py
+++ b/src/lightning/pytorch/demos/lstm.py
@@ -5,6 +5,7 @@ https://github.com/pytorch/examples/blob/main/word_language_model
 
 """
 
+from typing_extensions import override
 from collections.abc import Iterator, Sized
 from typing import Optional
 
@@ -38,6 +39,7 @@ class SimpleLSTM(nn.Module):
         nn.init.zeros_(self.decoder.bias)
         nn.init.uniform_(self.decoder.weight, -0.1, 0.1)
 
+    @override
     def forward(self, input: Tensor, hidden: tuple[Tensor, Tensor]) -> tuple[Tensor, Tensor]:
         emb = self.drop(self.encoder(input))
         output, hidden = self.rnn(emb, hidden)
@@ -60,6 +62,7 @@ class SequenceSampler(Sampler[list[int]]):
         self.batch_size = batch_size
         self.chunk_size = len(self.dataset) // self.batch_size
 
+    @override
     def __iter__(self) -> Iterator[list[int]]:
         n = len(self.dataset)
         for i in range(self.chunk_size):
@@ -75,9 +78,11 @@ class LightningLSTM(LightningModule):
         self.model = SimpleLSTM(vocab_size=vocab_size)
         self.hidden: Optional[tuple[Tensor, Tensor]] = None
 
+    @override
     def on_train_epoch_end(self) -> None:
         self.hidden = None
 
+    @override
     def training_step(self, batch: tuple[Tensor, Tensor], batch_idx: int) -> Tensor:
         input, target = batch
         if self.hidden is None:
@@ -88,12 +93,15 @@ class LightningLSTM(LightningModule):
         self.log("train_loss", loss, prog_bar=True)
         return loss
 
+    @override
     def prepare_data(self) -> None:
         WikiText2(download=True)
 
+    @override
     def train_dataloader(self) -> DataLoader:
         dataset = WikiText2()
         return DataLoader(dataset, batch_sampler=SequenceSampler(dataset, batch_size=20))
 
+    @override
     def configure_optimizers(self) -> Optimizer:
         return torch.optim.SGD(self.parameters(), lr=20.0)

--- a/src/lightning/pytorch/demos/mnist_datamodule.py
+++ b/src/lightning/pytorch/demos/mnist_datamodule.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import logging
 import os
 import random
@@ -25,6 +24,7 @@ from warnings import warn
 import torch
 from torch import Tensor
 from torch.utils.data import DataLoader, Dataset, random_split
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _IS_WINDOWS
 from lightning.pytorch import LightningDataModule

--- a/src/lightning/pytorch/demos/mnist_datamodule.py
+++ b/src/lightning/pytorch/demos/mnist_datamodule.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import logging
 import os
 import random
@@ -64,6 +65,7 @@ class _MNIST(Dataset):
         data_file = self.TRAIN_FILE_NAME if self.train else self.TEST_FILE_NAME
         self.data, self.targets = self._try_load(os.path.join(self.cached_folder_path, data_file))
 
+    @override
     def __getitem__(self, idx: int) -> tuple[Tensor, int]:
         img = self.data[idx].float().unsqueeze(0)
         target = int(self.targets[idx])
@@ -191,11 +193,13 @@ class MNISTDataModule(LightningDataModule):
     def num_classes(self) -> int:
         return 10
 
+    @override
     def prepare_data(self) -> None:
         """Saves MNIST files to `data_dir`"""
         MNIST(self.data_dir, train=True, download=True)
         MNIST(self.data_dir, train=False, download=True)
 
+    @override
     def setup(self, stage: str) -> None:
         """Split the train and valid dataset."""
         extra = {"transform": self.default_transforms} if self.default_transforms else {}
@@ -206,6 +210,7 @@ class MNISTDataModule(LightningDataModule):
             dataset, [train_length - self.val_split, self.val_split], generator=torch.Generator().manual_seed(42)
         )
 
+    @override
     def train_dataloader(self) -> DataLoader:
         """MNIST train set removes a subset to use for validation."""
         return DataLoader(
@@ -217,6 +222,7 @@ class MNISTDataModule(LightningDataModule):
             pin_memory=True,
         )
 
+    @override
     def val_dataloader(self) -> DataLoader:
         """MNIST val set uses a subset of the training set for validation."""
         return DataLoader(
@@ -228,6 +234,7 @@ class MNISTDataModule(LightningDataModule):
             pin_memory=True,
         )
 
+    @override
     def test_dataloader(self) -> DataLoader:
         """MNIST test set uses the test split."""
         extra = {"transform": self.default_transforms} if self.default_transforms else {}

--- a/src/lightning/pytorch/demos/transformer.py
+++ b/src/lightning/pytorch/demos/transformer.py
@@ -5,7 +5,6 @@ https://github.com/pytorch/examples/blob/main/word_language_model
 
 """
 
-from typing_extensions import override
 import math
 import os
 from pathlib import Path
@@ -18,6 +17,7 @@ from lightning_utilities.core.imports import RequirementCache
 from torch import Tensor
 from torch.nn.modules import MultiheadAttention
 from torch.utils.data import DataLoader, Dataset
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule
 

--- a/src/lightning/pytorch/demos/transformer.py
+++ b/src/lightning/pytorch/demos/transformer.py
@@ -5,6 +5,7 @@ https://github.com/pytorch/examples/blob/main/word_language_model
 
 """
 
+from typing_extensions import override
 import math
 import os
 from pathlib import Path
@@ -62,6 +63,7 @@ class Transformer(nn.Module):
         mask = mask.float().masked_fill(mask == 1, float("-inf")).masked_fill(mask == 0, 0.0)
         return mask
 
+    @override
     def forward(self, inputs: Tensor, target: Tensor, mask: Optional[Tensor] = None) -> Tensor:
         _, t = inputs.shape
 
@@ -90,6 +92,7 @@ class PositionalEncoding(nn.Module):
         self.max_len = max_len
         self.pe: Optional[Tensor] = None
 
+    @override
     def forward(self, x: Tensor) -> Tensor:
         if self.pe is None:
             # 1) can't use buffer, see https://github.com/pytorch/pytorch/issues/68407
@@ -128,6 +131,7 @@ class WikiText2(Dataset):
     def __len__(self) -> int:
         return len(self.data) // self.block_size - 1
 
+    @override
     def __getitem__(self, index: int) -> tuple[Tensor, Tensor]:
         start = index * self.block_size
         end = start + self.block_size
@@ -194,21 +198,26 @@ class LightningTransformer(LightningModule):
         super().__init__()
         self.model = Transformer(vocab_size=vocab_size)
 
+    @override
     def forward(self, inputs: Tensor, target: Tensor) -> Tensor:
         return self.model(inputs, target)
 
+    @override
     def training_step(self, batch: tuple[Tensor, Tensor], batch_idx: int) -> Tensor:
         inputs, target = batch
         output = self(inputs, target)
         loss = torch.nn.functional.nll_loss(output, target.view(-1))
         return loss
 
+    @override
     def configure_optimizers(self) -> torch.optim.Optimizer:
         return torch.optim.SGD(self.model.parameters(), lr=0.1)
 
+    @override
     def prepare_data(self) -> None:
         WikiText2(download=True)
 
+    @override
     def train_dataloader(self) -> DataLoader:
         dataset = WikiText2()
         return DataLoader(dataset)

--- a/src/lightning/pytorch/loggers/comet.py
+++ b/src/lightning/pytorch/loggers/comet.py
@@ -363,8 +363,8 @@ class CometLogger(Logger):
         # just save the data
         self.experiment.flush()
 
-    @property
     @override
+    @property
     def save_dir(self) -> Optional[str]:
         """Gets the save directory.
 
@@ -374,8 +374,8 @@ class CometLogger(Logger):
         """
         return self._comet_config.offline_directory
 
-    @property
     @override
+    @property
     def name(self) -> Optional[str]:
         """Gets the project name.
 
@@ -385,8 +385,8 @@ class CometLogger(Logger):
         """
         return self._project_name
 
-    @property
     @override
+    @property
     def version(self) -> Optional[str]:
         """Gets the version.
 
@@ -398,6 +398,7 @@ class CometLogger(Logger):
         if self._experiment is not None:
             return self._experiment.get_key()
 
+    @override
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
 

--- a/src/lightning/pytorch/loggers/csv_logs.py
+++ b/src/lightning/pytorch/loggers/csv_logs.py
@@ -102,8 +102,8 @@ class CSVLogger(Logger, FabricCSVLogger):
         )
         self._save_dir = os.fspath(save_dir)
 
-    @property
     @override
+    @property
     def root_dir(self) -> str:
         """Parent directory for all checkpoint subdirectories.
 
@@ -113,8 +113,8 @@ class CSVLogger(Logger, FabricCSVLogger):
         """
         return os.path.join(self.save_dir, self.name)
 
-    @property
     @override
+    @property
     def log_dir(self) -> str:
         """The log directory for this run.
 
@@ -126,8 +126,8 @@ class CSVLogger(Logger, FabricCSVLogger):
         version = self.version if isinstance(self.version, str) else f"version_{self.version}"
         return os.path.join(self.root_dir, version)
 
-    @property
     @override
+    @property
     def save_dir(self) -> str:
         """The current directory where logs are saved.
 
@@ -143,8 +143,8 @@ class CSVLogger(Logger, FabricCSVLogger):
         params = _convert_params(params)
         self.experiment.log_hparams(params)
 
-    @property
     @override
+    @property
     @rank_zero_experiment
     def experiment(self) -> _FabricExperimentWriter:
         r"""Actual _ExperimentWriter object. To use _ExperimentWriter features in your

--- a/src/lightning/pytorch/loggers/litlogger.py
+++ b/src/lightning/pytorch/loggers/litlogger.py
@@ -122,26 +122,26 @@ class LitLogger(Logger):
     # Properties
     # ──────────────────────────────────────────────────────────────────────────────
 
-    @property
     @override
+    @property
     def name(self) -> str:
         """Gets the name of the experiment."""
         return self._name
 
-    @property
     @override
+    @property
     def version(self) -> Optional[str]:
         """Get the experiment version - its time of creation."""
         return self._version
 
-    @property
     @override
+    @property
     def root_dir(self) -> str:
         """Gets the save directory where the litlogger experiments are saved."""
         return self._root_dir
 
-    @property
     @override
+    @property
     def log_dir(self) -> str:
         """The directory for this run's tensorboard checkpoint.
 

--- a/src/lightning/pytorch/loggers/logger.py
+++ b/src/lightning/pytorch/loggers/logger.py
@@ -72,14 +72,14 @@ class DummyLogger(Logger):
     def log_hyperparams(self, *args: Any, **kwargs: Any) -> None:
         pass
 
-    @property
     @override
+    @property
     def name(self) -> str:
         """Return the experiment name."""
         return ""
 
-    @property
     @override
+    @property
     def version(self) -> str:
         """Return the experiment version."""
         return ""

--- a/src/lightning/pytorch/loggers/mlflow.py
+++ b/src/lightning/pytorch/loggers/mlflow.py
@@ -289,8 +289,8 @@ class MLFlowLogger(Logger):
         if self.experiment.get_run(self.run_id):
             self.experiment.set_terminated(self.run_id, status)
 
-    @property
     @override
+    @property
     def save_dir(self) -> Optional[str]:
         """The root file directory in which MLflow experiments are saved.
 
@@ -303,8 +303,8 @@ class MLFlowLogger(Logger):
             return self._tracking_uri[len(LOCAL_FILE_URI_PREFIX) :]
         return None
 
-    @property
     @override
+    @property
     def name(self) -> Optional[str]:
         """Get the experiment id.
 
@@ -314,8 +314,8 @@ class MLFlowLogger(Logger):
         """
         return self.experiment_id
 
-    @property
     @override
+    @property
     def version(self) -> Optional[str]:
         """Get the run id.
 

--- a/src/lightning/pytorch/loggers/tensorboard.py
+++ b/src/lightning/pytorch/loggers/tensorboard.py
@@ -110,8 +110,8 @@ class TensorBoardLogger(Logger, FabricTensorBoardLogger):
         self._log_graph = log_graph and _TENSORBOARD_AVAILABLE
         self.hparams: Union[dict[str, Any], Namespace] = {}
 
-    @property
     @override
+    @property
     def root_dir(self) -> str:
         """Parent directory for all tensorboard checkpoint subdirectories.
 
@@ -121,8 +121,8 @@ class TensorBoardLogger(Logger, FabricTensorBoardLogger):
         """
         return os.path.join(super().root_dir, self.name)
 
-    @property
     @override
+    @property
     def log_dir(self) -> str:
         """The directory for this run's tensorboard checkpoint.
 
@@ -139,8 +139,8 @@ class TensorBoardLogger(Logger, FabricTensorBoardLogger):
         log_dir = os.path.expanduser(log_dir)
         return log_dir
 
-    @property
     @override
+    @property
     def save_dir(self) -> str:
         """Gets the save directory where the TensorBoard experiments are saved.
 

--- a/src/lightning/pytorch/loggers/wandb.py
+++ b/src/lightning/pytorch/loggers/wandb.py
@@ -352,6 +352,7 @@ class WandbLogger(Logger):
         self._id = self._wandb_init.get("id")
         self._checkpoint_name = checkpoint_name
 
+    @override
     def __getstate__(self) -> dict[str, Any]:
         import wandb
 
@@ -553,8 +554,8 @@ class WandbLogger(Logger):
         metrics = {key: [wandb.Video(video, **kwarg) for video, kwarg in zip(videos, kwarg_list)]}
         self.log_metrics(metrics, step)  # type: ignore[arg-type]
 
-    @property
     @override
+    @property
     def save_dir(self) -> Optional[str]:
         """Gets the save directory.
 
@@ -564,8 +565,8 @@ class WandbLogger(Logger):
         """
         return self._save_dir
 
-    @property
     @override
+    @property
     def name(self) -> Optional[str]:
         """The project name of this experiment.
 
@@ -576,8 +577,8 @@ class WandbLogger(Logger):
         """
         return self._project
 
-    @property
     @override
+    @property
     def version(self) -> Optional[str]:
         """Gets the id of the experiment.
 

--- a/src/lightning/pytorch/loops/evaluation_loop.py
+++ b/src/lightning/pytorch/loops/evaluation_loop.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import math
 import os
 import shutil
@@ -24,6 +23,7 @@ from typing import Any, Optional, Union
 
 from lightning_utilities.core.apply_func import apply_to_collection
 from torch import Tensor
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.fabric.utilities.data import _set_sampler_epoch

--- a/src/lightning/pytorch/loops/evaluation_loop.py
+++ b/src/lightning/pytorch/loops/evaluation_loop.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import math
 import os
 import shutil
@@ -223,6 +224,7 @@ class _EvaluationLoop(_Loop):
         else:
             self._restart_stage = RestartStage.NONE
 
+    @override
     def reset_restart_stage(self) -> None:
         self._restart_stage = RestartStage.NONE
 

--- a/src/lightning/pytorch/loops/fit_loop.py
+++ b/src/lightning/pytorch/loops/fit_loop.py
@@ -376,6 +376,7 @@ class _FitLoop(_Loop):
 
         self.epoch_loop.update_restart_stage()
 
+    @override
     def reset_restart_stage(self) -> None:
         self._restart_stage = RestartStage.NONE
 

--- a/src/lightning/pytorch/loops/progress.py
+++ b/src/lightning/pytorch/loops/progress.py
@@ -223,6 +223,7 @@ class _BatchProgress(_Progress):
         super().reset_on_run()
         self.is_last_batch = False
 
+    @override
     def increment_by(self, n: int, is_last_batch: bool = False) -> None:
         super().increment_by(n)
         self.is_last_batch = is_last_batch

--- a/src/lightning/pytorch/loops/training_epoch_loop.py
+++ b/src/lightning/pytorch/loops/training_epoch_loop.py
@@ -185,6 +185,7 @@ class _TrainingEpochLoop(loops._Loop):
 
         self.val_loop.update_restart_stage()
 
+    @override
     def reset_restart_stage(self) -> None:
         self._restart_stage = RestartStage.NONE
 

--- a/src/lightning/pytorch/overrides/distributed.py
+++ b/src/lightning/pytorch/overrides/distributed.py
@@ -261,6 +261,7 @@ class _IndexBatchSamplerWrapper:
     def __len__(self) -> int:
         return len(self._batch_sampler)
 
+    @override
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
         state["_iterator"] = None  # cannot pickle 'generator' object

--- a/src/lightning/pytorch/profilers/advanced.py
+++ b/src/lightning/pytorch/profilers/advanced.py
@@ -118,6 +118,7 @@ class AdvancedProfiler(Profiler):
         super().teardown(stage=stage)
         self.profiled_actions.clear()
 
+    @override
     def __reduce__(self) -> tuple:
         # avoids `TypeError: cannot pickle 'cProfile.Profile' object`
         return (

--- a/src/lightning/pytorch/strategies/ddp.py
+++ b/src/lightning/pytorch/strategies/ddp.py
@@ -113,8 +113,8 @@ class DDPStrategy(ParallelStrategy):
         )
         return True
 
-    @property
     @override
+    @property
     def root_device(self) -> torch.device:
         assert self.parallel_devices is not None
         return self.parallel_devices[self.local_rank]
@@ -132,8 +132,8 @@ class DDPStrategy(ParallelStrategy):
     def num_processes(self) -> int:
         return len(self.parallel_devices) if self.parallel_devices is not None else 0
 
-    @property
     @override
+    @property
     def distributed_sampler_kwargs(self) -> dict[str, Any]:
         return {"num_replicas": (self.num_nodes * self.num_processes), "rank": self.global_rank}
 

--- a/src/lightning/pytorch/strategies/deepspeed.py
+++ b/src/lightning/pytorch/strategies/deepspeed.py
@@ -398,8 +398,8 @@ class DeepSpeedStrategy(DDPStrategy):
         os.environ["WORLD_SIZE"] = str(self.world_size)
         os.environ["LOCAL_RANK"] = str(self.local_rank)
 
-    @property
     @override
+    @property
     def restore_checkpoint_after_setup(self) -> bool:
         return True
 
@@ -594,8 +594,8 @@ class DeepSpeedStrategy(DDPStrategy):
         )
         self.model = model
 
-    @property
     @override
+    @property
     def distributed_sampler_kwargs(self) -> dict[str, int]:
         return {"num_replicas": self.world_size, "rank": self.global_rank}
 
@@ -614,11 +614,12 @@ class DeepSpeedStrategy(DDPStrategy):
         self.optimizers = []
         self.lr_scheduler_configs = []
 
+    @override
     def _setup_model(self, model: Module) -> Module:  # type: ignore[override]
         return model
 
-    @property
     @override
+    @property
     def handles_gradient_accumulation(self) -> bool:
         """Whether the strategy handles gradient accumulation internally."""
         return True
@@ -703,8 +704,8 @@ class DeepSpeedStrategy(DDPStrategy):
             )
         return client_state
 
-    @property
     @override
+    @property
     def lightning_restore_optimizer(self) -> bool:
         assert self.lightning_module is not None
         # managed by DeepSpeed

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -194,8 +194,8 @@ class FSDPStrategy(ParallelStrategy):
         )
         self._state_dict_type = state_dict_type
 
-    @property
     @override
+    @property
     def root_device(self) -> torch.device:
         assert self.parallel_devices is not None
         return self.parallel_devices[self.local_rank]
@@ -208,6 +208,7 @@ class FSDPStrategy(ParallelStrategy):
     def process_group_backend(self) -> Optional[str]:
         return self._process_group_backend
 
+    @override
     @property
     def mixed_precision_config(self) -> Optional["MixedPrecision"]:
         if self.mixed_precision:
@@ -217,8 +218,8 @@ class FSDPStrategy(ParallelStrategy):
             return plugin.mixed_precision_config
         return None
 
-    @property
     @override
+    @property
     def precision_plugin(self) -> FSDPPrecision:
         plugin = self._precision_plugin
         if plugin is not None:
@@ -226,8 +227,8 @@ class FSDPStrategy(ParallelStrategy):
             return plugin
         return FSDPPrecision("32-true")
 
-    @precision_plugin.setter
     @override
+    @precision_plugin.setter
     def precision_plugin(self, precision_plugin: Optional[Precision]) -> None:
         if precision_plugin is not None and not isinstance(precision_plugin, FSDPPrecision):
             raise TypeError(
@@ -235,18 +236,18 @@ class FSDPStrategy(ParallelStrategy):
             )
         self._precision_plugin = precision_plugin
 
-    @property
     @override
+    @property
     def distributed_sampler_kwargs(self) -> dict:
         return {"num_replicas": (self.num_nodes * self.num_processes), "rank": self.global_rank}
 
-    @property
     @override
+    @property
     def restore_checkpoint_after_setup(self) -> bool:
         return True
 
-    @property
     @override
+    @property
     def lightning_restore_optimizer(self) -> bool:
         return False
 

--- a/src/lightning/pytorch/strategies/launchers/multiprocessing.py
+++ b/src/lightning/pytorch/strategies/launchers/multiprocessing.py
@@ -83,8 +83,8 @@ class _MultiProcessingLauncher(_Launcher):
         self.procs: list[mp.Process] = []
         self._already_fit = False
 
-    @property
     @override
+    @property
     def is_interactive_compatible(self) -> bool:
         # The start method 'spawn' is not supported in interactive environments
         # The start method 'fork' is the only one supported in Jupyter environments, with constraints around CUDA
@@ -265,6 +265,7 @@ class _MultiProcessingLauncher(_Launcher):
                 with suppress(ProcessLookupError):
                     os.kill(proc.pid, signum)
 
+    @override
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         state["procs"] = []  # SpawnProcess can't be pickled

--- a/src/lightning/pytorch/strategies/launchers/subprocess_script.py
+++ b/src/lightning/pytorch/strategies/launchers/subprocess_script.py
@@ -79,8 +79,8 @@ class _SubprocessScriptLauncher(_Launcher):
         self.num_nodes = num_nodes
         self.procs: list[subprocess.Popen] = []  # launched child subprocesses, does not include the launcher
 
-    @property
     @override
+    @property
     def is_interactive_compatible(self) -> bool:
         return False
 

--- a/src/lightning/pytorch/strategies/launchers/xla.py
+++ b/src/lightning/pytorch/strategies/launchers/xla.py
@@ -55,8 +55,8 @@ class _XLALauncher(_MultiProcessingLauncher):
             raise ModuleNotFoundError(str(_XLA_AVAILABLE))
         super().__init__(strategy=strategy, start_method="fork")
 
-    @property
     @override
+    @property
     def is_interactive_compatible(self) -> bool:
         return True
 

--- a/src/lightning/pytorch/strategies/model_parallel.py
+++ b/src/lightning/pytorch/strategies/model_parallel.py
@@ -103,8 +103,8 @@ class ModelParallelStrategy(ParallelStrategy):
             raise RuntimeError("Accessing the device mesh before processes have initialized is not allowed.")
         return self._device_mesh
 
-    @property
     @override
+    @property
     def root_device(self) -> torch.device:
         assert self.parallel_devices is not None
         return self.parallel_devices[self.local_rank]
@@ -113,8 +113,8 @@ class ModelParallelStrategy(ParallelStrategy):
     def num_processes(self) -> int:
         return len(self.parallel_devices) if self.parallel_devices is not None else 0
 
-    @property
     @override
+    @property
     def distributed_sampler_kwargs(self) -> dict[str, Any]:
         assert self.device_mesh is not None
         data_parallel_mesh = self.device_mesh["data_parallel"]
@@ -124,13 +124,13 @@ class ModelParallelStrategy(ParallelStrategy):
     def process_group_backend(self) -> Optional[str]:
         return self._process_group_backend
 
-    @property
     @override
+    @property
     def restore_checkpoint_after_setup(self) -> bool:
         return True
 
-    @property
     @override
+    @property
     def lightning_restore_optimizer(self) -> bool:
         return False
 

--- a/src/lightning/pytorch/strategies/parallel.py
+++ b/src/lightning/pytorch/strategies/parallel.py
@@ -66,8 +66,8 @@ class ParallelStrategy(Strategy, ABC):
     def world_size(self) -> int:
         return self.cluster_environment.world_size() if self.cluster_environment is not None else 1
 
-    @property
     @override
+    @property
     def is_global_zero(self) -> bool:
         return self.global_rank == 0
 

--- a/src/lightning/pytorch/strategies/single_device.py
+++ b/src/lightning/pytorch/strategies/single_device.py
@@ -68,8 +68,8 @@ class SingleDeviceStrategy(Strategy):
         """Perform a all_gather on all processes."""
         return tensor
 
-    @property
     @override
+    @property
     def root_device(self) -> torch.device:
         return self._root_device
 
@@ -78,8 +78,8 @@ class SingleDeviceStrategy(Strategy):
         assert self.model is not None, "self.model must be set before self.model.to()"
         self.model.to(self.root_device)
 
-    @property
     @override
+    @property
     def is_global_zero(self) -> bool:
         return True
 

--- a/src/lightning/pytorch/strategies/single_xla.py
+++ b/src/lightning/pytorch/strategies/single_xla.py
@@ -33,6 +33,7 @@ from lightning.pytorch.utilities import find_shared_parameters, set_shared_param
 class SingleDeviceXLAStrategy(SingleDeviceStrategy):
     """Strategy for training on a single XLA device."""
 
+    @override
     def __init__(
         self,
         device: _DEVICE,
@@ -56,8 +57,8 @@ class SingleDeviceXLAStrategy(SingleDeviceStrategy):
         )
         self.debug = debug
 
-    @property
     @override
+    @property
     def checkpoint_io(self) -> Union[XLACheckpointIO, _WrappingCheckpointIO]:
         plugin = self._checkpoint_io
         if plugin is not None:
@@ -65,15 +66,15 @@ class SingleDeviceXLAStrategy(SingleDeviceStrategy):
             return plugin
         return XLACheckpointIO()
 
-    @checkpoint_io.setter
     @override
+    @checkpoint_io.setter
     def checkpoint_io(self, io: Optional[CheckpointIO]) -> None:
         if io is not None and not isinstance(io, (XLACheckpointIO, _WrappingCheckpointIO)):
             raise TypeError(f"The XLA strategy can only work with the `XLACheckpointIO` plugin, found {io}")
         self._checkpoint_io = io
 
-    @property
     @override
+    @property
     def precision_plugin(self) -> XLAPrecision:
         plugin = self._precision_plugin
         if plugin is not None:
@@ -81,8 +82,8 @@ class SingleDeviceXLAStrategy(SingleDeviceStrategy):
             return plugin
         return XLAPrecision()
 
-    @precision_plugin.setter
     @override
+    @precision_plugin.setter
     def precision_plugin(self, precision_plugin: Optional[Precision]) -> None:
         if precision_plugin is not None and not isinstance(precision_plugin, XLAPrecision):
             raise TypeError(f"The XLA strategy can only work with the `XLAPrecision` plugin, found {precision_plugin}")

--- a/src/lightning/pytorch/strategies/strategy.py
+++ b/src/lightning/pytorch/strategies/strategy.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Mapping
@@ -22,6 +21,7 @@ import torch
 from torch import Tensor
 from torch.nn import Module
 from torch.optim import Optimizer
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.fabric.plugins import CheckpointIO

--- a/src/lightning/pytorch/strategies/strategy.py
+++ b/src/lightning/pytorch/strategies/strategy.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Mapping
@@ -588,6 +589,7 @@ class Strategy(ABC):
         self._lightning_optimizers = []
         self.lr_scheduler_configs = []
 
+    @override
     def __getstate__(self) -> dict:
         # `LightningOptimizer` overrides `self.__class__` so they cannot be pickled
         state = dict(vars(self))  # copy

--- a/src/lightning/pytorch/strategies/xla.py
+++ b/src/lightning/pytorch/strategies/xla.py
@@ -46,6 +46,7 @@ class XLAStrategy(DDPStrategy):
 
     strategy_name = "xla"
 
+    @override
     def __init__(
         self,
         accelerator: Optional["pl.accelerators.Accelerator"] = None,
@@ -70,8 +71,8 @@ class XLAStrategy(DDPStrategy):
         self._launched = False
         self._sync_module_states = sync_module_states
 
-    @property
     @override
+    @property
     def checkpoint_io(self) -> Union[XLACheckpointIO, _WrappingCheckpointIO]:
         plugin = self._checkpoint_io
         if plugin is not None:
@@ -79,15 +80,15 @@ class XLAStrategy(DDPStrategy):
             return plugin
         return XLACheckpointIO()
 
-    @checkpoint_io.setter
     @override
+    @checkpoint_io.setter
     def checkpoint_io(self, io: Optional[CheckpointIO]) -> None:
         if io is not None and not isinstance(io, (XLACheckpointIO, _WrappingCheckpointIO)):
             raise TypeError(f"The XLA strategy can only work with the `XLACheckpointIO` plugin, found {io}")
         self._checkpoint_io = io
 
-    @property
     @override
+    @property
     def precision_plugin(self) -> XLAPrecision:
         plugin = self._precision_plugin
         if plugin is not None:
@@ -95,15 +96,15 @@ class XLAStrategy(DDPStrategy):
             return plugin
         return XLAPrecision()
 
-    @precision_plugin.setter
     @override
+    @precision_plugin.setter
     def precision_plugin(self, precision_plugin: Optional[Precision]) -> None:
         if precision_plugin is not None and not isinstance(precision_plugin, XLAPrecision):
             raise TypeError(f"The XLA strategy can only work with the `XLAPrecision` plugin, found {precision_plugin}")
         self._precision_plugin = precision_plugin
 
-    @property
     @override
+    @property
     def root_device(self) -> torch.device:
         if not self._launched:
             raise RuntimeError("Accessing the XLA device before processes have spawned is not allowed.")
@@ -111,23 +112,23 @@ class XLAStrategy(DDPStrategy):
 
         return xm.xla_device()
 
-    @property
     @override
+    @property
     def global_rank(self) -> int:
         return super().global_rank if self._launched else 0
 
-    @property
     @override
+    @property
     def local_rank(self) -> int:
         return super().local_rank if self._launched else 0
 
-    @property
     @override
+    @property
     def node_rank(self) -> int:
         return super().node_rank if self._launched else 0
 
-    @property
     @override
+    @property
     def world_size(self) -> int:
         return super().world_size if self._launched else 1
 
@@ -170,8 +171,8 @@ class XLAStrategy(DDPStrategy):
     def _setup_model(self, model: Module) -> Module:  # type: ignore
         return model
 
-    @property
     @override
+    @property
     def distributed_sampler_kwargs(self) -> dict[str, int]:
         return {"num_replicas": self.world_size, "rank": self.global_rank}
 

--- a/src/lightning/pytorch/trainer/connectors/logger_connector/result.py
+++ b/src/lightning/pytorch/trainer/connectors/logger_connector/result.py
@@ -518,11 +518,13 @@ class _ResultCollection(dict):
         """Move all data to CPU."""
         return self.to(device="cpu")
 
+    @override
     def __str__(self) -> str:
         # remove empty values
         self_str = str({k: v for k, v in self.items() if v})
         return f"{self.__class__.__name__}({self_str})"
 
+    @override
     def __repr__(self) -> str:
         return f"{{{self.training}, {super().__repr__()}}}"
 

--- a/src/lightning/pytorch/trainer/connectors/signal_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/signal_connector.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import logging
 import os
 import re
@@ -152,6 +153,7 @@ class _SignalConnector:
         if threading.current_thread() is threading.main_thread():
             signal.signal(signum, handlers)  # type: ignore[arg-type]
 
+    @override
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         state["_original_handlers"] = {}

--- a/src/lightning/pytorch/trainer/connectors/signal_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/signal_connector.py
@@ -1,4 +1,3 @@
-from typing_extensions import override
 import logging
 import os
 import re
@@ -10,6 +9,7 @@ from typing import Any, Callable, Union
 
 import torch
 import torch.distributed as dist
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.fabric.plugins.environments import SLURMEnvironment

--- a/src/lightning/pytorch/utilities/combined_loader.py
+++ b/src/lightning/pytorch/utilities/combined_loader.py
@@ -51,6 +51,7 @@ class _ModeIterator(Iterator[_ITERATOR_RETURN]):
         self.iterators = []
         self._idx = 0
 
+    @override
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
 

--- a/src/lightning/pytorch/utilities/model_summary/model_summary.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Utilities related to model weights summary."""
 
-from typing_extensions import override
 import contextlib
 import logging
 import math
@@ -25,6 +24,7 @@ import torch.nn as nn
 from torch import Tensor
 from torch.utils.flop_counter import FlopCounterMode
 from torch.utils.hooks import RemovableHandle
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.fabric.utilities import rank_zero_warn

--- a/src/lightning/pytorch/utilities/model_summary/model_summary.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utilities related to model weights summary."""
 
+from typing_extensions import override
 import contextlib
 import logging
 import math
@@ -409,6 +410,7 @@ class ModelSummary:
         if "Out sizes" in layer_summaries:
             layer_summaries["Out sizes"].append(NOT_APPLICABLE)
 
+    @override
     def __str__(self) -> str:
         arrays = self._get_summary_data()
 
@@ -427,6 +429,7 @@ class ModelSummary:
             *arrays,
         )
 
+    @override
     def __repr__(self) -> str:
         return str(self)
 

--- a/src/lightning/pytorch/utilities/model_summary/model_summary_deepspeed.py
+++ b/src/lightning/pytorch/utilities/model_summary/model_summary_deepspeed.py
@@ -35,8 +35,8 @@ def deepspeed_param_size(p: torch.nn.Parameter) -> int:
 
 
 class DeepSpeedLayerSummary(LayerSummary):
-    @property
     @override
+    @property
     def num_parameters(self) -> int:
         """Returns the number of parameters in this module."""
         return sum(deepspeed_param_size(p) if not _tensor_has_shape(p) else 0 for p in self._module.parameters())
@@ -67,13 +67,13 @@ class DeepSpeedSummary(ModelSummary):
 
         return summary
 
-    @property
     @override
+    @property
     def total_parameters(self) -> int:
         return sum(deepspeed_param_size(p) if not _tensor_has_shape(p) else 0 for p in self._model.parameters())
 
-    @property
     @override
+    @property
     def trainable_parameters(self) -> int:
         return sum(
             deepspeed_param_size(p) if not _tensor_has_shape(p) else 0

--- a/tests/parity_fabric/models.py
+++ b/tests/parity_fabric/models.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from abc import ABC, abstractmethod
 from typing import Callable
 
@@ -20,6 +19,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader, TensorDataset
+from typing_extensions import override
 
 
 class ParityModel(ABC, nn.Module):

--- a/tests/parity_fabric/models.py
+++ b/tests/parity_fabric/models.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from abc import ABC, abstractmethod
 from typing import Callable
 
@@ -54,6 +55,7 @@ class ConvNet(ParityModel):
         self.fc2 = nn.Linear(120, 84)
         self.fc3 = nn.Linear(84, 10)
 
+    @override
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
@@ -62,9 +64,11 @@ class ConvNet(ParityModel):
         x = F.relu(self.fc2(x))
         return self.fc3(x)
 
+    @override
     def get_optimizer(self):
         return torch.optim.SGD(self.parameters(), lr=0.0001)
 
+    @override
     def get_dataloader(self):
         # multiply * 8 just in case world size is larger than 1
         dataset_size = self.num_steps * self.batch_size * 8
@@ -77,5 +81,6 @@ class ConvNet(ParityModel):
             num_workers=2,
         )
 
+    @override
     def get_loss_function(self):
         return F.cross_entropy

--- a/tests/parity_pytorch/models.py
+++ b/tests/parity_pytorch/models.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import torch
 import torch.nn.functional as F
 from tests_pytorch import _PATH_DATASETS
@@ -44,6 +45,7 @@ class ParityModuleCIFAR(LightningModule):
         ])
         self._loss = []  # needed for checking if the loss is the same as vanilla torch
 
+    @override
     def training_step(self, batch, batch_idx):
         x, y = batch
         y_hat = self.backbone(x)
@@ -52,9 +54,11 @@ class ParityModuleCIFAR(LightningModule):
         self._loss.append(loss.item())
         return {"loss": loss}
 
+    @override
     def configure_optimizers(self):
         return torch.optim.Adam(self.parameters(), lr=self.learning_rate)
 
+    @override
     def train_dataloader(self):
         return DataLoader(
             CIFAR10(root=_PATH_DATASETS, train=True, download=True, transform=self.transform),

--- a/tests/parity_pytorch/models.py
+++ b/tests/parity_pytorch/models.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import torch
 import torch.nn.functional as F
 from tests_pytorch import _PATH_DATASETS
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.pytorch.core.module import LightningModule
 from lightning.pytorch.utilities.imports import _TORCHVISION_AVAILABLE

--- a/tests/parity_pytorch/test_sync_batchnorm_parity.py
+++ b/tests/parity_pytorch/test_sync_batchnorm_parity.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, DistributedSampler
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer, seed_everything
 from parity_pytorch import RunIf

--- a/tests/parity_pytorch/test_sync_batchnorm_parity.py
+++ b/tests/parity_pytorch/test_sync_batchnorm_parity.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, DistributedSampler
@@ -28,9 +29,11 @@ class SyncBNModule(LightningModule):
         self.linear = nn.Linear(1, 10)
         self.bn_outputs = []
 
+    @override
     def on_train_start(self) -> None:
         assert isinstance(self.bn_layer, torch.nn.modules.batchnorm.SyncBatchNorm)
 
+    @override
     def training_step(self, batch, batch_idx):
         with torch.no_grad():
             out_bn = self.bn_layer(batch)
@@ -38,9 +41,11 @@ class SyncBNModule(LightningModule):
         out = self.linear(out_bn)
         return out.sum()
 
+    @override
     def configure_optimizers(self):
         return torch.optim.SGD(self.parameters(), lr=0.02)
 
+    @override
     def train_dataloader(self):
         dataset = torch.arange(64, dtype=torch.float).view(-1, 1)
         # we need to set a distributed sampler ourselves to force shuffle=False

--- a/tests/tests_fabric/accelerators/test_registry.py
+++ b/tests/tests_fabric/accelerators/test_registry.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from typing import Any
 
 import torch
@@ -27,29 +28,36 @@ class TestAccelerator(Accelerator):
         self.param2 = param2
         super().__init__()
 
+    @override
     def setup_device(self, device: torch.device) -> None:
         pass
 
+    @override
     def teardown(self) -> None:
         pass
 
     @staticmethod
+    @override
     def parse_devices(devices):
         return devices
 
     @staticmethod
+    @override
     def get_parallel_devices(devices):
         return ["foo"] * devices
 
     @staticmethod
+    @override
     def auto_device_count():
         return 3
 
     @staticmethod
+    @override
     def is_available():
         return True
 
     @staticmethod
+    @override
     def name():
         return "test_accelerator"
 
@@ -64,32 +72,39 @@ def test_accelerator_registry_with_new_accelerator():
             self.param2 = param2
             super().__init__()
 
+        @override
         def setup_device(self, device: torch.device) -> None:
             pass
 
         def get_device_stats(self, device: torch.device) -> dict[str, Any]:
             pass
 
+        @override
         def teardown(self) -> None:
             pass
 
         @staticmethod
+        @override
         def parse_devices(devices):
             return devices
 
         @staticmethod
+        @override
         def get_parallel_devices(devices):
             return ["foo"] * devices
 
         @staticmethod
+        @override
         def auto_device_count():
             return 3
 
         @staticmethod
+        @override
         def is_available():
             return True
 
         @staticmethod
+        @override
         def name():
             return "custom_accelerator"
 

--- a/tests/tests_fabric/accelerators/test_registry.py
+++ b/tests/tests_fabric/accelerators/test_registry.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from typing import Any
 
 import torch
+from typing_extensions import override
 
 from lightning.fabric.accelerators import ACCELERATOR_REGISTRY, Accelerator
 from lightning.fabric.accelerators.registry import _AcceleratorRegistry

--- a/tests/tests_fabric/helpers/dataloaders.py
+++ b/tests/tests_fabric/helpers/dataloaders.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 # Copyright The Lightning AI team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,6 +42,7 @@ class CustomNotImplementedErrorDataloader(CustomInfDataloader):
         """Raise NotImplementedError."""
         raise NotImplementedError
 
+    @override
     def __next__(self):
         if self.count >= 2:
             raise StopIteration

--- a/tests/tests_fabric/helpers/dataloaders.py
+++ b/tests/tests_fabric/helpers/dataloaders.py
@@ -1,4 +1,5 @@
 from typing_extensions import override
+
 # Copyright The Lightning AI team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/tests_fabric/helpers/datasets.py
+++ b/tests/tests_fabric/helpers/datasets.py
@@ -1,9 +1,9 @@
-from typing_extensions import override
 from collections.abc import Iterator
 
 import torch
 from torch import Tensor
 from torch.utils.data import Dataset, IterableDataset
+from typing_extensions import override
 
 
 class RandomDataset(Dataset):

--- a/tests/tests_fabric/helpers/datasets.py
+++ b/tests/tests_fabric/helpers/datasets.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 from collections.abc import Iterator
 
 import torch
@@ -10,6 +11,7 @@ class RandomDataset(Dataset):
         self.len = length
         self.data = torch.randn(length, size)
 
+    @override
     def __getitem__(self, index: int) -> Tensor:
         return self.data[index]
 
@@ -22,6 +24,7 @@ class RandomIterableDataset(IterableDataset):
         self.count = count
         self.size = size
 
+    @override
     def __iter__(self) -> Iterator[Tensor]:
         for _ in range(self.count):
             yield torch.randn(self.size)

--- a/tests/tests_fabric/plugins/precision/test_amp_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_amp_integration.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 """Integration tests for Automatic Mixed Precision (AMP) training."""
 
-from typing_extensions import override
 import pytest
 import torch
 import torch.nn as nn
+from typing_extensions import override
 
 from lightning.fabric import Fabric, seed_everything
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4

--- a/tests/tests_fabric/plugins/precision/test_amp_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_amp_integration.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Integration tests for Automatic Mixed Precision (AMP) training."""
 
+from typing_extensions import override
 import pytest
 import torch
 import torch.nn as nn
@@ -28,6 +29,7 @@ class MixedPrecisionModule(nn.Module):
         self.expected_dtype = expected_dtype
         self.layer = torch.nn.Linear(32, 2)
 
+    @override
     def forward(self, x):
         assert x.dtype == self.expected_dtype
         if x.device.type == "cpu":

--- a/tests/tests_fabric/plugins/precision/test_bitsandbytes.py
+++ b/tests/tests_fabric/plugins/precision/test_bitsandbytes.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+from typing_extensions import override
 import platform
 import sys
 from unittest.mock import Mock
@@ -246,6 +247,7 @@ def test_load_quantized_checkpoint(tmp_path):
             super().__init__()
             self.linear = torch.nn.Linear(16, 16, bias=False)
 
+        @override
         def forward(self, x):
             return self.linear(x)
 

--- a/tests/tests_fabric/plugins/precision/test_bitsandbytes.py
+++ b/tests/tests_fabric/plugins/precision/test_bitsandbytes.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from typing_extensions import override
 import platform
 import sys
 from unittest.mock import Mock
@@ -19,6 +18,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 import torch.distributed
+from typing_extensions import override
 
 import lightning.fabric
 from lightning.fabric import Fabric

--- a/tests/tests_fabric/plugins/precision/test_double_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_double_integration.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Integration tests for double-precision training."""
 
+from typing_extensions import override
 import torch
 import torch.nn as nn
 
@@ -26,6 +27,7 @@ class BoringDoubleModule(nn.Module):
         self.layer = torch.nn.Linear(32, 2)
         self.register_buffer("complex_buffer", torch.complex(torch.rand(10), torch.rand(10)), False)
 
+    @override
     def forward(self, x):
         assert x.dtype == torch.float64
         # the default dtype for new tensors is now float64

--- a/tests/tests_fabric/plugins/precision/test_double_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_double_integration.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Integration tests for double-precision training."""
 
-from typing_extensions import override
 import torch
 import torch.nn as nn
+from typing_extensions import override
 
 from lightning.fabric import Fabric
 from tests_fabric.helpers.runif import RunIf

--- a/tests/tests_fabric/plugins/precision/test_xla_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_xla_integration.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from unittest import mock
 
 import pytest
 import torch
 import torch.nn as nn
+from typing_extensions import override
 
 from lightning.fabric import Fabric
 from lightning.fabric.plugins import XLAPrecision

--- a/tests/tests_fabric/plugins/precision/test_xla_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_xla_integration.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from unittest import mock
 
@@ -29,6 +30,7 @@ class BoringPrecisionModule(nn.Module):
         self.expected_dtype = expected_dtype
         self.layer = torch.nn.Linear(32, 2)
 
+    @override
     def forward(self, x):
         # TODO: These should be float16/bfloat16
         assert x.dtype == torch.float32

--- a/tests/tests_fabric/strategies/test_ddp.py
+++ b/tests/tests_fabric/strategies/test_ddp.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from copy import deepcopy
 from datetime import timedelta
@@ -21,6 +20,7 @@ from unittest.mock import MagicMock, Mock
 import pytest
 import torch
 from torch.nn.parallel import DistributedDataParallel
+from typing_extensions import override
 
 from lightning.fabric.plugins import DoublePrecision, HalfPrecision, Precision
 from lightning.fabric.plugins.environments import LightningEnvironment

--- a/tests/tests_fabric/strategies/test_ddp.py
+++ b/tests/tests_fabric/strategies/test_ddp.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from copy import deepcopy
 from datetime import timedelta
@@ -46,6 +47,7 @@ def test_ddp_process_group_backend(process_group_backend, device_str, expected_p
             self._root_device = root_device
             super().__init__(process_group_backend=process_group_backend)
 
+        @override
         @property
         def root_device(self):
             return self._root_device

--- a/tests/tests_fabric/strategies/test_deepspeed_integration.py
+++ b/tests/tests_fabric/strategies/test_deepspeed_integration.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from copy import deepcopy
 from unittest import mock
@@ -22,6 +21,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.fabric import Fabric
 from lightning.fabric.plugins import DeepSpeedPrecision

--- a/tests/tests_fabric/strategies/test_deepspeed_integration.py
+++ b/tests/tests_fabric/strategies/test_deepspeed_integration.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from copy import deepcopy
 from unittest import mock
@@ -274,6 +275,7 @@ def test_deepspeed_with_bfloat16_precision():
             super().__init__()
             self.layer = nn.Linear(32, 2)
 
+        @override
         def forward(self, x):
             assert x.dtype == torch.bfloat16
             return self.layer(x)

--- a/tests/tests_fabric/strategies/test_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_fsdp_integration.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from copy import deepcopy
 from pathlib import Path
@@ -26,6 +25,7 @@ from torch.distributed.fsdp import FlatParameter, FullyShardedDataParallel, Opti
 from torch.distributed.fsdp.wrap import always_wrap_policy, wrap
 from torch.nn import Parameter
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.fabric import Fabric
 from lightning.fabric.plugins import FSDPPrecision

--- a/tests/tests_fabric/strategies/test_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_fsdp_integration.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from copy import deepcopy
 from pathlib import Path
@@ -75,11 +76,13 @@ class BasicTrainer:
 
 
 class _Trainer(BasicTrainer):
+    @override
     def get_model(self):
         model = torch.nn.Sequential(torch.nn.Linear(32, 32), torch.nn.ReLU(), torch.nn.Linear(32, 2))
         self.num_wrapped = 4
         return model
 
+    @override
     def step(self, model, batch):
         wrapped_layers = [m for m in model.modules() if isinstance(m, FullyShardedDataParallel)]
         assert len(wrapped_layers) == self.num_wrapped
@@ -104,6 +107,7 @@ class _Trainer(BasicTrainer):
 
 
 class _TrainerManualWrapping(_Trainer):
+    @override
     def get_model(self):
         model = super().get_model()
         for i, layer in enumerate(model):

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from copy import deepcopy
 from pathlib import Path
@@ -22,6 +21,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader, DistributedSampler
+from typing_extensions import override
 
 from lightning.fabric import Fabric
 from lightning.fabric.strategies.model_parallel import ModelParallelStrategy, _load_raw_module_state

--- a/tests/tests_fabric/strategies/test_model_parallel_integration.py
+++ b/tests/tests_fabric/strategies/test_model_parallel_integration.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from copy import deepcopy
 from pathlib import Path
@@ -43,6 +44,7 @@ class FeedForward(nn.Module):
         self.w2 = nn.Linear(32, 64)
         self.w3 = nn.Linear(64, 32)
 
+    @override
     def forward(self, x):
         return self.w3(F.silu(self.w1(x)) * self.w2(x))
 

--- a/tests/tests_fabric/test_connector.py
+++ b/tests/tests_fabric/test_connector.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+from typing_extensions import override
 import inspect
 import os
 import sys
@@ -125,10 +126,12 @@ def test_custom_cluster_environment_in_slurm_environment(_):
     """Test that we choose the custom cluster even when SLURM or TE flags are around."""
 
     class CustomCluster(LightningEnvironment):
+        @override
         @property
         def main_address(self):
             return "asdf"
 
+        @override
         @property
         def creates_processes_externally(self) -> bool:
             return True
@@ -162,32 +165,39 @@ def test_custom_cluster_environment_in_slurm_environment(_):
 @mock.patch("lightning.fabric.accelerators.cuda.num_cuda_devices", return_value=0)
 def test_custom_accelerator(*_):
     class Accel(Accelerator):
+        @override
         def setup_device(self, device: torch.device) -> None:
             pass
 
         def get_device_stats(self, device: torch.device) -> dict[str, Any]:
             pass
 
+        @override
         def teardown(self) -> None:
             pass
 
         @staticmethod
+        @override
         def parse_devices(devices):
             return devices
 
         @staticmethod
+        @override
         def get_parallel_devices(devices):
             return [torch.device("cpu")] * devices
 
         @staticmethod
+        @override
         def auto_device_count() -> int:
             return 1
 
         @staticmethod
+        @override
         def is_available() -> bool:
             return True
 
         @staticmethod
+        @override
         def name() -> str:
             return "custom_acc_name"
 

--- a/tests/tests_fabric/test_connector.py
+++ b/tests/tests_fabric/test_connector.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from typing_extensions import override
 import inspect
 import os
 import sys
@@ -24,6 +23,7 @@ import pytest
 import torch
 import torch.distributed
 from lightning_utilities.test.warning import no_warning_call
+from typing_extensions import override
 
 import lightning.fabric
 from lightning.fabric import Fabric

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import inspect
 import os
 import warnings
@@ -50,6 +51,7 @@ class BoringModel(nn.Module):
         super().__init__()
         self.layer = torch.nn.Linear(32, 2, bias=False)
 
+    @override
     def forward(self, x):
         x = self.layer(x)
         return torch.nn.functional.mse_loss(x, torch.ones_like(x))
@@ -62,6 +64,7 @@ def test_run_input_output():
         run_args = ()
         run_kwargs = {}
 
+        @override
         def run(self, *args, **kwargs):
             self.run_args = args
             self.run_kwargs = kwargs
@@ -682,6 +685,7 @@ def test_backward_required(_, strategy, precision, error_expected, setup_method)
 
     # Model that returns a datastructure of tensors
     class DictReturnModel(nn.Linear):
+        @override
         def forward(self, x):
             return {
                 "loss": super().forward(x).sum(),
@@ -849,6 +853,7 @@ def test_launch_and_strategies_unsupported_combinations(strategy, xla_available)
 @mock.patch.dict(os.environ, {"LT_CLI_USED": "1"})  # pretend we are using the CLI
 def test_overridden_run_and_cli_not_allowed():
     class FabricWithRun(Fabric):
+        @override
         def run(self):
             pass
 

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import inspect
 import os
 import warnings
@@ -26,6 +25,7 @@ import torch.nn.functional
 from lightning_utilities.test.warning import no_warning_call
 from torch import nn
 from torch.utils.data import DataLoader, DistributedSampler, RandomSampler, Sampler, SequentialSampler, TensorDataset
+from typing_extensions import override
 
 import lightning.fabric
 from lightning.fabric.fabric import Fabric

--- a/tests/tests_fabric/test_wrappers.py
+++ b/tests/tests_fabric/test_wrappers.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from unittest import mock
 from unittest.mock import Mock, call
 
@@ -83,6 +84,7 @@ def test_fabric_module_method_lookup():
             super().__init__()
             self.submodule = torch.nn.Linear(2, 3)
 
+        @override
         def forward(self, x):
             return x
 
@@ -102,6 +104,7 @@ def test_fabric_module_method_lookup():
             super().__init__()
             self.wrapped = module
 
+        @override
         def forward(self, *args, **kwargs):
             return self.wrapped(*args, **kwargs)
 
@@ -135,6 +138,7 @@ def test_fabric_module_mark_forward_method():
     class OriginalModule(torch.nn.Module):
         attribute = 1
 
+        @override
         def forward(self, x):
             return x
 
@@ -521,6 +525,7 @@ def test_fabric_optimizer_zero_grad_kwargs():
     custom_zero_grad = Mock()
 
     class CustomSGD(torch.optim.SGD):
+        @override
         def zero_grad(self, set_grads_to_None=False):
             custom_zero_grad(set_grads_to_None=set_grads_to_None)
 
@@ -607,10 +612,12 @@ def test_step_method_redirection():
             super().__init__()
             self.module = module
 
+        @override
         def forward(self, *args, **kwargs):
             return self.module(*args, **kwargs)
 
     class LightningModule(torch.nn.Module):
+        @override
         def forward(self):
             return "forward_return"
 

--- a/tests/tests_fabric/test_wrappers.py
+++ b/tests/tests_fabric/test_wrappers.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from unittest import mock
 from unittest.mock import Mock, call
 
@@ -20,6 +19,7 @@ import torch
 from torch._dynamo import OptimizedModule
 from torch.utils.data import BatchSampler, DistributedSampler
 from torch.utils.data.dataloader import DataLoader
+from typing_extensions import override
 
 from lightning.fabric.fabric import Fabric
 from lightning.fabric.plugins import Precision

--- a/tests/tests_fabric/utilities/test_data.py
+++ b/tests/tests_fabric/utilities/test_data.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import contextlib
 import os
 import random
@@ -82,6 +83,7 @@ def test_replace_dunder_methods_multiple_loaders_without_init():
 
 def test_replace_dunder_methods_cleanup_tolerates_concurrent_restore():
     class ConcurrentCleanupMeta(type):
+        @override
         def __getattribute__(cls, name):
             if (
                 name == "__old__delattr__"
@@ -296,6 +298,7 @@ def test_replace_dunder_methods_attrs():
     """
 
     class Loader(DataLoader):
+        @override
         def __setattr__(self, attr, val):
             if attr == "custom_arg":
                 val = val + 2
@@ -340,10 +343,12 @@ def test_replace_dunder_methods_restore_methods():
             super().__init__(*args, **kwargs)
 
     class SetAttr(DataLoader):
+        @override
         def __setattr__(self, *args):
             return super().__setattr__(*args)
 
     class DelAttr(DataLoader):
+        @override
         def __delattr__(self, *args):
             return super().__delattr__(*args)
 

--- a/tests/tests_fabric/utilities/test_data.py
+++ b/tests/tests_fabric/utilities/test_data.py
@@ -1,4 +1,3 @@
-from typing_extensions import override
 import contextlib
 import os
 import random
@@ -11,6 +10,7 @@ import torch
 from lightning_utilities.test.warning import no_warning_call
 from torch import Tensor
 from torch.utils.data import BatchSampler, DataLoader, RandomSampler
+from typing_extensions import override
 
 import lightning.fabric
 from lightning.fabric.utilities.data import (

--- a/tests/tests_fabric/utilities/test_distributed.py
+++ b/tests/tests_fabric/utilities/test_distributed.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import functools
 import os
 from functools import partial
@@ -288,6 +289,7 @@ class _CustomSampler(torch.utils.data.Sampler):
     def __len__(self):
         return len(self.data_source)
 
+    @override
     def __iter__(self):
         return iter(range(len(self.data_source)))
 
@@ -300,6 +302,7 @@ class _CustomSamplerWithSetEpoch(_CustomSampler):
         self.epoch = 0
         self.set_epoch_call_count = 0
 
+    @override
     def set_epoch(self, epoch):
         self.epoch = epoch
         self.set_epoch_call_count += 1

--- a/tests/tests_fabric/utilities/test_distributed.py
+++ b/tests/tests_fabric/utilities/test_distributed.py
@@ -1,4 +1,3 @@
-from typing_extensions import override
 import functools
 import os
 from functools import partial
@@ -9,6 +8,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 from lightning_utilities.core.imports import RequirementCache
+from typing_extensions import override
 
 import lightning.fabric
 from lightning.fabric.accelerators import CPUAccelerator, CUDAAccelerator, MPSAccelerator

--- a/tests/tests_pytorch/accelerators/test_common.py
+++ b/tests/tests_pytorch/accelerators/test_common.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from typing import Any
 
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.accelerators import Accelerator

--- a/tests/tests_pytorch/accelerators/test_common.py
+++ b/tests/tests_pytorch/accelerators/test_common.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from typing import Any
 
 import torch
@@ -22,32 +23,40 @@ from lightning.pytorch.strategies import DDPStrategy
 
 def test_pluggable_accelerator(mps_count_0, cuda_count_2):
     class TestAccelerator(Accelerator):
+        @override
         def setup_device(self, device: torch.device) -> None:
             pass
 
+        @override
         def get_device_stats(self, device: torch.device) -> dict[str, Any]:
             pass
 
+        @override
         def teardown(self) -> None:
             pass
 
         @staticmethod
+        @override
         def parse_devices(devices):
             return devices
 
         @staticmethod
+        @override
         def get_parallel_devices(devices):
             return ["foo"] * devices
 
         @staticmethod
+        @override
         def auto_device_count():
             return 3
 
         @staticmethod
+        @override
         def is_available():
             return True
 
         @staticmethod
+        @override
         def name():
             return "custom_acc_name"
 

--- a/tests/tests_pytorch/accelerators/test_cpu.py
+++ b/tests/tests_pytorch/accelerators/test_cpu.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import os
 from pathlib import Path
 from typing import Any, Union
@@ -45,14 +46,17 @@ def test_restore_checkpoint_after_pre_setup(tmp_path, restore_after_pre_setup):
     class TestPlugin(SingleDeviceStrategy):
         setup_called = False
 
+        @override
         def setup(self, trainer: "pl.Trainer") -> None:
             super().setup(trainer)
             self.setup_called = True
 
+        @override
         @property
         def restore_checkpoint_after_setup(self) -> bool:
             return restore_after_pre_setup
 
+        @override
         def load_checkpoint(self, checkpoint_path: Union[str, Path], weights_only: bool) -> dict[str, Any]:
             assert self.setup_called == restore_after_pre_setup
             return super().load_checkpoint(checkpoint_path, weights_only)

--- a/tests/tests_pytorch/accelerators/test_cpu.py
+++ b/tests/tests_pytorch/accelerators/test_cpu.py
@@ -1,4 +1,3 @@
-from typing_extensions import override
 import os
 from pathlib import Path
 from typing import Any, Union
@@ -6,6 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.fabric.plugins import TorchCheckpointIO

--- a/tests/tests_pytorch/accelerators/test_xla.py
+++ b/tests/tests_pytorch/accelerators/test_xla.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+from typing_extensions import override
 import collections
 import os
 from copy import deepcopy
@@ -43,6 +44,7 @@ class WeightSharingModule(BoringModel):
         self.layer_3 = nn.Linear(32, 10, bias=False)
         self.layer_3.weight = self.layer_1.weight
 
+    @override
     def forward(self, x):
         x = self.layer_1(x)
         x = self.layer_2(x)
@@ -115,10 +117,12 @@ class ManualOptimizationModel(BoringModel):
     def should_update(self):
         return self.count % 2 == 0
 
+    @override
     def on_train_batch_start(self, batch, batch_idx):
         self.called["on_train_batch_start"] += 1
         self.weight_before = self.layer.weight.clone()
 
+    @override
     def training_step(self, batch, batch_idx):
         self.called["training_step"] += 1
         opt = self.optimizers()
@@ -130,6 +134,7 @@ class ManualOptimizationModel(BoringModel):
             opt.zero_grad()
         return loss
 
+    @override
     def on_train_batch_end(self, *_):
         self.called["on_train_batch_end"] += 1
         after_before = self.layer.weight.clone()
@@ -140,11 +145,13 @@ class ManualOptimizationModel(BoringModel):
         assert_emtpy_grad(self.layer.weight.grad)
         self.count += 1
 
+    @override
     def on_train_start(self):
         opt = self.optimizers()
         self.opt_step_patch = patch.object(opt, "step", wraps=opt.step)
         self.opt_step_mock = self.opt_step_patch.start()
 
+    @override
     def on_train_end(self):
         # this might fail if run in an environment with too many ranks, as the total
         # length of the dataloader will be distributed among them and then each rank might not do 3 steps
@@ -214,6 +221,7 @@ class SubModule(nn.Module):
         super().__init__()
         self.layer = layer
 
+    @override
     def forward(self, x):
         return self.layer(x)
 
@@ -226,6 +234,7 @@ class NestedModule(BoringModel):
         self.layer_2 = nn.Linear(10, 32, bias=False)
         self.net_b = SubModule(self.layer)
 
+    @override
     def forward(self, x):
         x = self.net_a(x)
         x = self.layer_2(x)

--- a/tests/tests_pytorch/accelerators/test_xla.py
+++ b/tests/tests_pytorch/accelerators/test_xla.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from typing_extensions import override
 import collections
 import os
 from copy import deepcopy
@@ -22,6 +21,7 @@ import pytest
 import torch
 from torch import nn
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 import lightning.fabric
 from lightning.fabric.utilities.imports import _IS_WINDOWS

--- a/tests/tests_pytorch/callbacks/progress/test_rich_progress_bar.py
+++ b/tests/tests_pytorch/callbacks/progress/test_rich_progress_bar.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pickle
 from collections import defaultdict
 from unittest import mock
@@ -20,6 +19,7 @@ from unittest.mock import DEFAULT, Mock
 import pytest
 from tests_pytorch.helpers.runif import RunIf
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import ProgressBar, RichProgressBar

--- a/tests/tests_pytorch/callbacks/progress/test_rich_progress_bar.py
+++ b/tests/tests_pytorch/callbacks/progress/test_rich_progress_bar.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pickle
 from collections import defaultdict
 from unittest import mock
@@ -52,15 +53,19 @@ def test_rich_progress_bar_refresh_rate_enabled():
 @pytest.mark.parametrize("dataset", [RandomDataset(32, 64), RandomIterableDataset(32, 64)])
 def test_rich_progress_bar(tmp_path, dataset):
     class TestModel(BoringModel):
+        @override
         def train_dataloader(self):
             return DataLoader(dataset=dataset)
 
+        @override
         def val_dataloader(self):
             return DataLoader(dataset=dataset)
 
+        @override
         def test_dataloader(self):
             return DataLoader(dataset=dataset)
 
+        @override
         def predict_dataloader(self):
             return DataLoader(dataset=dataset)
 
@@ -140,6 +145,7 @@ def test_rich_progress_bar_keyboard_interrupt(tmp_path):
     """Test to ensure that when the user keyboard interrupts, we close the progress bar."""
 
     class TestModel(BoringModel):
+        @override
         def on_train_start(self) -> None:
             raise KeyboardInterrupt
 
@@ -169,6 +175,7 @@ def test_rich_progress_bar_configure_columns():
     custom_column = TextColumn("[progress.description]Testing Rich!")
 
     class CustomRichProgressBar(RichProgressBar):
+        @override
         def configure_columns(self, trainer):
             return [custom_column]
 
@@ -323,6 +330,7 @@ def test_rich_progress_bar_counter_with_val_check_interval(tmp_path):
 @RunIf(rich=True)
 def test_rich_progress_bar_metric_display_task_id(tmp_path):
     class CustomModel(BoringModel):
+        @override
         def training_step(self, *args, **kwargs):
             res = super().training_step(*args, **kwargs)
             self.log("train_loss", res["loss"], prog_bar=True)
@@ -373,6 +381,7 @@ def test_rich_progress_bar_correct_value_epoch_end(tmp_path):
     class MockedProgressBar(RichProgressBar):
         calls = defaultdict(list)
 
+        @override
         def get_metrics(self, trainer, pl_module):
             items = super().get_metrics(trainer, model)
             del items["v_num"]
@@ -386,14 +395,17 @@ def test_rich_progress_bar_correct_value_epoch_end(tmp_path):
             return items
 
     class MyModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             self.log("a", self.global_step, prog_bar=True, on_step=False, on_epoch=True, reduce_fx=max)
             return super().training_step(batch, batch_idx)
 
+        @override
         def validation_step(self, batch, batch_idx):
             self.log("b", self.global_step, prog_bar=True, on_step=False, on_epoch=True, reduce_fx=max)
             return super().validation_step(batch, batch_idx)
 
+        @override
         def test_step(self, batch, batch_idx):
             self.log("c", self.global_step, prog_bar=True, on_step=False, on_epoch=True, reduce_fx=max)
             return super().test_step(batch, batch_idx)
@@ -546,6 +558,7 @@ def test_rich_progress_bar_metrics_format(tmp_path, metrics_format):
     metric_name = "train_loss"
 
     class CustomModel(BoringModel):
+        @override
         def training_step(self, *args, **kwargs):
             res = super().training_step(*args, **kwargs)
             self.log(metric_name, res["loss"], prog_bar=True)
@@ -588,9 +601,11 @@ def test_rich_progress_bar_empty_val_dataloader_model(tmp_path):
     """Test that RichProgressBar doesn't crash with empty val_dataloader list from model."""
 
     class EmptyListModel(BoringModel):
+        @override
         def train_dataloader(self):
             return DataLoader(RandomDataset(32, 64), batch_size=2)
 
+        @override
         def val_dataloader(self):
             return []
 

--- a/tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar.py
+++ b/tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import math
 import os
 import pickle
@@ -119,21 +120,27 @@ def test_tqdm_progress_bar_totals(tmp_path, num_dl):
             dls = [DataLoader(RandomDataset(32, 64)), DataLoader(RandomDataset(32, 64))]
             return dls[0] if num_dl == 1 else dls
 
+        @override
         def val_dataloader(self):
             return self._get_dataloaders()
 
+        @override
         def test_dataloader(self):
             return self._get_dataloaders()
 
+        @override
         def predict_dataloader(self):
             return self._get_dataloaders()
 
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx=0):
             return
 
+        @override
         def test_step(self, batch, batch_idx, dataloader_idx=0):
             return
 
+        @override
         def predict_step(self, batch, batch_idx, dataloader_idx=0):
             return
 
@@ -244,14 +251,17 @@ def test_tqdm_progress_bar_progress_refresh(tmp_path, refresh_rate: int):
         val_batches_seen = 0
         test_batches_seen = 0
 
+        @override
         def on_train_batch_end(self, *args):
             super().on_train_batch_end(*args)
             self.train_batches_seen += 1
 
+        @override
         def on_validation_batch_end(self, *args):
             super().on_validation_batch_end(*args)
             self.val_batches_seen += 1
 
+        @override
         def on_test_batch_end(self, *args):
             super().on_test_batch_end(*args)
             self.test_batches_seen += 1
@@ -290,10 +300,12 @@ def test_num_sanity_val_steps_progress_bar(tmp_path, limit_val_batches: int):
         val_pbar_total = 0
         sanity_pbar_total = 0
 
+        @override
         def on_sanity_check_end(self, *args):
             self.sanity_pbar_total = self.val_progress_bar.total
             super().on_sanity_check_end(*args)
 
+        @override
         def on_validation_epoch_end(self, *args):
             self.val_pbar_total = self.val_progress_bar.total
             super().on_validation_epoch_end(*args)
@@ -416,6 +428,7 @@ def test_tensor_to_float_conversion(tmp_path):
     """Check tensor gets converted to float."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             self.log("a", torch.tensor(0.123), prog_bar=True, on_epoch=False)
             self.log("b", torch.tensor([1]), prog_bar=True, on_epoch=False)
@@ -460,18 +473,22 @@ def test_tqdm_format_num(input_num: Union[str, int, float], expected: str):
 
 
 class PrintModel(BoringModel):
+    @override
     def training_step(self, *args, **kwargs):
         self.print("training_step", end="")
         return super().training_step(*args, **kwargs)
 
+    @override
     def validation_step(self, *args, **kwargs):
         self.print("validation_step", file=sys.stderr)
         return super().validation_step(*args, **kwargs)
 
+    @override
     def test_step(self, *args, **kwargs):
         self.print("test_step")
         return super().test_step(*args, **kwargs)
 
+    @override
     def predict_step(self, *args, **kwargs):
         self.print("predict_step")
         return super().predict_step(*args, **kwargs)
@@ -667,6 +684,7 @@ def test_get_progress_bar_metrics(tmp_path):
     """Test that the metrics shown in the progress bar can be customized."""
 
     class TestProgressBar(TQDMProgressBar):
+        @override
         def get_metrics(self, trainer: Trainer, model: LightningModule):
             items = super().get_metrics(trainer, model)
             items.pop("v_num", None)
@@ -706,6 +724,7 @@ def test_tqdm_progress_bar_correct_value_epoch_end(tmp_path):
     class MockedProgressBar(TQDMProgressBar):
         calls = defaultdict(list)
 
+        @override
         def get_metrics(self, trainer, pl_module):
             items = super().get_metrics(trainer, model)
             del items["v_num"]
@@ -719,14 +738,17 @@ def test_tqdm_progress_bar_correct_value_epoch_end(tmp_path):
             return items
 
     class MyModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             self.log("a", self.global_step, prog_bar=True, on_step=False, on_epoch=True, reduce_fx=max)
             return super().training_step(batch, batch_idx)
 
+        @override
         def validation_step(self, batch, batch_idx):
             self.log("b", self.global_step, prog_bar=True, on_step=False, on_epoch=True, reduce_fx=max)
             return super().validation_step(batch, batch_idx)
 
+        @override
         def test_step(self, batch, batch_idx):
             self.log("c", self.global_step, prog_bar=True, on_step=False, on_epoch=True, reduce_fx=max)
             return super().test_step(batch, batch_idx)

--- a/tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar.py
+++ b/tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import math
 import os
 import pickle
@@ -25,6 +24,7 @@ import pytest
 import torch
 from tests_pytorch.helpers.runif import RunIf
 from torch.utils.data.dataloader import DataLoader
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint, ProgressBar, TQDMProgressBar

--- a/tests/tests_pytorch/callbacks/test_callback_hook_outputs.py
+++ b/tests/tests_pytorch/callbacks/test_callback_hook_outputs.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pytest
+from typing_extensions import override
 
 from lightning.pytorch import Callback, Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/callbacks/test_callback_hook_outputs.py
+++ b/tests/tests_pytorch/callbacks/test_callback_hook_outputs.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pytest
 
 from lightning.pytorch import Callback, Trainer
@@ -22,22 +23,28 @@ def test_train_step_no_return(tmp_path, single_cb: bool):
     """Tests that only training_step can be used."""
 
     class CB(Callback):
+        @override
         def on_train_batch_end(self, trainer, pl_module, outputs, *_):
             assert "loss" in outputs
 
+        @override
         def on_validation_batch_end(self, trainer, pl_module, outputs, *_):
             assert "x" in outputs
 
+        @override
         def on_test_batch_end(self, trainer, pl_module, outputs, *_):
             assert "x" in outputs
 
     class TestModel(BoringModel):
+        @override
         def on_train_batch_end(self, outputs, *_):
             assert "loss" in outputs
 
+        @override
         def on_validation_batch_end(self, outputs, *_):
             assert "x" in outputs
 
+        @override
         def on_test_batch_end(self, outputs, *_):
             assert "x" in outputs
 

--- a/tests/tests_pytorch/callbacks/test_callbacks.py
+++ b/tests/tests_pytorch/callbacks/test_callbacks.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from pathlib import Path
 from re import escape
 from unittest.mock import Mock, patch
@@ -30,6 +31,7 @@ def test_callbacks_configured_in_model(tmp_path):
     trainer_callback_mock = Mock(spec=Callback, model=Callback())
 
     class TestModel(BoringModel):
+        @override
         def configure_callbacks(self):
             return [model_callback_mock]
 
@@ -80,6 +82,7 @@ def test_configure_callbacks_hook_multiple_calls(tmp_path):
     model_callback_mock = Mock(spec=Callback, model=Callback())
 
     class TestModel(BoringModel):
+        @override
         def configure_callbacks(self):
             return model_callback_mock
 
@@ -109,13 +112,16 @@ class OldStatefulCallback(Callback):
     def __init__(self, state):
         self.state = state
 
+    @override
     @property
     def state_key(self):
         return type(self)
 
+    @override
     def state_dict(self):
         return {"state": self.state}
 
+    @override
     def load_state_dict(self, state_dict) -> None:
         self.state = state_dict["state"]
 

--- a/tests/tests_pytorch/callbacks/test_callbacks.py
+++ b/tests/tests_pytorch/callbacks/test_callbacks.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from pathlib import Path
 from re import escape
 from unittest.mock import Mock, patch
 
 import pytest
 from lightning_utilities.test.warning import no_warning_call
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_6
 from lightning.pytorch import Callback, Trainer

--- a/tests/tests_pytorch/callbacks/test_device_stats_monitor.py
+++ b/tests/tests_pytorch/callbacks/test_device_stats_monitor.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import csv
 import os
 import re
@@ -21,6 +20,7 @@ from unittest.mock import Mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.accelerators.cpu import _CPU_PERCENT, _CPU_SWAP_PERCENT, _CPU_VM_PERCENT, get_cpu_stats

--- a/tests/tests_pytorch/callbacks/test_device_stats_monitor.py
+++ b/tests/tests_pytorch/callbacks/test_device_stats_monitor.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import csv
 import os
 import re
@@ -40,6 +41,7 @@ def test_device_stats_gpu_from_torch(tmp_path):
 
     class DebugLogger(CSVLogger):
         @rank_zero_only
+        @override
         def log_metrics(self, metrics: dict[str, float], step: Optional[int] = None) -> None:
             fields = [
                 "allocated_bytes.all.freed",
@@ -74,6 +76,7 @@ def test_device_stats_cpu(cpu_stats_mock, tmp_path, cpu_stats):
     CPU_METRIC_KEYS = (_CPU_VM_PERCENT, _CPU_SWAP_PERCENT, _CPU_PERCENT)
 
     class DebugLogger(CSVLogger):
+        @override
         def log_metrics(self, metrics: dict[str, float], step: Optional[int] = None) -> None:
             enabled = cpu_stats is not False
             for f in CPU_METRIC_KEYS:
@@ -101,6 +104,7 @@ def test_device_stats_cpu(cpu_stats_mock, tmp_path, cpu_stats):
 
 class AssertTpuMetricsLogger(CSVLogger):
     @rank_zero_only
+    @override
     def log_metrics(self, metrics, step=None) -> None:
         fields = ["avg. free memory (MB)", "avg. peak memory (MB)"]
         for f in fields:
@@ -240,6 +244,7 @@ def test_device_stats_monitor_filter_keys(tmp_path, filter_keys, expected_presen
     model = BoringModel()
 
     class AssertFilterLogger(CSVLogger):
+        @override
         def log_metrics(self, metrics: dict[str, float], step: Optional[int] = None) -> None:
             for key in expected_present:
                 assert any(key in k for k in metrics), f"Expected key {key!r} not found in metrics"

--- a/tests/tests_pytorch/callbacks/test_early_stopping.py
+++ b/tests/tests_pytorch/callbacks/test_early_stopping.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import copy
 import logging
 import math
@@ -49,10 +50,12 @@ class EarlyStoppingTestRestore(EarlyStopping):
         # cache the state for each epoch
         self.saved_states = []
 
+    @override
     def on_train_start(self, trainer, pl_module):
         if self.expected_state:
             assert self.state_dict() == self.expected_state
 
+    @override
     def on_train_epoch_end(self, trainer, pl_module):
         super().on_train_epoch_end(trainer, pl_module)
         self.saved_states.append(self.state_dict().copy())
@@ -136,6 +139,7 @@ def test_early_stopping_patience(tmp_path, loss_values: list, patience: int, exp
     class ModelOverrideValidationReturn(BoringModel):
         validation_return_values = torch.tensor(loss_values)
 
+        @override
         def on_validation_epoch_end(self):
             loss = self.validation_return_values[self.current_epoch]
             self.log("test_val_loss", loss)
@@ -166,6 +170,7 @@ def test_early_stopping_patience_train(
     class ModelOverrideTrainReturn(BoringModel):
         train_return_values = torch.tensor(loss_values)
 
+        @override
         def on_train_epoch_end(self):
             loss = self.train_return_values[self.current_epoch]
             self.log("train_loss", loss)
@@ -227,6 +232,7 @@ def test_early_stopping_no_val_step(tmp_path):
 )
 def test_early_stopping_thresholds(tmp_path, stopping_threshold, divergence_threshold, losses, expected_epoch):
     class CurrentModel(BoringModel):
+        @override
         def on_validation_epoch_end(self):
             val_loss = losses[self.current_epoch]
             self.log("abc", val_loss)
@@ -252,6 +258,7 @@ def test_early_stopping_on_non_finite_monitor(tmp_path, stop_value):
     expected_stop_epoch = 2
 
     class CurrentModel(BoringModel):
+        @override
         def on_validation_epoch_end(self):
             val_loss = losses[self.current_epoch]
             self.log("val_loss", val_loss)
@@ -296,6 +303,7 @@ def test_min_epochs_min_steps_global_step(tmp_path, limit_train_batches, min_epo
         assert limit_train_batches < min_steps
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             self.log("foo", batch_idx)
             return super().training_step(batch, batch_idx)
@@ -352,16 +360,19 @@ class EarlyStoppingModel(BoringModel):
         self.log("abc", torch.tensor(loss))
         self.log("cba", torch.tensor(0))
 
+    @override
     def on_train_epoch_end(self):
         if not self.early_stop_on_train:
             return
         self._epoch_end()
 
+    @override
     def on_validation_epoch_end(self):
         if self.early_stop_on_train:
             return
         self._epoch_end()
 
+    @override
     def on_train_end(self) -> None:
         assert self.trainer.current_epoch - 1 == self.expected_end_epoch, "Early Stopping Failed"
 
@@ -442,6 +453,7 @@ def test_multiple_early_stopping_callbacks(
 )
 def test_check_on_train_epoch_end_smart_handling(tmp_path, case):
     class TestModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx):
             self.log("foo", 1)
             return super().validation_step(batch, batch_idx)
@@ -510,6 +522,7 @@ def test_early_stopping_log_info(log_rank_zero_only, world_size, global_rank, ex
 
 
 class ModelWithHighLoss(BoringModel):
+    @override
     def on_validation_epoch_end(self):
         self.log("val_loss", 10.0)
 
@@ -519,6 +532,7 @@ class ModelWithDecreasingLoss(BoringModel):
         super().__init__()
         self.epoch_losses = [5.0, 3.0, 1.0, 0.5]
 
+    @override
     def on_validation_epoch_end(self):
         loss = self.epoch_losses[self.current_epoch] if self.current_epoch < len(self.epoch_losses) else 0.1
         self.log("val_loss", loss)
@@ -529,6 +543,7 @@ class ModelWithIncreasingLoss(BoringModel):
         super().__init__()
         self.epoch_losses = [1.0, 2.0, 5.0, 10.0]
 
+    @override
     def on_validation_epoch_end(self):
         loss = self.epoch_losses[self.current_epoch] if self.current_epoch < len(self.epoch_losses) else 15.0
         self.log("val_loss", loss)
@@ -539,6 +554,7 @@ class ModelWithNaNLoss(BoringModel):
         super().__init__()
         self.epoch_losses = [1.0, 0.5, float("nan")]
 
+    @override
     def on_validation_epoch_end(self):
         loss = self.epoch_losses[self.current_epoch] if self.current_epoch < len(self.epoch_losses) else float("nan")
         self.log("val_loss", loss)
@@ -549,6 +565,7 @@ class ModelWithImprovingLoss(BoringModel):
         super().__init__()
         self.epoch_losses = [5.0, 4.0, 3.0, 2.0, 1.0]
 
+    @override
     def on_validation_epoch_end(self):
         loss = self.epoch_losses[self.current_epoch] if self.current_epoch < len(self.epoch_losses) else 0.1
         self.log("val_loss", loss)

--- a/tests/tests_pytorch/callbacks/test_early_stopping.py
+++ b/tests/tests_pytorch/callbacks/test_early_stopping.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import copy
 import logging
 import math
@@ -24,6 +23,7 @@ from unittest.mock import Mock
 import cloudpickle
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint

--- a/tests/tests_pytorch/callbacks/test_finetuning_callback.py
+++ b/tests/tests_pytorch/callbacks/test_finetuning_callback.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from collections import OrderedDict
 
 import pytest
@@ -19,6 +18,7 @@ import torch
 from torch import nn
 from torch.optim import SGD, Optimizer
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_3
 from lightning.pytorch import LightningModule, Trainer, seed_everything

--- a/tests/tests_pytorch/callbacks/test_finetuning_callback.py
+++ b/tests/tests_pytorch/callbacks/test_finetuning_callback.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from collections import OrderedDict
 
 import pytest
@@ -27,6 +28,7 @@ from tests_pytorch.helpers.runif import RunIf
 
 
 class TestBackboneFinetuningCallback(BackboneFinetuning):
+    @override
     def on_train_epoch_start(self, trainer, pl_module):
         super().on_train_epoch_start(trainer, pl_module)
         epoch = trainer.current_epoch
@@ -51,16 +53,19 @@ def test_finetuning_callback(tmp_path):
             self.layer = torch.nn.Linear(32, 2)
             self.backbone.has_been_used = False
 
+        @override
         def forward(self, x):
             self.backbone.has_been_used = True
             x = self.backbone(x)
             return self.layer(x)
 
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.7)
             return [optimizer], [lr_scheduler]
 
+        @override
         def train_dataloader(self):
             return DataLoader(RandomDataset(32, 64), batch_size=2)
 
@@ -74,6 +79,7 @@ def test_finetuning_callback(tmp_path):
 
 
 class TestBackboneFinetuningWarningCallback(BackboneFinetuning):
+    @override
     def finetune_function(self, pl_module, epoch: int, optimizer):
         """Called when the epoch begins."""
         if epoch == 0:
@@ -93,13 +99,16 @@ def test_finetuning_callback_warning(tmp_path):
             self.layer = None
             self.backbone.has_been_used = False
 
+        @override
         def forward(self, x):
             self.backbone.has_been_used = True
             return self.backbone(x)
 
+        @override
         def train_dataloader(self):
             return DataLoader(RandomDataset(32, 64), batch_size=2)
 
+        @override
         def configure_optimizers(self):
             return torch.optim.SGD(self.parameters(), lr=0.1)
 
@@ -201,9 +210,11 @@ def test_unfreeze_and_add_param_group_function(tmp_path):
 
 
 class OnEpochLayerFinetuning(BaseFinetuning):
+    @override
     def freeze_before_training(self, pl_module: LightningModule):
         self.freeze(pl_module.layer)
 
+    @override
     def finetune_function(self, pl_module: LightningModule, epoch: int, optimizer: Optimizer):
         self.unfreeze_and_add_param_group(pl_module.layer[epoch + 1], optimizer)
 
@@ -225,9 +236,11 @@ def test_base_finetuning_internal_optimizer_metadata(tmp_path):
                 nn.Linear(32, 2, bias=True),
             )
 
+        @override
         def forward(self, x):
             return self.layer(x)
 
+        @override
         def configure_optimizers(self):
             return torch.optim.SGD(self.layer[0].parameters(), lr=0.1)
 
@@ -258,6 +271,7 @@ class ConvBlock(nn.Module):
         self.act = nn.ReLU()
         self.bn = nn.BatchNorm2d(out_channels)
 
+    @override
     def forward(self, x):
         x = self.conv(x)
         x = self.act(x)
@@ -272,6 +286,7 @@ class ConvBlockParam(nn.Module):
         self.parent_param = nn.Parameter(torch.zeros((1), dtype=torch.float))
         self.bn = nn.BatchNorm2d(out_channels)
 
+    @override
     def forward(self, x):
         x = self.module_dict["conv"](x)
         x = self.module_dict["act"](x)
@@ -306,9 +321,11 @@ def test_complex_nested_model():
 
 
 class TestCallbacksRestoreCallback(BaseFinetuning):
+    @override
     def freeze_before_training(self, pl_module):
         self.freeze(pl_module.layer[:3])
 
+    @override
     def finetune_function(self, pl_module, epoch, optimizer):
         if epoch >= 1:
             self.unfreeze_and_add_param_group(pl_module.layer[epoch - 1], optimizer)
@@ -319,6 +336,7 @@ class FinetuningBoringModel(BoringModel):
         super().__init__()
         self.layer = nn.Sequential(nn.Linear(32, 32), nn.Linear(32, 32), nn.Linear(32, 32), nn.Linear(32, 2))
 
+    @override
     def configure_optimizers(self):
         parameters = filter(lambda x: x.requires_grad, self.parameters())
         return torch.optim.SGD(parameters, lr=0.1)
@@ -394,6 +412,7 @@ class BackboneBoringModel(BoringModel):
         self.layer = nn.Linear(32, 2)
         self.backbone = nn.Linear(32, 32)
 
+    @override
     def forward(self, x):
         return self.layer(self.backbone(x))
 

--- a/tests/tests_pytorch/callbacks/test_gradient_accumulation_scheduler.py
+++ b/tests/tests_pytorch/callbacks/test_gradient_accumulation_scheduler.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import math
 from unittest.mock import Mock, patch
 
@@ -114,10 +115,12 @@ def test_warn_if_model_has_overridden_optimization_hooks():
     """Test that the callback warns if optimization hooks were overridden in the LightningModule."""
 
     class OverriddenOptimizerStepModel(BoringModel):
+        @override
         def optimizer_step(self, *args, **kwargs):
             super().optimizer_step(*args, **kwargs)
 
     class OverriddenZeroGradModel(BoringModel):
+        @override
         def optimizer_zero_grad(self, *args, **kwargs):
             super().optimizer_zero_grad(*args, **kwargs)
 

--- a/tests/tests_pytorch/callbacks/test_gradient_accumulation_scheduler.py
+++ b/tests/tests_pytorch/callbacks/test_gradient_accumulation_scheduler.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import math
 from unittest.mock import Mock, patch
 
 import pytest
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import GradientAccumulationScheduler

--- a/tests/tests_pytorch/callbacks/test_lambda_function.py
+++ b/tests/tests_pytorch/callbacks/test_lambda_function.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from functools import partial
 
 import pytest
@@ -28,6 +29,7 @@ def test_lambda_call(tmp_path):
         pass
 
     class CustomModel(BoringModel):
+        @override
         def on_train_epoch_start(self):
             if self.current_epoch > 1:
                 raise CustomException("Custom exception to trigger `on_exception` hooks")

--- a/tests/tests_pytorch/callbacks/test_lambda_function.py
+++ b/tests/tests_pytorch/callbacks/test_lambda_function.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from functools import partial
 
 import pytest
+from typing_extensions import override
 
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import Callback, LambdaCallback

--- a/tests/tests_pytorch/callbacks/test_lr_monitor.py
+++ b/tests/tests_pytorch/callbacks/test_lr_monitor.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pytest
 import torch
 from torch import optim
@@ -60,6 +61,7 @@ def test_lr_monitor_single_lr_with_momentum(tmp_path, opt: str):
             super().__init__()
             self.opt = opt
 
+        @override
         def configure_optimizers(self):
             if self.opt == "SGD":
                 opt_kwargs = {"momentum": 0.9}
@@ -98,6 +100,7 @@ def test_log_momentum_no_momentum_optimizer(tmp_path):
     """Test that if optimizer doesn't have momentum then a warning is raised with log_momentum=True."""
 
     class LogMomentumModel(BoringModel):
+        @override
         def configure_optimizers(self):
             optimizer = optim.ASGD(self.parameters(), lr=1e-2)
             lr_scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=1)
@@ -126,6 +129,7 @@ def test_lr_monitor_no_lr_scheduler_single_lr(tmp_path):
     """Test that learning rates are extracted and logged for no lr scheduler."""
 
     class CustomBoringModel(BoringModel):
+        @override
         def configure_optimizers(self):
             return optim.SGD(self.parameters(), lr=0.1)
 
@@ -157,6 +161,7 @@ def test_lr_monitor_no_lr_scheduler_single_lr_with_momentum(tmp_path, opt: str):
             super().__init__()
             self.opt = opt
 
+        @override
         def configure_optimizers(self):
             if self.opt == "SGD":
                 opt_kwargs = {"momentum": 0.9}
@@ -188,6 +193,7 @@ def test_log_momentum_no_momentum_optimizer_no_lr_scheduler(tmp_path):
     """Test that if optimizer doesn't have momentum then a warning is raised with log_momentum=True."""
 
     class LogMomentumModel(BoringModel):
+        @override
         def configure_optimizers(self):
             optimizer = optim.ASGD(self.parameters(), lr=1e-2)
             return [optimizer]
@@ -230,6 +236,7 @@ def test_lr_monitor_multi_lrs(tmp_path, logging_interval: str):
             super().__init__()
             self.automatic_optimization = False
 
+        @override
         def training_step(self, batch, batch_idx):
             opt1, opt2 = self.optimizers()
 
@@ -243,11 +250,13 @@ def test_lr_monitor_multi_lrs(tmp_path, logging_interval: str):
             self.manual_backward(loss)
             opt2.step()
 
+        @override
         def on_train_epoch_end(self):
             scheduler1, scheduler2 = self.lr_schedulers()
             scheduler1.step()
             scheduler2.step()
 
+        @override
         def configure_optimizers(self):
             optimizer1 = optim.Adam(self.parameters(), lr=1e-2)
             optimizer2 = optim.Adam(self.parameters(), lr=1e-2)
@@ -293,6 +302,7 @@ def test_lr_monitor_no_lr_scheduler_multi_lrs(tmp_path, logging_interval: str):
             super().__init__()
             self.automatic_optimization = False
 
+        @override
         def training_step(self, batch, batch_idx):
             opt1, opt2 = self.optimizers()
 
@@ -306,6 +316,7 @@ def test_lr_monitor_no_lr_scheduler_multi_lrs(tmp_path, logging_interval: str):
             self.manual_backward(loss)
             opt2.step()
 
+        @override
         def configure_optimizers(self):
             optimizer1 = optim.Adam(self.parameters(), lr=1e-2)
             optimizer2 = optim.Adam(self.parameters(), lr=1e-2)
@@ -346,6 +357,7 @@ def test_lr_monitor_param_groups(tmp_path):
     """Test that learning rates are extracted and logged for single lr scheduler."""
 
     class CustomClassificationModel(ClassificationModel):
+        @override
         def configure_optimizers(self):
             param_groups = [
                 {"params": list(self.parameters())[:2], "lr": self.lr * 0.1},
@@ -377,6 +389,7 @@ def test_lr_monitor_param_groups(tmp_path):
 
 def test_lr_monitor_custom_name(tmp_path):
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             optimizer, [scheduler] = super().configure_optimizers()
             lr_scheduler = {"scheduler": scheduler, "name": "my_logging_name"}
@@ -399,6 +412,7 @@ def test_lr_monitor_custom_name(tmp_path):
 
 def test_lr_monitor_custom_pg_name(tmp_path):
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD([{"params": list(self.layer.parameters()), "name": "linear"}], lr=0.1)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
@@ -426,10 +440,12 @@ def test_lr_monitor_duplicate_custom_pg_names(tmp_path):
             self.linear_a = torch.nn.Linear(32, 16)
             self.linear_b = torch.nn.Linear(16, 2)
 
+        @override
         def forward(self, x):
             x = self.linear_a(x)
             return self.linear_b(x)
 
+        @override
         def configure_optimizers(self):
             param_groups = [
                 {"params": list(self.linear_a.parameters()), "name": "linear"},
@@ -467,6 +483,7 @@ def test_multiple_optimizers_basefinetuning(tmp_path):
             )
             self.layer = torch.nn.Linear(32, 2)
 
+        @override
         def training_step(self, batch, batch_idx):
             opt1, opt2, opt3 = self.optimizers()
 
@@ -488,14 +505,17 @@ def test_multiple_optimizers_basefinetuning(tmp_path):
             opt3.step()
             opt3.zero_grad()
 
+        @override
         def on_train_epoch_end(self) -> None:
             lr_sched1, lr_sched2 = self.lr_schedulers()
             lr_sched1.step()
             lr_sched2.step()
 
+        @override
         def forward(self, x):
             return self.layer(self.backbone(x))
 
+        @override
         def configure_optimizers(self):
             parameters = list(filter(lambda p: p.requires_grad, self.parameters()))
             opt = optim.SGD(parameters, lr=0.1)
@@ -509,6 +529,7 @@ def test_multiple_optimizers_basefinetuning(tmp_path):
             return optimizers, schedulers
 
     class Check(Callback):
+        @override
         def on_train_epoch_start(self, trainer, pl_module) -> None:
             num_param_groups = sum(len(opt.param_groups) for opt in trainer.optimizers)
 
@@ -538,11 +559,13 @@ def test_multiple_optimizers_basefinetuning(tmp_path):
                 assert list(lr_monitor.lrs) == expected
 
     class TestFinetuning(BackboneFinetuning):
+        @override
         def freeze_before_training(self, pl_module):
             self.freeze(pl_module.backbone[0])
             self.freeze(pl_module.backbone[1])
             self.freeze(pl_module.layer)
 
+        @override
         def finetune_function(self, pl_module, epoch: int, optimizer):
             """Called when the epoch begins."""
             if epoch == 1 and isinstance(optimizer, torch.optim.SGD):
@@ -600,10 +623,12 @@ def test_lr_monitor_multiple_param_groups_no_lr_scheduler(tmp_path):
             self.linear_a = torch.nn.Linear(32, 16)
             self.linear_b = torch.nn.Linear(16, 2)
 
+        @override
         def forward(self, x):
             x = self.linear_a(x)
             return self.linear_b(x)
 
+        @override
         def configure_optimizers(self):
             param_groups = [
                 {
@@ -648,6 +673,7 @@ def test_lr_monitor_update_callback_metrics(tmp_path):
     """Test that the `LearningRateMonitor` callback updates trainer.callback_metrics."""
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.5)
@@ -687,6 +713,7 @@ def test_lr_monitor_with_float64_lr(tmp_path):
     import numpy as np
 
     class Float64LRModel(BoringModel):
+        @override
         def configure_optimizers(self):
             return optim.SGD(self.parameters(), lr=np.float64(0.01))
 
@@ -735,6 +762,7 @@ def test_lr_monitor_log_key_prefix_with_momentum_and_weight_decay(tmp_path):
     """Test that prefix is applied to momentum and weight decay metric names as well."""
 
     class CustomModel(BoringModel):
+        @override
         def configure_optimizers(self):
             optimizer = optim.Adam(self.parameters(), lr=1e-2, betas=(0.9, 0.999), weight_decay=0.01)
             lr_scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=1)
@@ -766,6 +794,7 @@ def test_lr_monitor_log_key_prefix_multi_optimizers(tmp_path):
             super().__init__()
             self.automatic_optimization = False
 
+        @override
         def training_step(self, batch, batch_idx):
             opt1, opt2 = self.optimizers()
 
@@ -779,6 +808,7 @@ def test_lr_monitor_log_key_prefix_multi_optimizers(tmp_path):
             self.manual_backward(loss)
             opt2.step()
 
+        @override
         def configure_optimizers(self):
             optimizer1 = optim.Adam(self.parameters(), lr=1e-2)
             optimizer2 = optim.SGD(self.parameters(), lr=1e-2)

--- a/tests/tests_pytorch/callbacks/test_lr_monitor.py
+++ b/tests/tests_pytorch/callbacks/test_lr_monitor.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pytest
 import torch
 from torch import optim
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import EarlyStopping, LearningRateMonitor

--- a/tests/tests_pytorch/callbacks/test_model_checkpoint_additional_cases.py
+++ b/tests/tests_pytorch/callbacks/test_model_checkpoint_additional_cases.py
@@ -1,4 +1,3 @@
-from typing_extensions import override
 import math
 import os
 from datetime import timedelta
@@ -8,6 +7,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader, Dataset
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer, seed_everything
 from lightning.pytorch.callbacks import ModelCheckpoint

--- a/tests/tests_pytorch/callbacks/test_model_checkpoint_additional_cases.py
+++ b/tests/tests_pytorch/callbacks/test_model_checkpoint_additional_cases.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import math
 import os
 from datetime import timedelta
@@ -21,6 +22,7 @@ class TinyDataset(Dataset):
     def __len__(self):
         return len(self.x)
 
+    @override
     def __getitem__(self, idx):
         return self.x[idx], self.y[idx]
 
@@ -31,6 +33,7 @@ class TrainMetricModule(LightningModule):
         self.layer = nn.Linear(1, 1)
         self._counter = 0.0
 
+    @override
     def training_step(self, batch, batch_idx):
         x, y = batch
         y_hat = self.layer(x)
@@ -40,9 +43,11 @@ class TrainMetricModule(LightningModule):
         self.log("train_score", torch.tensor(self._counter), on_step=True, on_epoch=False, prog_bar=False, logger=True)
         return {"loss": loss}
 
+    @override
     def validation_step(self, batch, batch_idx):
         pass
 
+    @override
     def configure_optimizers(self):
         return torch.optim.SGD(self.parameters(), lr=0.01)
 
@@ -148,19 +153,23 @@ class ValMetricModule(LightningModule):
         self.layer = nn.Linear(1, 1)
         self._val_scores = [float(s) for s in val_scores]
 
+    @override
     def training_step(self, batch, batch_idx):
         x, y = batch
         y_hat = self.layer(x)
         loss = F.mse_loss(y_hat, y)
         return {"loss": loss}
 
+    @override
     def validation_step(self, batch, batch_idx):
         pass
 
+    @override
     def on_validation_epoch_end(self):
         score = self._val_scores[self.current_epoch]
         self.log("auroc", torch.tensor(score, dtype=torch.float32), prog_bar=False, logger=True)
 
+    @override
     def configure_optimizers(self):
         return torch.optim.SGD(self.parameters(), lr=0.01)
 

--- a/tests/tests_pytorch/callbacks/test_model_checkpoint_edge_cases.py
+++ b/tests/tests_pytorch/callbacks/test_model_checkpoint_edge_cases.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import math
 from datetime import timedelta
 
@@ -19,6 +20,7 @@ class TinyDataset(Dataset):
     def __len__(self):
         return len(self.x)
 
+    @override
     def __getitem__(self, idx):
         return self.x[idx], self.y[idx]
 
@@ -39,20 +41,24 @@ class MultiValPerEpochModule(LightningModule):
         self._val_scores = [float(s) for s in val_scores]
         self._val_call_idx = 0
 
+    @override
     def training_step(self, batch, batch_idx):
         x, y = batch
         y_hat = self.layer(x)
         loss = F.mse_loss(y_hat, y)
         return {"loss": loss}
 
+    @override
     def validation_step(self, batch, batch_idx):
         pass
 
+    @override
     def on_validation_epoch_end(self):
         score = self._val_scores[self._val_call_idx]
         self._val_call_idx += 1
         self.log("auroc", torch.tensor(score, dtype=torch.float32), prog_bar=False, logger=True)
 
+    @override
     def configure_optimizers(self):
         return torch.optim.SGD(self.parameters(), lr=0.01)
 
@@ -65,20 +71,24 @@ class ValOnceEveryTwoEpochsModule(LightningModule):
         self.layer = nn.Linear(1, 1)
         self._val_scores = [float(s) for s in val_scores]
 
+    @override
     def training_step(self, batch, batch_idx):
         x, y = batch
         y_hat = self.layer(x)
         loss = F.mse_loss(y_hat, y)
         return {"loss": loss}
 
+    @override
     def validation_step(self, batch, batch_idx):
         pass
 
+    @override
     def on_validation_epoch_end(self):
         # current_epoch indexes into provided scores; only called when validation runs
         score = self._val_scores[self.current_epoch]
         self.log("auroc", torch.tensor(score, dtype=torch.float32), prog_bar=False, logger=True)
 
+    @override
     def configure_optimizers(self):
         return torch.optim.SGD(self.parameters(), lr=0.01)
 

--- a/tests/tests_pytorch/callbacks/test_model_checkpoint_edge_cases.py
+++ b/tests/tests_pytorch/callbacks/test_model_checkpoint_edge_cases.py
@@ -1,4 +1,3 @@
-from typing_extensions import override
 import math
 from datetime import timedelta
 
@@ -7,6 +6,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader, Dataset
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer, seed_everything
 from lightning.pytorch.callbacks import ModelCheckpoint

--- a/tests/tests_pytorch/callbacks/test_model_checkpoint_manual_opt.py
+++ b/tests/tests_pytorch/callbacks/test_model_checkpoint_manual_opt.py
@@ -1,4 +1,3 @@
-from typing_extensions import override
 import shutil
 import tempfile
 import warnings
@@ -8,6 +7,7 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader, Dataset
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint

--- a/tests/tests_pytorch/callbacks/test_model_checkpoint_manual_opt.py
+++ b/tests/tests_pytorch/callbacks/test_model_checkpoint_manual_opt.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import shutil
 import tempfile
 import warnings
@@ -20,6 +21,7 @@ class FakeDataset(Dataset):
     def __len__(self):
         return 4
 
+    @override
     def __getitem__(self, idx):
         return self.data[idx], self.labels[idx]
 
@@ -47,6 +49,7 @@ class SimpleModule(LightningModule):
         ]
         self.saved_models = {}
 
+    @override
     def training_step(self, batch, batch_idx):
         out = self.layer(batch[0])
         loss = torch.nn.functional.binary_cross_entropy_with_logits(out, batch[1].float())
@@ -59,6 +62,7 @@ class SimpleModule(LightningModule):
         optimizer.step()
         return loss
 
+    @override
     def configure_optimizers(self):
         return torch.optim.SGD(self.parameters(), lr=0.01)
 
@@ -123,6 +127,7 @@ def test_model_checkpoint_manual_opt_warning():
     """Test that a warning is raised when using manual optimization without saving the state."""
 
     class SimpleModuleNoSave(SimpleModule):
+        @override
         def training_step(self, batch, batch_idx):
             out = self.layer(batch[0])
             loss = torch.nn.functional.binary_cross_entropy_with_logits(out, batch[1].float())

--- a/tests/tests_pytorch/callbacks/test_model_checkpoint_step_interval_val_metric.py
+++ b/tests/tests_pytorch/callbacks/test_model_checkpoint_step_interval_val_metric.py
@@ -1,4 +1,3 @@
-from typing_extensions import override
 import math
 
 import pytest
@@ -6,6 +5,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader, Dataset
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer, seed_everything
 from lightning.pytorch.callbacks import ModelCheckpoint

--- a/tests/tests_pytorch/callbacks/test_model_checkpoint_step_interval_val_metric.py
+++ b/tests/tests_pytorch/callbacks/test_model_checkpoint_step_interval_val_metric.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import math
 
 import pytest
@@ -18,6 +19,7 @@ class TinyDataset(Dataset):
     def __len__(self):
         return len(self.x)
 
+    @override
     def __getitem__(self, idx):
         return self.x[idx], self.y[idx]
 
@@ -29,16 +31,19 @@ class ValMetricModule(LightningModule):
         self._val_scores = [float(s) for s in val_scores]
 
     # LightningModule API (minimal)
+    @override
     def training_step(self, batch, batch_idx):
         x, y = batch
         y_hat = self.layer(x)
         loss = F.mse_loss(y_hat, y)
         return {"loss": loss}
 
+    @override
     def validation_step(self, batch, batch_idx):
         # do nothing per-step; we log at epoch end
         pass
 
+    @override
     def on_validation_epoch_end(self):
         # Log a validation metric only at validation epoch end
         # Values increase across epochs; best should be the last epoch
@@ -46,6 +51,7 @@ class ValMetricModule(LightningModule):
         # use logger=True so it lands in trainer.callback_metrics
         self.log("auroc", torch.tensor(score, dtype=torch.float32), prog_bar=False, logger=True)
 
+    @override
     def configure_optimizers(self):
         return torch.optim.SGD(self.parameters(), lr=0.01)
 

--- a/tests/tests_pytorch/callbacks/test_model_summary.py
+++ b/tests/tests_pytorch/callbacks/test_model_summary.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from typing import Any
 
 from lightning.pytorch import Trainer
@@ -44,6 +45,7 @@ def test_model_summary_callback_with_enable_model_summary_true():
 def test_custom_model_summary_callback_summarize(tmp_path):
     class CustomModelSummary(ModelSummary):
         @staticmethod
+        @override
         def summarize(
             summary_data: list[tuple[str, list[str]]],
             total_parameters: int,

--- a/tests/tests_pytorch/callbacks/test_model_summary.py
+++ b/tests/tests_pytorch/callbacks/test_model_summary.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from typing import Any
+
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import ModelSummary

--- a/tests/tests_pytorch/callbacks/test_prediction_writer.py
+++ b/tests/tests_pytorch/callbacks/test_prediction_writer.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from unittest.mock import ANY, Mock, call
 
 import pytest
@@ -23,9 +24,11 @@ from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
 
 class DummyPredictionWriter(BasePredictionWriter):
+    @override
     def write_on_batch_end(self, *_, **__):
         pass
 
+    @override
     def write_on_epoch_end(self, *_, **__):
         pass
 
@@ -107,6 +110,7 @@ def test_batch_level_batch_indices(tmp_path):
     DummyPredictionWriter.write_on_batch_end = Mock()
 
     class CustomBoringModel(BoringModel):
+        @override
         def on_predict_epoch_end(self, *args, **kwargs):
             assert self.trainer.predict_loop.epoch_batch_indices == [[]]
 

--- a/tests/tests_pytorch/callbacks/test_prediction_writer.py
+++ b/tests/tests_pytorch/callbacks/test_prediction_writer.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from unittest.mock import ANY, Mock, call
 
 import pytest
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import BasePredictionWriter

--- a/tests/tests_pytorch/callbacks/test_pruning.py
+++ b/tests/tests_pytorch/callbacks/test_pruning.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import re
 from collections import OrderedDict
 from logging import INFO
@@ -40,6 +41,7 @@ class TestModel(BoringModel):
             ])
         )
 
+    @override
     def training_step(self, batch, batch_idx):
         self.log("test", -batch_idx)
         return super().training_step(batch, batch_idx)
@@ -48,6 +50,7 @@ class TestModel(BoringModel):
 class TestPruningMethod(pytorch_prune.BasePruningMethod):
     PRUNING_TYPE = "unstructured"
 
+    @override
     def compute_mask(self, _, default_mask):
         mask = default_mask.clone()
         # Prune every other entry in a tensor
@@ -55,6 +58,7 @@ class TestPruningMethod(pytorch_prune.BasePruningMethod):
         return mask
 
     @classmethod
+    @override
     def apply(cls, module, name, amount):
         return super().apply(module, name, amount=amount)
 
@@ -196,6 +200,7 @@ def test_pruning_lth_callable(tmp_path, resample_parameters):
     class ModelPruningTestCallback(ModelPruning):
         lth_calls = 0
 
+        @override
         def apply_lottery_ticket_hypothesis(self):
             super().apply_lottery_ticket_hypothesis()
             self.lth_calls += 1
@@ -297,6 +302,7 @@ def test_permanent_when_model_is_saved_multiple_times(
         )
 
     class TestPruning(ModelPruning):
+        @override
         def on_save_checkpoint(self, trainer, pl_module, checkpoint):
             had_buffers = hasattr(pl_module.layer.mlp_3, "weight_orig")
             super().on_save_checkpoint(trainer, pl_module, checkpoint)
@@ -487,6 +493,7 @@ def test_sparsity_calculation(tmp_path, caplog, pruning_amount: float, model_typ
             # Total: 2112 + 130 = 2242 params (but only layer1 will be pruned)
             # layer1 params: 2112
 
+        @override
         def forward(self, x):
             x = torch.relu(self.layer1(x))
             return self.layer2(x)

--- a/tests/tests_pytorch/callbacks/test_pruning.py
+++ b/tests/tests_pytorch/callbacks/test_pruning.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import re
 from collections import OrderedDict
 from logging import INFO
@@ -22,6 +21,7 @@ import torch
 import torch.nn.utils.prune as pytorch_prune
 from torch import nn
 from torch.nn import Sequential
+from typing_extensions import override
 
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import ModelCheckpoint, ModelPruning

--- a/tests/tests_pytorch/callbacks/test_rich_model_summary.py
+++ b/tests/tests_pytorch/callbacks/test_rich_model_summary.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from typing import Any
 from unittest import mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import RichModelSummary, RichProgressBar

--- a/tests/tests_pytorch/callbacks/test_rich_model_summary.py
+++ b/tests/tests_pytorch/callbacks/test_rich_model_summary.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from typing import Any
 from unittest import mock
 
@@ -48,6 +49,7 @@ def test_rich_summary_tuples(mock_table_add_row, mock_console):
     model_summary = RichModelSummary()
 
     class TestModel(BoringModel):
+        @override
         @property
         def example_input_array(self) -> Any:
             return torch.randn(4, 32)

--- a/tests/tests_pytorch/callbacks/test_spike.py
+++ b/tests/tests_pytorch/callbacks/test_spike.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import contextlib
 
 import pytest
@@ -17,6 +18,7 @@ class IdentityModule(LightningModule):
         self.spike_global_rank = spike_global_rank
         self.spike_value = spike_value
 
+    @override
     def training_step(self, batch, batch_idx: int):
         # initialize it all to weights one so that input = output but with gradients
         with torch.no_grad():
@@ -31,11 +33,13 @@ class IdentityModule(LightningModule):
 
         return self.layer(torch.tensor(curr_loss_val, device=self.device, dtype=self.dtype).view(1, 1))
 
+    @override
     def configure_optimizers(self):
         return torch.optim.SGD(self.parameters(), lr=1e-3)
 
 
 class MyTrainerSpikeDetection(SpikeDetection):
+    @override
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         context = (
             pytest.raises(TrainingSpikeException) if batch_idx == 4 and self.should_raise else contextlib.nullcontext()

--- a/tests/tests_pytorch/callbacks/test_spike.py
+++ b/tests/tests_pytorch/callbacks/test_spike.py
@@ -1,8 +1,8 @@
-from typing_extensions import override
 import contextlib
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _TORCHMETRICS_GREATER_EQUAL_1_0_0
 from lightning.fabric.utilities.spike import TrainingSpikeException

--- a/tests/tests_pytorch/callbacks/test_stochastic_weight_avg.py
+++ b/tests/tests_pytorch/callbacks/test_stochastic_weight_avg.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import logging
 import os
 from contextlib import AbstractContextManager
@@ -65,16 +66,19 @@ class SwaTestModel(BoringModel):
         self.iterable_dataset = iterable_dataset
         self.crash_on_epoch = crash_on_epoch
 
+    @override
     def training_step(self, batch, batch_idx):
         if self.crash_on_epoch and self.trainer.current_epoch >= self.crash_on_epoch:
             raise Exception("SWA crash test")
         return super().training_step(batch, batch_idx)
 
+    @override
     def train_dataloader(self):
         dset_cls = RandomIterableDataset if self.iterable_dataset else RandomDataset
         dset = dset_cls(32, 64)
         return DataLoader(dset, batch_size=2)
 
+    @override
     def configure_optimizers(self):
         optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
         return {
@@ -92,14 +96,17 @@ class SwaTestCallback(StochasticWeightAveraging):
     # Record the first epoch, as if we are resuming from a checkpoint this may not be equal to 0
     first_epoch: Optional[int] = None
 
+    @override
     def update_parameters(self, *args, **kwargs):
         self.update_parameters_calls += 1
         return StochasticWeightAveraging.update_parameters(*args, **kwargs)
 
+    @override
     def transfer_weights(self, *args, **kwargs):
         self.transfer_weights_calls += 1
         return StochasticWeightAveraging.transfer_weights(*args, **kwargs)
 
+    @override
     def on_train_epoch_start(self, trainer, *args):
         super().on_train_epoch_start(trainer, *args)
         if self.first_epoch is None and not trainer.fit_loop.restarting:
@@ -113,6 +120,7 @@ class SwaTestCallback(StochasticWeightAveraging):
             assert trainer.lr_scheduler_configs[0].interval == "epoch"
             assert trainer.lr_scheduler_configs[0].frequency == 1
 
+    @override
     def on_train_epoch_end(self, trainer, *args):
         super().on_train_epoch_end(trainer, *args)
         if self.swa_start <= trainer.current_epoch <= self.swa_end:
@@ -124,6 +132,7 @@ class SwaTestCallback(StochasticWeightAveraging):
         elif trainer.current_epoch > self.swa_end:
             assert self.n_averaged == self._max_epochs - self.swa_start
 
+    @override
     def on_train_end(self, trainer, pl_module):
         super().on_train_end(trainer, pl_module)
 
@@ -242,6 +251,7 @@ def test_swa_deepcopy(tmp_path):
             super().__init__(*args, **kwargs)
             self.setup_called = False
 
+        @override
         def setup(self, trainer, pl_module, stage) -> None:
             super().setup(trainer, pl_module, stage)
             assert self._average_model.train_dataloader is not pl_module.train_dataloader
@@ -266,14 +276,17 @@ def test_swa_multiple_lrs(tmp_path):
             self.layer2 = torch.nn.Linear(32, 2)
             self.on_train_epoch_start_called = False
 
+        @override
         def forward(self, x):
             x = self.layer1(x)
             return self.layer2(x)
 
+        @override
         def configure_optimizers(self):
             params = [{"params": self.layer1.parameters(), "lr": 0.1}, {"params": self.layer2.parameters(), "lr": 0.2}]
             return torch.optim.Adam(params)
 
+        @override
         def on_train_epoch_start(self):
             optimizer = trainer.optimizers[0]
             assert [pg["lr"] for pg in optimizer.param_groups] == [0.1, 0.2]
@@ -324,6 +337,7 @@ def _swa_resume_training_from_checkpoint(tmp_path, model, resume_model, ddp=Fals
 
 
 class CustomSchedulerModel(SwaTestModel):
+    @override
     def configure_optimizers(self):
         optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
 

--- a/tests/tests_pytorch/callbacks/test_stochastic_weight_avg.py
+++ b/tests/tests_pytorch/callbacks/test_stochastic_weight_avg.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import logging
 import os
 from contextlib import AbstractContextManager
@@ -25,6 +24,7 @@ from torch import nn
 from torch.optim.lr_scheduler import LambdaLR
 from torch.optim.swa_utils import SWALR
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_6
 from lightning.pytorch import Trainer

--- a/tests/tests_pytorch/callbacks/test_timer.py
+++ b/tests/tests_pytorch/callbacks/test_timer.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import logging
 import time
 from datetime import timedelta
@@ -28,6 +29,7 @@ from tests_pytorch.helpers.runif import RunIf
 
 def test_trainer_flag(caplog, tmp_path):
     class TestModel(BoringModel):
+        @override
         def on_fit_start(self):
             raise SystemExit()
 

--- a/tests/tests_pytorch/callbacks/test_timer.py
+++ b/tests/tests_pytorch/callbacks/test_timer.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import logging
 import time
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import pytest
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint

--- a/tests/tests_pytorch/callbacks/test_weight_averaging.py
+++ b/tests/tests_pytorch/callbacks/test_weight_averaging.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from copy import deepcopy
 from pathlib import Path
@@ -38,11 +39,13 @@ class TestModel(BoringModel):
         self.layer = nn.Sequential(*layers)
         self.crash_on_epoch = None
 
+    @override
     def training_step(self, batch: Tensor, batch_idx: int) -> None:
         if self.crash_on_epoch and self.trainer.current_epoch >= self.crash_on_epoch:
             raise Exception("CRASH")
         return super().training_step(batch, batch_idx)
 
+    @override
     def configure_optimizers(self) -> None:
         return torch.optim.SGD(self.layer.parameters(), lr=0.1)
 
@@ -52,10 +55,12 @@ class LargeTestModel(BoringModel):
         super().__init__()
         self.layer = None
 
+    @override
     def configure_model(self):
         print("XXX configure_model")
         self.layer = nn.Sequential(nn.Linear(32, 32), nn.ReLU(), nn.Linear(32, 2))
 
+    @override
     def configure_optimizers(self):
         return torch.optim.SGD(self.parameters(), lr=0.01)
 
@@ -86,19 +91,23 @@ class EMATestCallback(WeightAveraging):
         # Record the first epoch, as if we are resuming from a checkpoint this may not be equal to 0.
         self.first_epoch: Optional[int] = None
 
+    @override
     def _swap_models(self, *args: Any, **kwargs: Any):
         self.swap_calls += 1
         return super()._swap_models(*args, **kwargs)
 
+    @override
     def _copy_average_to_current(self, *args: Any, **kwargs: Any):
         self.copy_calls += 1
         return super()._copy_average_to_current(*args, **kwargs)
 
+    @override
     def on_train_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
         super().on_train_start(trainer, pl_module)
         assert self.swap_calls == 0
         assert self.copy_calls == 0
 
+    @override
     def on_train_epoch_start(self, trainer: Trainer, *args: Any) -> None:
         super().on_train_epoch_start(trainer, *args)
         # Since the checkpoint loaded was saved `on_train_epoch_end`, the first `FitLoop` iteration will not update the
@@ -107,12 +116,14 @@ class EMATestCallback(WeightAveraging):
         if self.first_epoch is None and not trainer.fit_loop.restarting:
             self.first_epoch = trainer.current_epoch
 
+    @override
     def on_train_epoch_end(self, trainer: Trainer, *args: Any) -> None:
         super().on_train_epoch_end(trainer, *args)
         assert self._average_model.n_averaged == trainer.global_step
         assert self.swap_calls == (trainer.current_epoch + 1 - self.first_epoch) * 2
         assert self.copy_calls == 0
 
+    @override
     def on_train_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
         super().on_train_end(trainer, pl_module)
         # length=32, batch_size=4, accumulate_grad_batches=2
@@ -132,22 +143,27 @@ class SWATestCallback(WeightAveraging):
         # Record the first epoch, as if we are resuming from a checkpoint this may not be equal to 0.
         self.first_epoch: Optional[int] = None
 
+    @override
     def should_update(self, step_idx: Optional[int] = None, epoch_idx: Optional[int] = None) -> bool:
         return epoch_idx in (3, 5, 7)
 
+    @override
     def _swap_models(self, *args: Any, **kwargs: Any):
         self.swap_calls += 1
         return super()._swap_models(*args, **kwargs)
 
+    @override
     def _copy_average_to_current(self, *args: Any, **kwargs: Any):
         self.copy_calls += 1
         return super()._copy_average_to_current(*args, **kwargs)
 
+    @override
     def on_train_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
         super().on_train_start(trainer, pl_module)
         assert self.swap_calls == 0
         assert self.copy_calls == 0
 
+    @override
     def on_train_epoch_start(self, trainer: Trainer, *args: Any) -> None:
         super().on_train_epoch_start(trainer, *args)
         # Since the checkpoint loaded was saved `on_train_epoch_end`, the first `FitLoop` iteration will not update the
@@ -156,6 +172,7 @@ class SWATestCallback(WeightAveraging):
         if self.first_epoch is None and not trainer.fit_loop.restarting:
             self.first_epoch = trainer.current_epoch
 
+    @override
     def on_train_epoch_end(self, trainer: Trainer, *args: Any) -> None:
         super().on_train_epoch_end(trainer, *args)
         if trainer.current_epoch < 3:
@@ -169,6 +186,7 @@ class SWATestCallback(WeightAveraging):
         assert self.swap_calls == (trainer.current_epoch + 1 - self.first_epoch) * 2
         assert self.copy_calls == 0
 
+    @override
     def on_train_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
         super().on_train_end(trainer, pl_module)
         assert self._average_model.n_averaged == 3
@@ -185,6 +203,7 @@ def test_weight_averaging_deepcopy(tmp_path):
             super().__init__(*args, **kwargs)
             self.setup_called = False
 
+        @override
         def setup(self, trainer, pl_module, stage) -> None:
             super().setup(trainer, pl_module, stage)
             assert self._average_model.module.train_dataloader is not pl_module.train_dataloader

--- a/tests/tests_pytorch/callbacks/test_weight_averaging.py
+++ b/tests/tests_pytorch/callbacks/test_weight_averaging.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from copy import deepcopy
 from pathlib import Path
@@ -22,6 +21,7 @@ import torch
 from torch import Tensor, nn
 from torch.optim.swa_utils import get_swa_avg_fn
 from torch.utils.data import DataLoader, Dataset
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.callbacks import EMAWeightAveraging, WeightAveraging

--- a/tests/tests_pytorch/checkpointing/test_checkpoint_callback_frequency.py
+++ b/tests/tests_pytorch/checkpointing/test_checkpoint_callback_frequency.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from unittest import mock
 
@@ -61,6 +62,7 @@ def test_top_k(save_mock, tmp_path, k, epochs, val_check_interval, expected, sav
             super().__init__()
             self.last_coeff = 10.0
 
+        @override
         def training_step(self, batch, batch_idx):
             loss = self.step(torch.ones(32, device=self.device))
             loss = loss / (loss + 0.0000001)
@@ -89,11 +91,13 @@ def test_top_k(save_mock, tmp_path, k, epochs, val_check_interval, expected, sav
 @pytest.mark.parametrize(("k", "epochs", "val_check_interval", "expected"), [(1, 1, 1.0, 1), (2, 2, 0.3, 4)])
 def test_top_k_ddp(save_mock, tmp_path, k, epochs, val_check_interval, expected):
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             local_rank = int(os.getenv("LOCAL_RANK"))
             self.log("my_loss", batch_idx * (1 + local_rank), on_epoch=True)
             return super().training_step(batch, batch_idx)
 
+        @override
         def on_train_epoch_end(self):
             local_rank = int(os.getenv("LOCAL_RANK"))
             if self.trainer.is_global_zero:

--- a/tests/tests_pytorch/checkpointing/test_checkpoint_callback_frequency.py
+++ b/tests/tests_pytorch/checkpointing/test_checkpoint_callback_frequency.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from unittest import mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer, callbacks
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/checkpointing/test_legacy_checkpoints.py
+++ b/tests/tests_pytorch/checkpointing/test_legacy_checkpoints.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import glob
 import os
 import sys
@@ -20,6 +19,7 @@ from unittest.mock import patch
 import pytest
 import torch
 from packaging.version import Version
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.pytorch import Callback, Trainer

--- a/tests/tests_pytorch/checkpointing/test_legacy_checkpoints.py
+++ b/tests/tests_pytorch/checkpointing/test_legacy_checkpoints.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import glob
 import os
 import sys
@@ -65,6 +66,7 @@ class LimitNbEpochs(Callback):
         self.limit = nb
         self._count = 0
 
+    @override
     def on_train_epoch_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
         self._count += 1
         if self._count >= self.limit:

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import math
 import os
 import pickle
@@ -56,11 +57,13 @@ def test_model_checkpoint_state_key():
 
 
 class LogInTwoMethods(BoringModel):
+    @override
     def training_step(self, batch, batch_idx):
         out = super().training_step(batch, batch_idx)
         self.log("early_stop_on", out["loss"])
         return out
 
+    @override
     def on_validation_epoch_end(self):
         self.log("val_acc", torch.tensor(1.23))
 
@@ -101,16 +104,19 @@ def test_model_checkpoint_score_and_ckpt(
             self.val_logs = torch.randn(max_epochs, limit_val_batches)
             self.scores = []
 
+        @override
         def training_step(self, batch, batch_idx):
             log_value = self.train_log_epochs[self.current_epoch, batch_idx]
             self.log("train_log", log_value, on_epoch=True)
             return super().training_step(batch, batch_idx)
 
+        @override
         def validation_step(self, batch, batch_idx):
             log_value = self.val_logs[self.current_epoch, batch_idx]
             self.log("val_log", log_value)
             return super().validation_step(batch, batch_idx)
 
+        @override
         def configure_optimizers(self):
             optimizer = optim.SGD(self.parameters(), lr=lr)
 
@@ -125,10 +131,12 @@ def test_model_checkpoint_score_and_ckpt(
 
             return [optimizer], [lr_scheduler]
 
+        @override
         def on_train_epoch_end(self):
             if "train" in monitor:
                 self.scores.append(self.trainer.logged_metrics[monitor])
 
+        @override
         def on_validation_epoch_end(self):
             if not self.trainer.sanity_checking and "val" in monitor:
                 self.scores.append(self.trainer.logged_metrics[monitor])
@@ -210,15 +218,18 @@ def test_model_checkpoint_score_and_ckpt_val_check_interval(
             self.val_loop_count = 0
             self.scores = []
 
+        @override
         def validation_step(self, batch, batch_idx):
             log_value = self.val_logs[self.val_loop_count, batch_idx]
             self.log("val_log", log_value)
             return super().validation_step(batch, batch_idx)
 
+        @override
         def on_validation_epoch_end(self):
             self.val_loop_count += 1
             self.scores.append(self.trainer.logged_metrics[monitor])
 
+        @override
         def configure_optimizers(self):
             optimizer = optim.SGD(self.parameters(), lr=lr)
 
@@ -368,13 +379,16 @@ class ModelCheckpointTestInvocations(ModelCheckpoint):
         self.expected_count = expected_count
         self.state_dict_count = 0
 
+    @override
     def on_train_start(self, trainer, pl_module):
         torch.save = Mock(wraps=torch.save)
 
+    @override
     def state_dict(self):
         super().state_dict()
         self.state_dict_count += 1
 
+    @override
     def on_train_end(self, trainer, pl_module):
         super().on_train_end(trainer, pl_module)
         assert self.best_model_path
@@ -627,6 +641,7 @@ def test_none_monitor_not_alternating(tmp_path):
     """Regression test for the case where the callback saved alternating `model.ckpt` and `model-v1.ckpt` files."""
 
     class ListDirModel(BoringModel):
+        @override
         def on_train_epoch_start(self):
             if self.current_epoch > 0:
                 assert os.listdir(tmp_path) == ["model.ckpt"]
@@ -776,6 +791,7 @@ def test_model_checkpoint_on_exception_run_condition_on_validation_start(tmp_pat
 
     # Don't save checkpoint if sanity check fails
     class TroubledModelSanityCheck(BoringModel):
+        @override
         def on_validation_start(self) -> None:
             if self.trainer.sanity_checking:
                 print("Trouble!")
@@ -803,6 +819,7 @@ def test_model_checkpoint_on_exception_fast_dev_run_on_train_batch_start(tmp_pat
 
     # Don't save checkpoint if fast dev run fails
     class TroubledModelFastDevRun(BoringModel):
+        @override
         def on_train_batch_start(self, batch, batch_idx) -> None:
             if self.trainer.fast_dev_run and batch_idx == 1:
                 raise RuntimeError("Trouble!")
@@ -829,6 +846,7 @@ def test_model_checkpoint_on_exception_run_condition_on_train_batch_start(tmp_pa
 
     # Don't save checkpoint if already saved a checkpoint
     class TroubledModelAlreadySavedCheckpoint(BoringModel):
+        @override
         def on_train_batch_start(self, batch, batch_idx) -> None:
             if self.trainer.global_step == 1:
                 raise RuntimeError("Trouble!")
@@ -849,136 +867,159 @@ def test_model_checkpoint_on_exception_run_condition_on_train_batch_start(tmp_pa
 
 
 class TroubledModelInTrainingStep(BoringModel):
+    @override
     def training_step(self, batch, batch_idx):
         if batch_idx == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelInValidationStep(BoringModel):
+    @override
     def validation_step(self, batch, batch_idx):
         if not self.trainer.sanity_checking and batch_idx == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelBackward(BoringModel):
+    @override
     def backward(self, loss):
         if self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnBeforeBackward(BoringModel):
+    @override
     def on_before_backward(self, loss):
         if self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnAfterBackward(BoringModel):
+    @override
     def on_after_backward(self):
         if self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnBeforeZeroGrad(BoringModel):
+    @override
     def on_before_zero_grad(self, optimizer):
         if self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnFitEnd(BoringModel):
+    @override
     def on_fit_end(self):
         raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnTrainEnd(BoringModel):
+    @override
     def on_train_end(self):
         raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnValidationStart(BoringModel):
+    @override
     def on_validation_start(self):
         if not self.trainer.sanity_checking and self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnValidationEnd(BoringModel):
+    @override
     def on_validation_end(self):
         if not self.trainer.sanity_checking:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnTrainBatchStart(BoringModel):
+    @override
     def on_train_batch_start(self, batch, batch_idx):
         if batch_idx == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnTrainBatchEnd(BoringModel):
+    @override
     def on_train_batch_end(self, outputs, batch, batch_idx):
         if batch_idx == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnTrainEpochStart(BoringModel):
+    @override
     def on_train_epoch_start(self):
         if self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnTrainEpochEnd(BoringModel):
+    @override
     def on_train_epoch_end(self):
         if self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnValidationBatchStart(BoringModel):
+    @override
     def on_validation_batch_start(self, batch, batch_idx):
         if not self.trainer.sanity_checking and batch_idx == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnValidationBatchEnd(BoringModel):
+    @override
     def on_validation_batch_end(self, outputs, batch, batch_idx):
         if not self.trainer.sanity_checking and batch_idx == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnValidationEpochStart(BoringModel):
+    @override
     def on_validation_epoch_start(self):
         if not self.trainer.sanity_checking and self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnValidationEpochEnd(BoringModel):
+    @override
     def on_validation_epoch_end(self):
         if not self.trainer.sanity_checking and self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnValidationModelEval(BoringModel):
+    @override
     def on_validation_model_eval(self):
         if not self.trainer.sanity_checking and self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnValidationModelTrain(BoringModel):
+    @override
     def on_validation_model_train(self):
         if not self.trainer.sanity_checking and self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOnBeforeOptimizerStep(BoringModel):
+    @override
     def on_before_optimizer_step(self, optimizer):
         if self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelConfigureGradienClipping(BoringModel):
+    @override
     def configure_gradient_clipping(self, optimizer, gradient_clip_val=None, gradient_clip_algorithm=None):
         if self.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledModelOptimizerStep(BoringModel):
+    @override
     def optimizer_step(self, epoch, batch_idx, optimizer, optimizer_closure=None):
         optimizer.step(closure=optimizer_closure)
         if self.current_epoch == 1:
@@ -986,6 +1027,7 @@ class TroubledModelOptimizerStep(BoringModel):
 
 
 class TroubledModelOptimizerZeroGrad(BoringModel):
+    @override
     def optimizer_zero_grad(self, epoch, batch_idx, optimizer):
         if self.current_epoch == 1:
             raise RuntimeError("Trouble!")
@@ -1049,94 +1091,110 @@ def test_model_checkpoint_on_exception_parametrized(tmp_path, TroubledModel):
 
 
 class TroubledCallbackOnFitEnd(Callback):
+    @override
     def on_fit_end(self, trainer, pl_module):
         raise RuntimeError("Trouble!")
 
 
 class TroubledCallbackOnTrainBatchStart(Callback):
+    @override
     def on_train_batch_start(self, trainer, pl_module, batch, batch_idx):
         if batch_idx == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledCallbackOnTrainBatchEnd(Callback):
+    @override
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         if batch_idx == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledCallbackOnTrainEpochStart(Callback):
+    @override
     def on_train_epoch_start(self, trainer, pl_module):
         if trainer.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledCallbackOnTrainEpochEnd(Callback):
+    @override
     def on_train_epoch_end(self, trainer, pl_module):
         if trainer.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledCallbackOnValidationEpochStart(Callback):
+    @override
     def on_validation_epoch_start(self, trainer, pl_module):
         if not trainer.sanity_checking and trainer.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledCallbackOnValidationEpochEnd(Callback):
+    @override
     def on_validation_epoch_end(self, trainer, pl_module):
         if not trainer.sanity_checking and trainer.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledCallbackOnValidationBatchStart(Callback):
+    @override
     def on_validation_batch_start(self, trainer, pl_module, batch, batch_idx):
         if not trainer.sanity_checking and batch_idx == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledCallbackOnValidationBatchEnd(Callback):
+    @override
     def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         if not trainer.sanity_checking and batch_idx == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubledCallbackOnTrainEnd(Callback):
+    @override
     def on_train_end(self, trainer, pl_module):
         raise RuntimeError("Trouble!")
 
 
 class TroubledCallbackOnValidationStart(Callback):
+    @override
     def on_validation_start(self, trainer, pl_module):
         if not trainer.sanity_checking:
             raise RuntimeError("Trouble!")
 
 
 class TroubledCallbackOnValidationEnd(Callback):
+    @override
     def on_validation_end(self, trainer, pl_module):
         if not trainer.sanity_checking:
             raise RuntimeError("Trouble!")
 
 
 class TroubleCallbackOnBeforeBackward(Callback):
+    @override
     def on_before_backward(self, trainer, pl_module, loss):
         if trainer.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubleCallbackOnAfterBackward(Callback):
+    @override
     def on_after_backward(self, trainer, pl_module):
         if trainer.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubleCallbackOnBeforeOptimizerStep(Callback):
+    @override
     def on_before_optimizer_step(self, trainer, pl_module, optimizer):
         if trainer.current_epoch == 1:
             raise RuntimeError("Trouble!")
 
 
 class TroubleCallbackOnBeforeZeroGrad(Callback):
+    @override
     def on_before_zero_grad(self, trainer, pl_module, optimizer):
         if trainer.current_epoch == 1:
             raise RuntimeError("Trouble!")
@@ -1377,6 +1435,7 @@ def test_checkpointing_with_nan_as_first(tmp_path, mode):
     monitor += [5, 7, 8] if mode == "max" else [8, 7, 5]
 
     class CurrentModel(LogInTwoMethods):
+        @override
         def on_validation_epoch_end(self):
             val_loss = monitor[self.current_epoch]
             self.log("abc", val_loss)
@@ -1406,6 +1465,7 @@ def test_checkpoint_repeated_strategy(tmp_path):
     checkpoint_callback = ModelCheckpoint(monitor="val_loss", dirpath=tmp_path, filename="{epoch:02d}")
 
     class ExtendedBoringModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.log("val_loss", loss)
@@ -1443,6 +1503,7 @@ def test_checkpoint_repeated_strategy_extended(tmp_path):
     nothing run."""
 
     class ExtendedBoringModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.log("val_loss", loss)
@@ -1583,6 +1644,7 @@ def test_current_score(tmp_path):
     """Check that the current_score value is correct and was saved."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, *args):
             self.log("foo", (self.current_epoch + 1) / 10)
             return super().training_step(*args)
@@ -1616,6 +1678,7 @@ def test_current_score_when_nan(tmp_path, mode: str):
     """Check that ModelCheckpoint handles NaN values correctly."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, *args):
             self.log("foo", float("nan"))
             return super().training_step(*args)
@@ -1797,6 +1860,7 @@ def test_model_checkpoint_saveload_ckpt(tmp_path):
                 assert getattr(cb_restore, key) != written_ckpt[key]
 
     class CustomModelCheckpoint(ModelCheckpoint):
+        @override
         def on_load_checkpoint(self, *args, **kwargs):
             assert self.dirpath is not None
             return super().on_load_checkpoint(*args, **kwargs)
@@ -2064,9 +2128,11 @@ def test_load_with_inf_data_loader(tmp_path):
     dataset = RandomIterableDataset(size=32, count=10)
 
     class ModelWithIterableDataset(BoringModel):
+        @override
         def train_dataloader(self) -> DataLoader:
             return DataLoader(dataset)
 
+        @override
         def val_dataloader(self) -> DataLoader:
             return DataLoader(dataset)
 
@@ -2134,6 +2200,7 @@ def test_save_last_only_when_checkpoint_saved(tmp_path):
             super().__init__()
             self.validation_step_outputs = []
 
+        @override
         def validation_step(self, batch, batch_idx):
             outputs = super().validation_step(batch, batch_idx)
             epoch = self.trainer.current_epoch
@@ -2142,6 +2209,7 @@ def test_save_last_only_when_checkpoint_saved(tmp_path):
             self.validation_step_outputs.append(outputs)
             return outputs
 
+        @override
         def on_validation_epoch_end(self):
             if self.validation_step_outputs:
                 avg_loss = torch.stack([x["val_loss"] for x in self.validation_step_outputs]).mean()

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import math
 import os
 import pickle
@@ -32,6 +31,7 @@ import yaml
 from jsonargparse import ArgumentParser
 from torch import optim
 from torch.utils.data.dataloader import DataLoader
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.fabric.utilities.cloud_io import _load as pl_load

--- a/tests/tests_pytorch/checkpointing/test_trainer_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_trainer_checkpoint.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from unittest import mock
 from unittest.mock import ANY, Mock
@@ -30,11 +31,13 @@ def test_finetuning_with_ckpt_path(tmp_path):
     checkpoint_callback = ModelCheckpoint(monitor="val_loss", dirpath=tmp_path, filename="{epoch:02d}", save_top_k=-1)
 
     class ExtendedBoringModel(BoringModel):
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.001)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
             return [optimizer], [lr_scheduler]
 
+        @override
         def validation_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.log("val_loss", loss, on_epoch=True, prog_bar=True)

--- a/tests/tests_pytorch/checkpointing/test_trainer_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_trainer_checkpoint.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from unittest import mock
 from unittest.mock import ANY, Mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.fabric.plugins import TorchCheckpointIO, XLACheckpointIO

--- a/tests/tests_pytorch/core/test_datamodules.py
+++ b/tests/tests_pytorch/core/test_datamodules.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 import pickle
 from argparse import Namespace
@@ -22,6 +21,7 @@ from unittest.mock import Mock, PropertyMock, call
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import LightningDataModule, Trainer, seed_everything
 from lightning.pytorch.callbacks import ModelCheckpoint

--- a/tests/tests_pytorch/core/test_datamodules.py
+++ b/tests/tests_pytorch/core/test_datamodules.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 import pickle
 from argparse import Namespace
@@ -47,6 +48,7 @@ if _OMEGACONF_AVAILABLE:
 @mock.patch("lightning.pytorch.trainer.trainer.Trainer.local_rank", new_callable=PropertyMock)
 def test_can_prepare_data(local_rank, node_rank):
     class MyDataModule(LightningDataModule):
+        @override
         def prepare_data(self):
             pass
 
@@ -114,9 +116,11 @@ def test_hooks_no_recursion_error():
     # hooks were appended in cascade every tine a new data module was instantiated leading to a recursion error.
     # See https://github.com/Lightning-AI/pytorch-lightning/issues/3652
     class DummyDM(LightningDataModule):
+        @override
         def setup(self, *args, **kwargs):
             pass
 
+        @override
         def prepare_data(self, *args, **kwargs):
             pass
 
@@ -187,15 +191,18 @@ def test_train_val_loop_only(tmp_path):
 
 def test_dm_checkpoint_save_and_load(tmp_path):
     class CustomBoringModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx):
             out = super().validation_step(batch, batch_idx)
             self.log("early_stop_on", out["x"])
             return out
 
     class CustomBoringDataModule(BoringDataModule):
+        @override
         def state_dict(self) -> dict[str, Any]:
             return {"my": "state_dict"}
 
+        @override
         def load_state_dict(self, state_dict: dict[str, Any]) -> None:
             self.my_state_dict = state_dict
 
@@ -257,6 +264,7 @@ def test_dm_reload_dataloaders_every_n_epochs(tmp_path):
             super().__init__()
             self._epochs_called_for = []
 
+        @override
         def train_dataloader(self):
             assert self.trainer.current_epoch not in self._epochs_called_for
             self._epochs_called_for.append(self.trainer.current_epoch)
@@ -275,6 +283,7 @@ def test_dm_reload_dataloaders_every_n_epochs(tmp_path):
 
 
 class DummyDS(torch.utils.data.Dataset):
+    @override
     def __getitem__(self, index):
         return 1
 
@@ -283,6 +292,7 @@ class DummyDS(torch.utils.data.Dataset):
 
 
 class DummyIDS(torch.utils.data.IterableDataset):
+    @override
     def __iter__(self):
         yield 1
 
@@ -473,10 +483,12 @@ def test_datamodule_hooks_are_profiled(tmp_path):
         )
 
     class CustomBoringDataModule(BoringDataModule):
+        @override
         def state_dict(self):
             return {"temp": 1}
 
         # override so that it gets called
+        @override
         def prepare_data(self):
             pass
 

--- a/tests/tests_pytorch/core/test_lightning_module.py
+++ b/tests/tests_pytorch/core/test_lightning_module.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import sys
 import weakref
 from unittest.mock import Mock
@@ -20,6 +19,7 @@ import pytest
 import torch
 from torch import nn
 from torch.optim import SGD, Adam
+from typing_extensions import override
 
 from lightning.fabric import Fabric
 from lightning.pytorch import LightningModule, Trainer

--- a/tests/tests_pytorch/core/test_lightning_module.py
+++ b/tests/tests_pytorch/core/test_lightning_module.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import sys
 import weakref
 from unittest.mock import Mock
@@ -153,6 +154,7 @@ def test_toggle_untoggle_2_optimizers_no_shared_parameters(tmp_path):
             self.layer_2[1].weight.requires_grad = False
             self.layer_2[3].weight.requires_grad = False
 
+        @override
         def training_step(self, batch, batch_idx):
             opt1, opt2 = self.optimizers()
 
@@ -186,6 +188,7 @@ def test_toggle_untoggle_2_optimizers_no_shared_parameters(tmp_path):
             opt2.step()
             self.untoggle_optimizer(opt2)
 
+        @override
         def configure_optimizers(self):
             optimizer_1 = SGD(self.layer_1.parameters(), lr=0.1)
             optimizer_2 = Adam(self.layer_2.parameters(), lr=0.1)
@@ -222,6 +225,7 @@ def test_toggle_untoggle_3_optimizers_shared_parameters(tmp_path):
             self.layer_3[1].weight.requires_grad = False
             self.layer_3[5].weight.requires_grad = False
 
+        @override
         def training_step(self, batch, batch_idx):
             opt1, opt2, opt3 = self.optimizers()
 
@@ -287,6 +291,7 @@ def test_toggle_untoggle_3_optimizers_shared_parameters(tmp_path):
             yield from gen_1
             yield from gen_2
 
+        @override
         def configure_optimizers(self):
             optimizer_1 = SGD(self.combine_generators(self.layer_1.parameters(), self.layer_2.parameters()), lr=0.1)
             optimizer_2 = Adam(self.combine_generators(self.layer_2.parameters(), self.layer_3.parameters()), lr=0.1)
@@ -385,6 +390,7 @@ def test_lightning_module_configure_gradient_clipping(tmp_path):
         has_validated_gradients = False
         custom_gradient_clip_val = 1e-2
 
+        @override
         def configure_gradient_clipping(self, optimizer, gradient_clip_val, gradient_clip_algorithm):
             assert gradient_clip_val == self.trainer.gradient_clip_val
             assert gradient_clip_algorithm == self.trainer.gradient_clip_algorithm
@@ -414,6 +420,7 @@ def test_lightning_module_configure_gradient_clipping_different_argument_values(
     class TestModel(BoringModel):
         custom_gradient_clip_val = 1e-2
 
+        @override
         def configure_gradient_clipping(self, optimizer, gradient_clip_val, gradient_clip_algorithm):
             self.clip_gradients(optimizer, gradient_clip_val=self.custom_gradient_clip_val)
 
@@ -430,6 +437,7 @@ def test_lightning_module_configure_gradient_clipping_different_argument_values(
     class TestModel(BoringModel):
         custom_gradient_clip_algorithm = "foo"
 
+        @override
         def configure_gradient_clipping(self, optimizer, gradient_clip_val, gradient_clip_algorithm):
             self.clip_gradients(optimizer, gradient_clip_algorithm=self.custom_gradient_clip_algorithm)
 

--- a/tests/tests_pytorch/core/test_lightning_optimizer.py
+++ b/tests/tests_pytorch/core/test_lightning_optimizer.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from copy import deepcopy
 from unittest.mock import DEFAULT, Mock, patch
 
@@ -29,6 +30,7 @@ def test_lightning_optimizer(tmp_path):
     """Test that optimizer are correctly wrapped by our LightningOptimizer."""
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
@@ -78,6 +80,7 @@ def test_lightning_optimizer_manual_optimization_and_accumulated_gradients(tmp_p
             super().__init__()
             self.automatic_optimization = False
 
+        @override
         def training_step(self, batch, batch_idx):
             opt_1, opt_2 = self.optimizers()
 
@@ -99,6 +102,7 @@ def test_lightning_optimizer_manual_optimization_and_accumulated_gradients(tmp_p
             # since the optimizer is mocked, the step output is a Mock
             assert isinstance(step_output, Mock)
 
+        @override
         def configure_optimizers(self):
             optimizer_1 = torch.optim.SGD(self.layer.parameters(), lr=0.1)
             optimizer_2 = torch.optim.Adam(self.layer.parameters(), lr=0.1)
@@ -176,10 +180,12 @@ def test_lightning_optimizer_automatic_optimization_optimizer_zero_grad(tmp_path
     """Test overriding zero_grad works in automatic_optimization."""
 
     class TestModel(BoringModel):
+        @override
         def optimizer_zero_grad(self, epoch, batch_idx, optimizer):
             if batch_idx % 2 == 0:
                 optimizer.zero_grad()
 
+        @override
         def configure_optimizers(self):
             optimizer_1 = torch.optim.SGD(self.layer.parameters(), lr=0.1)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer_1, step_size=1)
@@ -199,6 +205,7 @@ def test_lightning_optimizer_automatic_optimization_optimizer_step(tmp_path):
     """Test overriding step works in automatic_optimization."""
 
     class TestModel(BoringModel):
+        @override
         def optimizer_step(self, epoch, batch_idx, optimizer, optimizer_closure, **_):
             assert isinstance(optimizer_closure, Closure)
             # zero_grad is called inside the closure
@@ -207,6 +214,7 @@ def test_lightning_optimizer_automatic_optimization_optimizer_step(tmp_path):
             if batch_idx % 2 == 0:
                 optimizer.step()
 
+        @override
         def configure_optimizers(self):
             optimizer_1 = torch.optim.SGD(self.layer.parameters(), lr=0.1)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer_1, step_size=1)
@@ -238,6 +246,7 @@ def test_lightning_optimizer_automatic_optimization_lbfgs_zero_grad(tmp_path):
     seed_everything(0)
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             return torch.optim.LBFGS(self.parameters())
 
@@ -292,6 +301,7 @@ class OptimizerWithHooks(Optimizer):
         if mod.training:
             self.state[mod]["grad"] = grad_output[0] * batch_size
 
+    @override
     def step(self, closure=None):
         closure()
         for group in self.param_groups:
@@ -311,11 +321,13 @@ def test_lightning_optimizer_keeps_hooks():
 
 def test_params_groups_and_state_are_accessible(tmp_path):
     class TestModel(BoringModel):
+        @override
         def on_train_start(self):
             # Update the learning rate manually on the unwrapped optimizer
             assert not isinstance(self.trainer.optimizers[0], LightningOptimizer)
             self.trainer.optimizers[0].param_groups[0]["lr"] = 2.0
 
+        @override
         def training_step(self, batch, batch_idx):
             opt = self.optimizers()
             assert opt.param_groups[0]["lr"] == 2.0
@@ -324,9 +336,11 @@ def test_params_groups_and_state_are_accessible(tmp_path):
             self.__loss = loss
             return loss
 
+        @override
         def configure_optimizers(self):
             return SGD(self.layer.parameters(), lr=0.1)
 
+        @override
         def optimizer_step(self, epoch, batch_idx, optimizer, optimizer_closure, **__):
             # check attributes are accessible
             assert all("lr" in pg for pg in optimizer.param_groups)

--- a/tests/tests_pytorch/core/test_lightning_optimizer.py
+++ b/tests/tests_pytorch/core/test_lightning_optimizer.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from copy import deepcopy
 from unittest.mock import DEFAULT, Mock, patch
 
 import torch
 from torch.optim import SGD, Adam, Optimizer
+from typing_extensions import override
 
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.core.optimizer import LightningOptimizer

--- a/tests/tests_pytorch/core/test_metric_result_integration.py
+++ b/tests/tests_pytorch/core/test_metric_result_integration.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 import pickle
 from contextlib import nullcontext, suppress
@@ -281,6 +282,7 @@ class DummyMeanMetric(Metric):
     def compute(self):
         return self.sum // self.count
 
+    @override
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(sum={self.sum}, count={self.count})"
 
@@ -302,6 +304,7 @@ def result_collection_reload(default_root_dir, accelerator="auto", devices=1, **
         def results(self):
             return self.trainer.fit_loop._results
 
+        @override
         def training_step(self, batch, batch_idx):
             # We run 5 batches, meaning batch_idx from [0..4]
             # Without failure, we expect to get `total=sum(range(5))` and `num_batches=5`
@@ -343,6 +346,7 @@ def result_collection_reload(default_root_dir, accelerator="auto", devices=1, **
 
             return super().training_step(batch, batch_idx)
 
+        @override
         def on_train_epoch_end(self) -> None:
             if self.trainer.fit_loop.restarting:
                 # the state of the results before the exception is not saved and restored, so the total starts after
@@ -419,6 +423,7 @@ def test_metric_collections(tmp_path):
                 "a": ModuleList([ModuleDict({"b": DummyMetric()}), DummyMetric()])
             })
 
+        @override
         def training_step(self, batch, batch_idx):
             loss = super().training_step(batch, batch_idx)
             self.metrics_list[0](batch_idx)
@@ -447,6 +452,7 @@ def test_metric_collections(tmp_path):
 
             return loss
 
+        @override
         def on_train_epoch_end(self) -> None:
             results = self.trainer.fit_loop.epoch_loop._results
             assert results["training_step.a"].meta.metric_attribute == "metrics_list.0"
@@ -582,6 +588,7 @@ def test_compute_not_a_tensor_raises():
             super().__init__()
             self.metric = RandomMetric()
 
+        @override
         def on_train_start(self):
             self.log("foo", self.metric)
 

--- a/tests/tests_pytorch/core/test_metric_result_integration.py
+++ b/tests/tests_pytorch/core/test_metric_result_integration.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 import pickle
 from contextlib import nullcontext, suppress
@@ -24,6 +23,7 @@ from torch import Tensor, tensor
 from torch.nn import ModuleDict, ModuleList
 from torchmetrics import Metric, MetricCollection
 from torchmetrics.classification import Accuracy
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.fabric.utilities.warnings import PossibleUserWarning

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -1,8 +1,8 @@
-from typing_extensions import override
 from unittest.mock import ANY, Mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks import ModelCheckpoint

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 from unittest.mock import ANY, Mock
 
 import pytest
@@ -98,9 +99,11 @@ def test_load_from_checkpoint_device_placement_with_extra_state(tmp_path):
     """Test that the device gets chosen based on the device of the saved tensors in the checkpoint."""
 
     class ExtraStateModel(BoringModel):
+        @override
         def get_extra_state(self):
             return {"extra": "state"}  # state without tensors
 
+        @override
         def set_extra_state(self, state):
             pass
 

--- a/tests/tests_pytorch/deprecated_api/test_no_removal_version.py
+++ b/tests/tests_pytorch/deprecated_api/test_no_removal_version.py
@@ -1,9 +1,9 @@
-from typing_extensions import override
 import sys
 from unittest.mock import Mock
 
 import pytest
 import torch.nn
+from typing_extensions import override
 
 import lightning.fabric
 from lightning.pytorch import Trainer

--- a/tests/tests_pytorch/deprecated_api/test_no_removal_version.py
+++ b/tests/tests_pytorch/deprecated_api/test_no_removal_version.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import sys
 from unittest.mock import Mock
 
@@ -13,6 +14,7 @@ from lightning.pytorch.strategies import DDPStrategy, FSDPStrategy
 
 def test_configure_sharded_model():
     class MyModel(BoringModel):
+        @override
         def configure_sharded_model(self) -> None: ...
 
     model = MyModel()
@@ -21,6 +23,7 @@ def test_configure_sharded_model():
         trainer.fit(model)
 
     class MyModelBoth(MyModel):
+        @override
         def configure_model(self): ...
 
     model = MyModelBoth()

--- a/tests/tests_pytorch/helpers/advanced_models.py
+++ b/tests/tests_pytorch/helpers/advanced_models.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.pytorch.core.module import LightningModule
 from tests_pytorch import _PATH_DATASETS

--- a/tests/tests_pytorch/helpers/advanced_models.py
+++ b/tests/tests_pytorch/helpers/advanced_models.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import numpy as np
 import torch
 import torch.nn as nn
@@ -44,6 +45,7 @@ class Generator(nn.Module):
             nn.Tanh(),
         )
 
+    @override
     def forward(self, z):
         img = self.model(z)
         return img.view(img.size(0), *self.img_shape)
@@ -62,6 +64,7 @@ class Discriminator(nn.Module):
             nn.Sigmoid(),
         )
 
+    @override
     def forward(self, img):
         img_flat = img.view(img.size(0), -1)
         return self.model(img_flat)
@@ -91,12 +94,14 @@ class BasicGAN(LightningModule):
 
         self.example_input_array = torch.rand(2, self.hidden_dim)
 
+    @override
     def forward(self, z):
         return self.generator(z)
 
     def adversarial_loss(self, y_hat, y):
         return F.binary_cross_entropy(y_hat, y)
 
+    @override
     def training_step(self, batch, batch_idx):
         imgs, _ = batch
         self.last_imgs = imgs
@@ -148,6 +153,7 @@ class BasicGAN(LightningModule):
         optimizer2.zero_grad()
         self.untoggle_optimizer(optimizer2)
 
+    @override
     def configure_optimizers(self):
         lr = self.learning_rate
         b1 = self.b1
@@ -157,6 +163,7 @@ class BasicGAN(LightningModule):
         opt_d = torch.optim.Adam(self.discriminator.parameters(), lr=lr, betas=(b1, b2))
         return [opt_g, opt_d], []
 
+    @override
     def train_dataloader(self):
         return DataLoader(TrialMNIST(root=_PATH_DATASETS, train=True, download=True), batch_size=16)
 
@@ -169,10 +176,12 @@ class ParityModuleRNN(LightningModule):
         self.example_input_array = torch.rand(2, 3, 10)
         self._loss = []  # needed for checking if the loss is the same as vanilla torch
 
+    @override
     def forward(self, x):
         seq, _ = self.rnn(x)
         return self.linear_out(seq)
 
+    @override
     def training_step(self, batch, batch_nb):
         x, y = batch
         y_hat = self(x)
@@ -180,9 +189,11 @@ class ParityModuleRNN(LightningModule):
         self._loss.append(loss.item())
         return {"loss": loss}
 
+    @override
     def configure_optimizers(self):
         return torch.optim.Adam(self.parameters(), lr=0.02)
 
+    @override
     def train_dataloader(self):
         return DataLoader(AverageDataset(), batch_size=30)
 
@@ -197,6 +208,7 @@ class ParityModuleMNIST(LightningModule):
         self.example_input_array = torch.rand(2, 1, 28, 28)
         self._loss = []  # needed for checking if the loss is the same as vanilla torch
 
+    @override
     def forward(self, x):
         x = x.view(x.size(0), -1)
         x = self.c_d1(x)
@@ -205,6 +217,7 @@ class ParityModuleMNIST(LightningModule):
         x = self.c_d1_drop(x)
         return self.c_d2(x)
 
+    @override
     def training_step(self, batch, batch_nb):
         x, y = batch
         y_hat = self(x)
@@ -212,9 +225,11 @@ class ParityModuleMNIST(LightningModule):
         self._loss.append(loss.item())
         return {"loss": loss}
 
+    @override
     def configure_optimizers(self):
         return torch.optim.Adam(self.parameters(), lr=0.02)
 
+    @override
     def train_dataloader(self):
         return DataLoader(MNIST(root=_PATH_DATASETS, train=True, download=True), batch_size=128, num_workers=1)
 
@@ -234,10 +249,12 @@ class TBPTTModule(LightningModule):
         self.rnn = nn.LSTM(self.in_features, self.hidden_dim, batch_first=True)
         self.linear_out = nn.Linear(in_features=self.hidden_dim, out_features=self.out_features)
 
+    @override
     def forward(self, x, hs):
         seq, hs = self.rnn(x, hs)
         return self.linear_out(seq), hs
 
+    @override
     def training_step(self, batch, batch_idx):
         x, y = batch
         split_x, split_y = [
@@ -263,8 +280,10 @@ class TBPTTModule(LightningModule):
 
         return
 
+    @override
     def configure_optimizers(self):
         return torch.optim.Adam(self.parameters(), lr=0.001)
 
+    @override
     def train_dataloader(self):
         return DataLoader(AverageDataset(), batch_size=self.batch_size)

--- a/tests/tests_pytorch/helpers/dataloaders.py
+++ b/tests/tests_pytorch/helpers/dataloaders.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 # Copyright The Lightning AI team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,6 +42,7 @@ class CustomNotImplementedErrorDataloader(CustomInfDataloader):
         """Raise NotImplementedError."""
         raise NotImplementedError
 
+    @override
     def __next__(self):
         if self.count >= 2:
             raise StopIteration

--- a/tests/tests_pytorch/helpers/dataloaders.py
+++ b/tests/tests_pytorch/helpers/dataloaders.py
@@ -1,4 +1,5 @@
 from typing_extensions import override
+
 # Copyright The Lightning AI team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/tests_pytorch/helpers/datamodules.py
+++ b/tests/tests_pytorch/helpers/datamodules.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import torch
 from lightning_utilities.core.imports import RequirementCache
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.pytorch.core.datamodule import LightningDataModule
 from tests_pytorch.helpers.datasets import MNIST, SklearnDataset, TrialMNIST

--- a/tests/tests_pytorch/helpers/datamodules.py
+++ b/tests/tests_pytorch/helpers/datamodules.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import torch
 from lightning_utilities.core.imports import RequirementCache
 from torch.utils.data import DataLoader
@@ -32,20 +33,24 @@ class MNISTDataModule(LightningDataModule):
         # TrialMNIST is a constrained MNIST dataset
         self.dataset_cls = TrialMNIST if use_trials else MNIST
 
+    @override
     def prepare_data(self):
         # download only
         self.dataset_cls(self.data_dir, train=True, download=True)
         self.dataset_cls(self.data_dir, train=False, download=True)
 
+    @override
     def setup(self, stage: str):
         if stage == "fit":
             self.mnist_train = self.dataset_cls(self.data_dir, train=True)
         if stage == "test":
             self.mnist_test = self.dataset_cls(self.data_dir, train=False)
 
+    @override
     def train_dataloader(self):
         return DataLoader(self.mnist_train, batch_size=self.batch_size, shuffle=False)
 
+    @override
     def test_dataloader(self):
         return DataLoader(self.mnist_test, batch_size=self.batch_size, shuffle=False)
 
@@ -72,22 +77,26 @@ class SklearnDataModule(LightningDataModule):
             self.x_train, self.y_train, test_size=0.40, random_state=42
         )
 
+    @override
     def train_dataloader(self):
         return DataLoader(
             SklearnDataset(self.x_train, self.y_train, self._x_type, self._y_type),
             batch_size=self.batch_size,
         )
 
+    @override
     def val_dataloader(self):
         return DataLoader(
             SklearnDataset(self.x_valid, self.y_valid, self._x_type, self._y_type), batch_size=self.batch_size
         )
 
+    @override
     def test_dataloader(self):
         return DataLoader(
             SklearnDataset(self.x_test, self.y_test, self._x_type, self._y_type), batch_size=self.batch_size
         )
 
+    @override
     def predict_dataloader(self):
         return DataLoader(
             SklearnDataset(self.x_test, self.y_test, self._x_type, self._y_type), batch_size=self.batch_size

--- a/tests/tests_pytorch/helpers/datasets.py
+++ b/tests/tests_pytorch/helpers/datasets.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import logging
 import os
 import random
@@ -23,6 +22,7 @@ from typing import Optional
 import torch
 from torch import Tensor
 from torch.utils.data import Dataset
+from typing_extensions import override
 
 
 class MNIST(Dataset):

--- a/tests/tests_pytorch/helpers/datasets.py
+++ b/tests/tests_pytorch/helpers/datasets.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import logging
 import os
 import random
@@ -64,6 +65,7 @@ class MNIST(Dataset):
         data_file = self.TRAIN_FILE_NAME if self.train else self.TEST_FILE_NAME
         self.data, self.targets = self._try_load(os.path.join(self.cached_folder_path, data_file))
 
+    @override
     def __getitem__(self, idx: int) -> tuple[Tensor, int]:
         img = self.data[idx].float().unsqueeze(0)
         target = int(self.targets[idx])
@@ -162,6 +164,7 @@ class TrialMNIST(MNIST):
         targets = full_targets[indexes]
         return data, targets
 
+    @override
     def _download(self, data_folder: str) -> None:
         super()._download(data_folder)
         for fname in (self.TRAIN_FILE_NAME, self.TEST_FILE_NAME):
@@ -183,6 +186,7 @@ class AverageDataset(Dataset):
     def __len__(self):
         return self.dataset_len
 
+    @override
     def __getitem__(self, item):
         return self.input_seq[item], self.output_seq[item]
 
@@ -194,6 +198,7 @@ class SklearnDataset(Dataset):
         self._x_type = x_type
         self._y_type = y_type
 
+    @override
     def __getitem__(self, idx):
         return torch.tensor(self.x[idx], dtype=self._x_type), torch.tensor(self.y[idx], dtype=self._y_type)
 

--- a/tests/tests_pytorch/helpers/deterministic_model.py
+++ b/tests/tests_pytorch/helpers/deterministic_model.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import torch
 from torch import Tensor, nn
 from torch.utils.data import DataLoader, Dataset
@@ -33,6 +34,7 @@ class DeterministicModel(LightningModule):
             p = torch.nn.Parameter(weights, requires_grad=True)
             self.l1.weight = p
 
+    @override
     def forward(self, x):
         return self.l1(x)
 
@@ -61,12 +63,15 @@ class DeterministicModel(LightningModule):
     # -----------------------------
     # DATA
     # -----------------------------
+    @override
     def train_dataloader(self):
         return DataLoader(DummyDataset(), batch_size=3, shuffle=False)
 
+    @override
     def val_dataloader(self):
         return DataLoader(DummyDataset(), batch_size=3, shuffle=False)
 
+    @override
     def configure_optimizers(self):
         return torch.optim.Adam(self.parameters(), lr=0)
 
@@ -82,6 +87,7 @@ class DeterministicModel(LightningModule):
         scheduler = {"scheduler": lr_scheduler, "interval": "step", "monitor": "pbar_acc1"}
         return [optimizer], [scheduler]
 
+    @override
     def backward(self, loss, *args, **kwargs):
         if self.assert_backward:
             if self.trainer.precision == "16-mixed":
@@ -96,5 +102,6 @@ class DummyDataset(Dataset):
     def __len__(self):
         return 12
 
+    @override
     def __getitem__(self, idx):
         return torch.tensor([0.5, 1.0, 2.0])

--- a/tests/tests_pytorch/helpers/deterministic_model.py
+++ b/tests/tests_pytorch/helpers/deterministic_model.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import torch
 from torch import Tensor, nn
 from torch.utils.data import DataLoader, Dataset
+from typing_extensions import override
 
 from lightning.pytorch.core.module import LightningModule
 

--- a/tests/tests_pytorch/helpers/simple_models.py
+++ b/tests/tests_pytorch/helpers/simple_models.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import operator
 
 import torch
@@ -40,6 +41,7 @@ class ClassificationModel(LightningModule):
         self.valid_acc = acc.clone()
         self.test_acc = acc.clone()
 
+    @override
     def forward(self, x):
         x = self.layer_0(x)
         x = self.layer_0a(x)
@@ -50,10 +52,12 @@ class ClassificationModel(LightningModule):
         x = self.layer_end(x)
         return F.softmax(x, dim=1)
 
+    @override
     def configure_optimizers(self):
         optimizer = torch.optim.Adam(self.parameters(), lr=self.lr)
         return [optimizer], []
 
+    @override
     def training_step(self, batch, batch_idx):
         x, y = batch
         logits = self.forward(x)
@@ -62,18 +66,21 @@ class ClassificationModel(LightningModule):
         self.log("train_acc", self.train_acc(logits, y), prog_bar=True)
         return {"loss": loss}
 
+    @override
     def validation_step(self, batch, batch_idx):
         x, y = batch
         logits = self.forward(x)
         self.log("val_loss", F.cross_entropy(logits, y), prog_bar=False)
         self.log("val_acc", self.valid_acc(logits, y), prog_bar=True)
 
+    @override
     def test_step(self, batch, batch_idx):
         x, y = batch
         logits = self.forward(x)
         self.log("test_loss", F.cross_entropy(logits, y), prog_bar=False)
         self.log("test_acc", self.test_acc(logits, y), prog_bar=True)
 
+    @override
     def predict_step(self, batch, batch_idx):
         x, _ = batch
         return self.forward(x)
@@ -93,6 +100,7 @@ class RegressionModel(LightningModule):
         self.valid_mse = MeanSquaredError()
         self.test_mse = MeanSquaredError()
 
+    @override
     def forward(self, x):
         x = self.layer_0(x)
         x = self.layer_0a(x)
@@ -102,10 +110,12 @@ class RegressionModel(LightningModule):
         x = self.layer_2a(x)
         return self.layer_end(x)
 
+    @override
     def configure_optimizers(self):
         optimizer = torch.optim.Adam(self.parameters(), lr=0.01)
         return [optimizer], []
 
+    @override
     def training_step(self, batch, batch_idx):
         x, y = batch
         out = self.forward(x)
@@ -114,12 +124,14 @@ class RegressionModel(LightningModule):
         self.log("train_MSE", self.train_mse(out, y), prog_bar=True)
         return {"loss": loss}
 
+    @override
     def validation_step(self, batch, batch_idx):
         x, y = batch
         out = self.forward(x)
         self.log("val_loss", F.mse_loss(out, y), prog_bar=False)
         self.log("val_MSE", self.valid_mse(out, y), prog_bar=True)
 
+    @override
     def test_step(self, batch, batch_idx):
         x, y = batch
         out = self.forward(x)

--- a/tests/tests_pytorch/helpers/simple_models.py
+++ b/tests/tests_pytorch/helpers/simple_models.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import operator
 
 import torch
@@ -19,6 +18,7 @@ import torch.nn.functional as F
 from lightning_utilities.core.imports import compare_version
 from torch import nn
 from torchmetrics import Accuracy, MeanSquaredError
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule
 

--- a/tests/tests_pytorch/helpers/threading.py
+++ b/tests/tests_pytorch/helpers/threading.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from threading import Thread
+
+from typing_extensions import override
 
 
 class ThreadExceptionHandler(Thread):

--- a/tests/tests_pytorch/helpers/threading.py
+++ b/tests/tests_pytorch/helpers/threading.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from threading import Thread
 
 
@@ -21,12 +22,14 @@ class ThreadExceptionHandler(Thread):
         super().__init__(*args, **kwargs)
         self.exception = None
 
+    @override
     def run(self):
         try:
             super().run()
         except Exception as e:
             self.exception = e
 
+    @override
     def join(self):
         super().join()
         if self.exception:

--- a/tests/tests_pytorch/loggers/test_all.py
+++ b/tests/tests_pytorch/loggers/test_all.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import inspect
 import os
 import pickle
@@ -72,14 +73,17 @@ def test_loggers_fit_test_all(logger_class, mlflow_mock, wandb_mock, comet_mock,
     monkeypatch.chdir(tmp_path)
 
     class CustomModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.log("train_some_val", loss)
             return {"loss": loss}
 
+        @override
         def on_validation_epoch_end(self):
             self.log_dict({"early_stop_on": torch.tensor(1), "val_loss": torch.tensor(0.5)})
 
+        @override
         def on_test_epoch_end(self):
             self.log("test_loss", torch.tensor(2))
 
@@ -205,6 +209,7 @@ def test_logger_reset_correctly(tmp_path, tuner_method):
 
 
 class LazyInitExperimentCheck(Callback):
+    @override
     def setup(self, trainer, pl_module, stage=None):
         if trainer.global_rank > 0:
             return
@@ -215,6 +220,7 @@ class LazyInitExperimentCheck(Callback):
 
 
 class RankZeroLoggerCheck(Callback):
+    @override
     def on_train_batch_start(self, trainer, pl_module, batch, batch_idx):
         is_dummy = isinstance(trainer.logger.experiment, DummyExperiment)
         if trainer.is_global_zero:
@@ -225,17 +231,21 @@ class RankZeroLoggerCheck(Callback):
 
 
 class CustomLoggerWithoutExperiment(Logger):
+    @override
     @property
     def name(self):
         return ""
 
+    @override
     @property
     def version(self):
         return None
 
+    @override
     def log_metrics(self, metrics, step=None) -> None:
         pass
 
+    @override
     def log_hyperparams(self, params, *args, **kwargs) -> None:
         pass
 

--- a/tests/tests_pytorch/loggers/test_all.py
+++ b/tests/tests_pytorch/loggers/test_all.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import inspect
 import os
 import pickle
@@ -20,6 +19,7 @@ from unittest.mock import ANY, Mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Callback, Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/loggers/test_litlogger.py
+++ b/tests/tests_pytorch/loggers/test_litlogger.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from argparse import Namespace
 from unittest.mock import MagicMock, call
@@ -276,6 +277,7 @@ def test_litlogger_with_trainer(litlogger_mock, tmp_path):
     """Test LitLogger works with Trainer."""
 
     class LoggingModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             loss = super().training_step(batch, batch_idx)
             self.log("train_loss", loss["loss"])

--- a/tests/tests_pytorch/loggers/test_litlogger.py
+++ b/tests/tests_pytorch/loggers/test_litlogger.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from argparse import Namespace
 from unittest.mock import MagicMock, call
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/loggers/test_logger.py
+++ b/tests/tests_pytorch/loggers/test_logger.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pickle
 from argparse import Namespace
 from copy import deepcopy
@@ -46,37 +47,45 @@ class CustomLogger(Logger):
         return self._experiment
 
     @rank_zero_only
+    @override
     def log_hyperparams(self, params):
         self.hparams_logged = params
 
     @rank_zero_only
+    @override
     def log_metrics(self, metrics, step):
         self.metrics_logged = metrics
 
     @rank_zero_only
+    @override
     def finalize(self, status):
         self.finalized_status = status
 
+    @override
     @property
     def save_dir(self) -> Optional[str]:
         """Return the root directory where experiment logs get saved, or `None` if the logger does not save data
         locally."""
         return None
 
+    @override
     @property
     def name(self):
         return self._name
 
+    @override
     @property
     def version(self):
         return self._version
 
+    @override
     def after_save_checkpoint(self, checkpoint_callback):
         self.after_save_checkpoint_called = True
 
 
 def test_custom_logger(tmp_path):
     class CustomModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.log("train_loss", loss)
@@ -94,6 +103,7 @@ def test_custom_logger(tmp_path):
 
 def test_multiple_loggers(tmp_path):
     class CustomModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.log("train_loss", loss)
@@ -137,6 +147,7 @@ def test_adding_step_key(tmp_path):
             super().__init__(*args, **kwargs)
             self.logged_step = 0
 
+        @override
         def log_metrics(self, metrics, step):
             if "val_acc" in metrics:
                 assert step == self.logged_step
@@ -144,10 +155,12 @@ def test_adding_step_key(tmp_path):
             super().log_metrics(metrics, step)
 
     class CustomModel(BoringModel):
+        @override
         def on_train_epoch_end(self):
             self.logger.logged_step += 1
             self.log_dict({"step": self.logger.logged_step, "train_acc": self.logger.logged_step / 10})
 
+        @override
         def on_validation_epoch_end(self):
             self.logger.logged_step += 1
             self.log_dict({"step": self.logger.logged_step, "val_acc": self.logger.logged_step / 10})
@@ -193,6 +206,7 @@ def test_np_sanitization():
             self.logged_params = None
 
         @rank_zero_only
+        @override
         def log_hyperparams(self, params):
             params = _convert_params(params)
             params = _sanitize_params(params)

--- a/tests/tests_pytorch/loggers/test_logger.py
+++ b/tests/tests_pytorch/loggers/test_logger.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pickle
 from argparse import Namespace
 from copy import deepcopy
@@ -21,6 +20,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.fabric.utilities.logger import _convert_params, _sanitize_params
 from lightning.pytorch import Trainer

--- a/tests/tests_pytorch/loggers/test_mlflow.py
+++ b/tests/tests_pytorch/loggers/test_mlflow.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from unittest import mock
 from unittest.mock import MagicMock, Mock
 
 import pytest
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/loggers/test_mlflow.py
+++ b/tests/tests_pytorch/loggers/test_mlflow.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from unittest import mock
 from unittest.mock import MagicMock, Mock
@@ -191,6 +192,7 @@ def test_mlflow_logger_dirs_creation(tmp_path):
         assert set(os.listdir(tmp_path / exp_id)) == {run_id, "meta.yaml"}
 
     class CustomModel(BoringModel):
+        @override
         def on_train_epoch_end(self, *args, **kwargs):
             self.log("epoch", self.current_epoch)
 

--- a/tests/tests_pytorch/loggers/test_tensorboard.py
+++ b/tests/tests_pytorch/loggers/test_tensorboard.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from argparse import Namespace
 from unittest import mock
@@ -111,10 +112,12 @@ def test_tensorboard_no_name(tmp_path, name):
 def test_tensorboard_log_sub_dir(tmp_path):
     class TestLogger(TensorBoardLogger):
         # for reproducibility
+        @override
         @property
         def version(self):
             return "version"
 
+        @override
         @property
         def name(self):
             return "name"
@@ -248,6 +251,7 @@ def test_tensorboard_with_accumulated_gradients(mock_log_metrics, tmp_path):
             super().__init__()
             self.indexes = []
 
+        @override
         def training_step(self, *args):
             self.log("foo", 1, on_step=True, on_epoch=True)
             if not self.trainer.fit_loop._should_accumulate() and self.trainer._logger_connector.should_update_logs:

--- a/tests/tests_pytorch/loggers/test_tensorboard.py
+++ b/tests/tests_pytorch/loggers/test_tensorboard.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from argparse import Namespace
 from unittest import mock
@@ -21,6 +20,7 @@ import numpy as np
 import pytest
 import torch
 import yaml
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/loggers/test_wandb.py
+++ b/tests/tests_pytorch/loggers/test_wandb.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 import pickle
 from pathlib import Path
@@ -20,6 +19,7 @@ from unittest import mock
 import pytest
 import yaml
 from lightning_utilities.test.warning import no_warning_call
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint

--- a/tests/tests_pytorch/loggers/test_wandb.py
+++ b/tests/tests_pytorch/loggers/test_wandb.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 import pickle
 from pathlib import Path
@@ -650,6 +651,7 @@ def test_wandb_logger_cli_integration(log_model, expected, wandb_mock, monkeypat
     monkeypatch.chdir(tmp_path)
 
     class InspectParsedCLI(LightningCLI):
+        @override
         def before_instantiate_classes(self):
             assert self.config.trainer.logger.init_args.log_model == expected
 

--- a/tests/tests_pytorch/loops/optimization/test_automatic_loop.py
+++ b/tests/tests_pytorch/loops/optimization/test_automatic_loop.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from collections.abc import Iterator, Mapping
 from contextlib import nullcontext
 from typing import Generic, TypeVar
@@ -54,12 +55,15 @@ class OutputMapping(Generic[T], Mapping[str, T]):
     def __init__(self, d: dict[str, T]) -> None:
         self.d: dict[str, T] = d
 
+    @override
     def __iter__(self) -> Iterator[str]:
         return iter(self.d)
 
+    @override
     def __len__(self) -> int:
         return len(self.d)
 
+    @override
     def __getitem__(self, key: str) -> T:
         return self.d[key]
 
@@ -76,6 +80,7 @@ def test_warning_invalid_trainstep_output(tmp_path, case):
     output, match = case
 
     class InvalidTrainStepModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             return output
 
@@ -91,6 +96,7 @@ def test_skip_training_step_not_allowed(world_size, tmp_path):
     """Test that skipping the training_step in distributed training is not allowed."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             return None
 

--- a/tests/tests_pytorch/loops/optimization/test_automatic_loop.py
+++ b/tests/tests_pytorch/loops/optimization/test_automatic_loop.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from collections.abc import Iterator, Mapping
 from contextlib import nullcontext
 from typing import Generic, TypeVar
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/loops/optimization/test_closure.py
+++ b/tests/tests_pytorch/loops/optimization/test_closure.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/loops/optimization/test_closure.py
+++ b/tests/tests_pytorch/loops/optimization/test_closure.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pytest
 import torch
 
@@ -21,6 +22,7 @@ from lightning.pytorch.utilities.exceptions import MisconfigurationException
 
 def test_optimizer_step_no_closure_raises(tmp_path):
     class TestModel(BoringModel):
+        @override
         def optimizer_step(self, epoch=None, batch_idx=None, optimizer=None, optimizer_closure=None, **_):
             # does not call `optimizer_closure()`
             pass
@@ -31,8 +33,10 @@ def test_optimizer_step_no_closure_raises(tmp_path):
         trainer.fit(model)
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             class BrokenSGD(torch.optim.SGD):
+                @override
                 def step(self, closure=None):
                     # forgot to pass the closure
                     return super().step()
@@ -55,16 +59,19 @@ def test_closure_with_no_grad_optimizer(tmp_path):
 
     class NoGradAdamW(torch.optim.AdamW):
         @torch.no_grad()
+        @override
         def step(self, closure):
             if closure is not None:
                 closure()
             return super().step()
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             assert torch.is_grad_enabled()
             return super().training_step(batch, batch_idx)
 
+        @override
         def configure_optimizers(self):
             return NoGradAdamW(self.parameters(), lr=0.1)
 

--- a/tests/tests_pytorch/loops/optimization/test_manual_loop.py
+++ b/tests/tests_pytorch/loops/optimization/test_manual_loop.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/loops/optimization/test_manual_loop.py
+++ b/tests/tests_pytorch/loops/optimization/test_manual_loop.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pytest
 import torch
 
@@ -35,6 +36,7 @@ def test_warning_invalid_trainstep_output(tmp_path):
             super().__init__()
             self.automatic_optimization = False
 
+        @override
         def training_step(self, batch, batch_idx):
             return 5
 

--- a/tests/tests_pytorch/loops/test_all.py
+++ b/tests/tests_pytorch/loops/test_all.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pytest
 
 from lightning.pytorch import Callback, Trainer
@@ -29,53 +30,69 @@ def _device_check_helper(batch_device, module_device):
 
 
 class BatchHookObserverCallback(Callback):
+    @override
     def on_train_batch_start(self, trainer, pl_module, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
+    @override
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
+    @override
     def on_validation_batch_start(self, trainer, pl_module, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
+    @override
     def on_validation_batch_end(self, trainer, pl_module, outputs, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
+    @override
     def on_test_batch_start(self, trainer, pl_module, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
+    @override
     def on_test_batch_end(self, trainer, pl_module, outputs, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
+    @override
     def on_predict_batch_start(self, trainer, pl_module, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
+    @override
     def on_predict_batch_end(self, trainer, pl_module, outputs, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
 
 class BatchHookObserverModel(BoringModel):
+    @override
     def on_train_batch_start(self, batch, *_):
         _device_check_helper(batch.device, self.device)
 
+    @override
     def on_train_batch_end(self, outputs, batch, *_):
         _device_check_helper(batch.device, self.device)
 
+    @override
     def on_validation_batch_start(self, batch, *_):
         _device_check_helper(batch.device, self.device)
 
+    @override
     def on_validation_batch_end(self, outputs, batch, *_):
         _device_check_helper(batch.device, self.device)
 
+    @override
     def on_test_batch_start(self, batch, *_):
         _device_check_helper(batch.device, self.device)
 
+    @override
     def on_test_batch_end(self, outputs, batch, *_):
         _device_check_helper(batch.device, self.device)
 
+    @override
     def on_predict_batch_start(self, batch, *_):
         _device_check_helper(batch.device, self.device)
 
+    @override
     def on_predict_batch_end(self, outputs, batch, *_):
         _device_check_helper(batch.device, self.device)
 

--- a/tests/tests_pytorch/loops/test_all.py
+++ b/tests/tests_pytorch/loops/test_all.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pytest
+from typing_extensions import override
 
 from lightning.pytorch import Callback, Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/loops/test_double_iter_in_iterable_dataset.py
+++ b/tests/tests_pytorch/loops/test_double_iter_in_iterable_dataset.py
@@ -15,7 +15,6 @@
 # This test tests the resuming of training from a checkpoint file using an IterableDataset.
 # And contains code mentioned in the issue: #19427.
 # Ref: https://github.com/Lightning-AI/pytorch-lightning/issues/19427
-from typing_extensions import override
 import multiprocessing as mp
 import os
 import sys
@@ -26,6 +25,7 @@ from queue import Queue
 import numpy as np
 import pytest
 from torch.utils.data import DataLoader, IterableDataset
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/loops/test_double_iter_in_iterable_dataset.py
+++ b/tests/tests_pytorch/loops/test_double_iter_in_iterable_dataset.py
@@ -15,6 +15,7 @@
 # This test tests the resuming of training from a checkpoint file using an IterableDataset.
 # And contains code mentioned in the issue: #19427.
 # Ref: https://github.com/Lightning-AI/pytorch-lightning/issues/19427
+from typing_extensions import override
 import multiprocessing as mp
 import os
 import sys
@@ -35,6 +36,7 @@ class QueueDataset(IterableDataset):
         super().__init__()
         self.queue = queue
 
+    @override
     def __iter__(self) -> Iterator:
         for _ in range(5):
             tensor, _ = self.queue.get(timeout=5)

--- a/tests/tests_pytorch/loops/test_evaluation_loop.py
+++ b/tests/tests_pytorch/loops/test_evaluation_loop.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from unittest import mock
 from unittest.mock import Mock, call
 
@@ -19,6 +18,7 @@ import pytest
 import torch
 from torch.utils.data.dataloader import DataLoader
 from torch.utils.data.sampler import BatchSampler, RandomSampler
+from typing_extensions import override
 
 from lightning.fabric.accelerators.cuda import _clear_cuda_memory
 from lightning.pytorch import LightningModule, Trainer

--- a/tests/tests_pytorch/loops/test_evaluation_loop.py
+++ b/tests/tests_pytorch/loops/test_evaluation_loop.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from unittest import mock
 from unittest.mock import Mock, call
 
@@ -95,6 +96,7 @@ def test_log_epoch_metrics_before_on_evaluation_end(update_eval_epoch_metrics_mo
     update_eval_epoch_metrics_mock.side_effect = lambda _: order.append("log_epoch_metrics")
 
     class LessBoringModel(BoringModel):
+        @override
         def on_validation_end(self):
             order.append("on_validation_end")
             super().on_validation_end()
@@ -125,14 +127,17 @@ def test_memory_consumption_validation(tmp_path):
         def num_params(self):
             return sum(p.numel() for p in self.parameters())
 
+        @override
         def train_dataloader(self):
             # batch target memory >= 100x boring_model size
             batch_size = self.num_params * 100 // 32 + 1
             return DataLoader(RandomDataset(32, 5000), batch_size=batch_size)
 
+        @override
         def val_dataloader(self):
             return self.train_dataloader()
 
+        @override
         def training_step(self, batch, batch_idx):
             # there is a batch and the boring model, but not two batches on gpu, assume 32 bit = 4 bytes
             lower = 101 * self.num_params * 4
@@ -142,6 +147,7 @@ def test_memory_consumption_validation(tmp_path):
             assert current - initial_memory < upper
             return super().training_step(batch, batch_idx)
 
+        @override
         def validation_step(self, batch, batch_idx):
             # there is a batch and the boring model, but not two batches on gpu, assume 32 bit = 4 bytes
             lower = 101 * self.num_params * 4
@@ -177,12 +183,15 @@ def test_evaluation_loop_dataloader_iter_multiple_dataloaders(tmp_path):
         step_outs = []
         batch_end_ins = []
 
+        @override
         def on_validation_batch_start(self, batch, batch_idx, dataloader_idx):
             self.batch_start_ins.append((batch, batch_idx, dataloader_idx))
 
+        @override
         def validation_step(self, dataloader_iter):
             self.step_outs.append(next(dataloader_iter))
 
+        @override
         def on_validation_batch_end(self, outputs, batch, batch_idx, dataloader_idx):
             self.batch_end_ins.append((batch, batch_idx, dataloader_idx))
 
@@ -200,8 +209,10 @@ def test_invalid_dataloader_idx_raises_step(tmp_path):
     trainer = Trainer(default_root_dir=tmp_path, fast_dev_run=True)
 
     class ExtraDataloaderIdx(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx): ...
 
+        @override
         def test_step(self, batch, batch_idx, dataloader_idx): ...
 
     model = ExtraDataloaderIdx()
@@ -211,8 +222,10 @@ def test_invalid_dataloader_idx_raises_step(tmp_path):
         trainer.test(model)
 
     class GoodDefault(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx=0): ...
 
+        @override
         def test_step(self, batch, batch_idx, dataloader_idx=0): ...
 
     model = GoodDefault()
@@ -220,8 +233,10 @@ def test_invalid_dataloader_idx_raises_step(tmp_path):
     trainer.test(model)
 
     class ExtraDlIdxOtherName(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx, dl_idx): ...
 
+        @override
         def test_step(self, batch, batch_idx, dl_idx): ...
 
     model = ExtraDlIdxOtherName()
@@ -232,9 +247,11 @@ def test_invalid_dataloader_idx_raises_step(tmp_path):
         trainer.test(model)
 
     class MultipleDataloader(BoringModel):
+        @override
         def val_dataloader(self):
             return [super().val_dataloader(), super().val_dataloader()]
 
+        @override
         def test_dataloader(self):
             return [super().test_dataloader(), super().test_dataloader()]
 
@@ -245,8 +262,10 @@ def test_invalid_dataloader_idx_raises_step(tmp_path):
         trainer.test(model)
 
     class IgnoringModel(MultipleDataloader):
+        @override
         def validation_step(self, batch, batch_idx, *_): ...
 
+        @override
         def test_step(self, batch, batch_idx, *_): ...
 
     model = IgnoringModel()
@@ -254,8 +273,10 @@ def test_invalid_dataloader_idx_raises_step(tmp_path):
     trainer.test(model)
 
     class IgnoringModel2(MultipleDataloader):
+        @override
         def validation_step(self, batch, batch_idx, **_): ...
 
+        @override
         def test_step(self, batch, batch_idx, **_): ...
 
     model = IgnoringModel2()
@@ -269,8 +290,10 @@ def test_invalid_dataloader_idx_raises_batch_start(tmp_path):
     trainer = Trainer(default_root_dir=tmp_path, fast_dev_run=True)
 
     class ExtraDataloaderIdx(BoringModel):
+        @override
         def on_validation_batch_start(self, batch, batch_idx, dataloader_idx): ...
 
+        @override
         def on_test_batch_start(self, batch, batch_idx, dataloader_idx): ...
 
     model = ExtraDataloaderIdx()
@@ -282,8 +305,10 @@ def test_invalid_dataloader_idx_raises_batch_start(tmp_path):
         trainer.test(model)
 
     class GoodDefault(BoringModel):
+        @override
         def on_validation_batch_start(self, batch, batch_idx, dataloader_idx=0): ...
 
+        @override
         def on_test_batch_start(self, batch, batch_idx, dataloader_idx=0): ...
 
     model = GoodDefault()
@@ -291,8 +316,10 @@ def test_invalid_dataloader_idx_raises_batch_start(tmp_path):
     trainer.test(model)
 
     class ExtraDlIdxOtherName(BoringModel):
+        @override
         def on_validation_batch_start(self, batch, batch_idx, dl_idx): ...
 
+        @override
         def on_test_batch_start(self, batch, batch_idx, dl_idx): ...
 
     model = ExtraDlIdxOtherName()
@@ -303,17 +330,23 @@ def test_invalid_dataloader_idx_raises_batch_start(tmp_path):
         trainer.test(model)
 
     class MultipleDataloader(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx=0): ...
 
+        @override
         def test_step(self, batch, batch_idx, dataloader_idx=0): ...
 
+        @override
         def on_validation_batch_start(self, batch, batch_idx): ...
 
+        @override
         def on_test_batch_start(self, batch, batch_idx): ...
 
+        @override
         def val_dataloader(self):
             return [super().val_dataloader(), super().val_dataloader()]
 
+        @override
         def test_dataloader(self):
             return [super().test_dataloader(), super().test_dataloader()]
 
@@ -326,8 +359,10 @@ def test_invalid_dataloader_idx_raises_batch_start(tmp_path):
         trainer.test(model)
 
     class IgnoringModel(MultipleDataloader):
+        @override
         def on_validation_batch_start(self, batch, batch_idx, *_): ...
 
+        @override
         def on_test_batch_start(self, batch, batch_idx, *_): ...
 
     model = IgnoringModel()
@@ -335,8 +370,10 @@ def test_invalid_dataloader_idx_raises_batch_start(tmp_path):
     trainer.test(model)
 
     class IgnoringModel2(MultipleDataloader):
+        @override
         def on_validation_batch_start(self, batch, batch_idx, **_): ...
 
+        @override
         def on_test_batch_start(self, batch, batch_idx, **_): ...
 
     model = IgnoringModel2()
@@ -350,8 +387,10 @@ def test_invalid_dataloader_idx_raises_batch_end(tmp_path):
     trainer = Trainer(default_root_dir=tmp_path, fast_dev_run=True)
 
     class ExtraDataloaderIdx(BoringModel):
+        @override
         def on_validation_batch_end(self, outputs, batch, batch_idx, dataloader_idx): ...
 
+        @override
         def on_test_batch_end(self, outputs, batch, batch_idx, dataloader_idx): ...
 
     model = ExtraDataloaderIdx()
@@ -363,8 +402,10 @@ def test_invalid_dataloader_idx_raises_batch_end(tmp_path):
         trainer.test(model)
 
     class GoodDefault(BoringModel):
+        @override
         def on_validation_batch_end(self, outputs, batch, batch_idx, dataloader_idx=0): ...
 
+        @override
         def on_test_batch_end(self, outputs, batch, batch_idx, dataloader_idx=0): ...
 
     model = GoodDefault()
@@ -372,8 +413,10 @@ def test_invalid_dataloader_idx_raises_batch_end(tmp_path):
     trainer.test(model)
 
     class ExtraDlIdxOtherName(BoringModel):
+        @override
         def on_validation_batch_end(self, outputs, batch, batch_idx, dl_idx): ...
 
+        @override
         def on_test_batch_end(self, outputs, batch, batch_idx, dl_idx): ...
 
     model = ExtraDlIdxOtherName()
@@ -384,17 +427,23 @@ def test_invalid_dataloader_idx_raises_batch_end(tmp_path):
         trainer.test(model)
 
     class MultipleDataloader(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx=0): ...
 
+        @override
         def test_step(self, batch, batch_idx, dataloader_idx=0): ...
 
+        @override
         def on_validation_batch_end(self, outputs, batch, batch_idx): ...
 
+        @override
         def on_test_batch_end(self, outputs, batch, batch_idx): ...
 
+        @override
         def val_dataloader(self):
             return [super().val_dataloader(), super().val_dataloader()]
 
+        @override
         def test_dataloader(self):
             return [super().test_dataloader(), super().test_dataloader()]
 
@@ -407,8 +456,10 @@ def test_invalid_dataloader_idx_raises_batch_end(tmp_path):
         trainer.test(model)
 
     class IgnoringModel(MultipleDataloader):
+        @override
         def on_validation_batch_end(self, outputs, batch, batch_idx, *_): ...
 
+        @override
         def on_test_batch_end(self, outputs, batch, batch_idx, *_): ...
 
     model = IgnoringModel()
@@ -416,8 +467,10 @@ def test_invalid_dataloader_idx_raises_batch_end(tmp_path):
     trainer.test(model)
 
     class IgnoringModel2(MultipleDataloader):
+        @override
         def on_validation_batch_end(self, outputs, batch, batch_idx, **_): ...
 
+        @override
         def on_test_batch_end(self, outputs, batch, batch_idx, **_): ...
 
     model = IgnoringModel2()
@@ -442,9 +495,11 @@ def test_evaluation_loop_non_sequential_mode_supprt(tmp_path, mode, expected, fn
     seen = []
 
     class MyModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx):
             seen.append(batch)
 
+        @override
         def test_step(self, batch, batch_idx):
             seen.append(batch)
 
@@ -467,10 +522,12 @@ def test_evaluation_loop_when_batch_idx_argument_is_not_given(tmp_path):
             self.validation_step_called = False
             self.test_step_called = False
 
+        @override
         def validation_step(self, batch):
             self.validation_step_called = True
             return {"x": self.step(batch)}
 
+        @override
         def test_step(self, batch):
             self.test_step_called = True
             return {"y": self.step(batch)}

--- a/tests/tests_pytorch/loops/test_evaluation_loop_flow.py
+++ b/tests/tests_pytorch/loops/test_evaluation_loop_flow.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests the evaluation loop."""
 
+from typing_extensions import override
 import torch
 from torch import Tensor
 
@@ -26,12 +27,14 @@ def test__eval_step__flow(tmp_path):
     """Tests that only training_step can be used."""
 
     class TestModel(DeterministicModel):
+        @override
         def training_step(self, batch, batch_idx):
             acc = self.step(batch, batch_idx)
             acc = acc + batch_idx
             self.training_step_called = True
             return acc
 
+        @override
         def validation_step(self, batch, batch_idx):
             self.validation_step_called = True
             if batch_idx == 0:
@@ -40,6 +43,7 @@ def test__eval_step__flow(tmp_path):
                 out = {"something": "random"}
             return out
 
+        @override
         def backward(self, loss):
             return LightningModule.backward(self, loss)
 
@@ -75,12 +79,14 @@ def test__eval_step__epoch_end__flow(tmp_path):
     """Tests that only training_step can be used."""
 
     class TestModel(DeterministicModel):
+        @override
         def training_step(self, batch, batch_idx):
             acc = self.step(batch, batch_idx)
             acc = acc + batch_idx
             self.training_step_called = True
             return acc
 
+        @override
         def validation_step(self, batch, batch_idx):
             self.validation_step_called = True
             if batch_idx == 0:
@@ -91,6 +97,7 @@ def test__eval_step__epoch_end__flow(tmp_path):
                 self.out_b = out
             return out
 
+        @override
         def backward(self, loss):
             return LightningModule.backward(self, loss)
 

--- a/tests/tests_pytorch/loops/test_evaluation_loop_flow.py
+++ b/tests/tests_pytorch/loops/test_evaluation_loop_flow.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Tests the evaluation loop."""
 
-from typing_extensions import override
 import torch
 from torch import Tensor
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.core.module import LightningModule

--- a/tests/tests_pytorch/loops/test_fetchers.py
+++ b/tests/tests_pytorch/loops/test_fetchers.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from collections import Counter
 from collections.abc import Iterator
 from typing import Any
@@ -33,6 +34,7 @@ class IterDataset(IterableDataset):
     def __init__(self, size=3):
         self.size = size
 
+    @override
     def __iter__(self):
         yield from range(1, self.size + 1)
 
@@ -41,6 +43,7 @@ class SizedDataset(Dataset):
     def __len__(self):
         return 3
 
+    @override
     def __getitem__(self, idx):
         return idx + 1
 
@@ -87,6 +90,7 @@ def test_profiler_closing(multiple_iterables):
         def __init__(self):
             self.list = list(range(1))
 
+        @override
         def __iter__(self):
             return iter(self.list)
 
@@ -105,6 +109,7 @@ def test_profiler_closing(multiple_iterables):
 
 
 class EmptyIterDataset(IterableDataset):
+    @override
     def __iter__(self):
         return iter([])
 
@@ -176,6 +181,7 @@ def test_fetching_dataloader_iter_opt(automatic_optimization, tmp_path):
             self.count = 0
             self.batches = []
 
+        @override
         def training_step(self, dataloader_iter):
             assert isinstance(self.trainer.fit_loop._data_fetcher, _DataLoaderIterDataFetcher)
             # fetch 2 batches
@@ -199,6 +205,7 @@ def test_fetching_dataloader_iter_opt(automatic_optimization, tmp_path):
                 loss.backward()
                 opt.step()
 
+        @override
         def on_train_epoch_end(self):
             # since the dataset is sized, the loop stops at the limit even though the training_step controls the
             # consumption of batches
@@ -220,16 +227,19 @@ def test_fetching_dataloader_iter_running_stages(fn, tmp_path):
             assert data_fetcher.fetched == batch_idx + 1
             return batch
 
+        @override
         def validation_step(self, dataloader_iter):
             data_fetcher = self.trainer.validate_loop._data_fetcher
             batch = self.fetch(data_fetcher, dataloader_iter)
             return super().validation_step(batch, 0)
 
+        @override
         def test_step(self, dataloader_iter):
             data_fetcher = self.trainer.test_loop._data_fetcher
             batch = self.fetch(data_fetcher, dataloader_iter)
             return super().test_step(batch, 0)
 
+        @override
         def predict_step(self, dataloader_iter):
             data_fetcher = self.trainer.predict_loop._data_fetcher
             batch = self.fetch(data_fetcher, dataloader_iter)
@@ -259,6 +269,7 @@ class AsyncBoringModel(BoringModel):
     def _async_op(self, batch: Any) -> DummyWaitable:
         return DummyWaitable(val=batch)
 
+    @override
     def training_step(self, dataloader_iter: Iterator) -> STEP_OUTPUT:
         if self.batch_i_handle is None:
             batch_i_raw, _, _ = next(dataloader_iter)
@@ -286,6 +297,7 @@ class AsyncBoringModel(BoringModel):
 
         return {"loss": loss, "is_last": is_last}
 
+    @override
     def train_dataloader(self):
         return DataLoader(RandomDataset(BATCH_SIZE, DATASET_LEN))
 
@@ -321,16 +333,20 @@ class DataLoaderIterMonitorModel(BoringModel):
             self.record[stage]["fetched"] += 1
         return self.layer(batch).sum()
 
+    @override
     def training_step(self, dataloader_iter):
         return self.shared_step(dataloader_iter, "training")
 
+    @override
     def validation_step(self, dataloader_iter):
         stage = "sanity_validation" if self.trainer.sanity_checking else "validation"
         return self.shared_step(dataloader_iter, stage)
 
+    @override
     def test_step(self, dataloader_iter):
         return self.shared_step(dataloader_iter, "test")
 
+    @override
     def predict_step(self, dataloader_iter):
         return self.shared_step(dataloader_iter, "predict")
 
@@ -416,6 +432,7 @@ def test_stop_iteration_with_dataloader_iter(trigger_stop_iteration, tmp_path):
             super().__init__()
             self.trigger_stop_iteration = trigger_stop_iteration
 
+        @override
         def training_step(self, dataloader_iter: Iterator) -> STEP_OUTPUT:
             output = super().training_step(dataloader_iter)
             batch_idx = self.trainer.fit_loop.epoch_loop.batch_idx
@@ -423,6 +440,7 @@ def test_stop_iteration_with_dataloader_iter(trigger_stop_iteration, tmp_path):
                 raise StopIteration
             return output
 
+        @override
         def train_dataloader(self):
             if self.trigger_stop_iteration:
                 return DataLoader(RandomDataset(BATCH_SIZE, 2 * EXPECT_NUM_BATCHES_PROCESSED))
@@ -441,6 +459,7 @@ def test_transfer_hooks_with_unpacking(tmp_path):
     """This test asserts the `transfer_batch` hooks are called only once per batch."""
 
     class RandomDictDataset(RandomDataset):
+        @override
         def __getitem__(self, index):
             return {"x": self.data[index], "y_true": torch.ones((2,)), "other": torch.ones((1,))}
 
@@ -449,29 +468,36 @@ def test_transfer_hooks_with_unpacking(tmp_path):
         count_called_transfer_batch_to_device = 0
         count_called_on_after_batch_transfer = 0
 
+        @override
         def train_dataloader(self):
             return DataLoader(RandomDictDataset(32, 2))
 
+        @override
         def val_dataloader(self):
             return DataLoader(RandomDictDataset(32, 2))
 
+        @override
         def on_before_batch_transfer(self, batch, dataloader_idx: int):
             self.count_called_on_before_batch_transfer += 1
             return batch["x"], batch["y_true"]
 
+        @override
         def transfer_batch_to_device(self, *args, **kwargs):
             self.count_called_transfer_batch_to_device += 1
             return super().transfer_batch_to_device(*args, **kwargs)
 
+        @override
         def on_after_batch_transfer(self, batch, dataloader_idx: int):
             self.count_called_on_after_batch_transfer += 1
             return super().on_after_batch_transfer(batch, dataloader_idx)
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             x, _ = batch
             return super().training_step(x, batch_idx)
 
+        @override
         def validation_step(self, batch, batch_idx):
             x, _ = batch
             return super().validation_step(x, batch_idx)
@@ -488,9 +514,11 @@ def test_fetching_is_profiled():
     """Test that fetching is profiled."""
 
     class MyModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx=0):
             return super().validation_step(batch, batch_idx)
 
+        @override
         def val_dataloader(self):
             return [super().val_dataloader(), super().val_dataloader()]
 
@@ -539,6 +567,7 @@ def test_fetching_is_profiled():
 
     # now test profiling when the dataloader_iter is polled manually
     class MyModel(BoringModel):
+        @override
         def training_step(self, dataloader_iter):
             _ = next(dataloader_iter)
             batch, _, _ = next(dataloader_iter)

--- a/tests/tests_pytorch/loops/test_fetchers.py
+++ b/tests/tests_pytorch/loops/test_fetchers.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from collections import Counter
 from collections.abc import Iterator
 from typing import Any
@@ -20,6 +19,7 @@ import pytest
 import torch
 from torch import Tensor
 from torch.utils.data import DataLoader, Dataset, IterableDataset
+from typing_extensions import override
 
 from lightning.pytorch import LightningDataModule, Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel, RandomDataset

--- a/tests/tests_pytorch/loops/test_flow_warnings.py
+++ b/tests/tests_pytorch/loops/test_flow_warnings.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import warnings
 
 from lightning.pytorch import Trainer
@@ -18,6 +19,7 @@ from lightning.pytorch.demos.boring_classes import BoringModel
 
 
 class TestModel(BoringModel):
+    @override
     def training_step(self, batch, batch_idx):
         return self.step(batch[0])
 

--- a/tests/tests_pytorch/loops/test_flow_warnings.py
+++ b/tests/tests_pytorch/loops/test_flow_warnings.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import warnings
+
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/loops/test_loops.py
+++ b/tests/tests_pytorch/loops/test_loops.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from collections.abc import Iterator
 from copy import deepcopy
@@ -88,9 +89,11 @@ def test_loop_restore():
 
             self.outputs.append(value)
 
+        @override
         def state_dict(self) -> dict:
             return {"iteration_count": self.iteration_count, "outputs": self.outputs}
 
+        @override
         def load_state_dict(self, state_dict: dict) -> None:
             self.iteration_count = state_dict["iteration_count"]
             self.outputs = state_dict["outputs"]
@@ -141,9 +144,11 @@ def test_loop_hierarchy():
                 return
             loop.run()
 
+        @override
         def on_save_checkpoint(self) -> dict:
             return {"a": self.a}
 
+        @override
         def on_load_checkpoint(self, state_dict: dict) -> None:
             self.a = state_dict["a"]
 
@@ -205,11 +210,13 @@ def test_loop_restart_progress_multiple_dataloaders(tmp_path, n_dataloaders, sto
         def __init__(self):
             super().__init__()
 
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx):
             if self.current_epoch == stop_epoch and batch_idx == stop_batch and dataloader_idx == stop_dataloader:
                 raise CustomException
             return super().validation_step(batch, batch_idx)
 
+        @override
         def val_dataloader(self):
             return [super(ValidationModel, self).val_dataloader() for _ in range(n_dataloaders)]
 
@@ -263,6 +270,7 @@ def test_loop_state_on_exception(accumulate_grad_batches, stop_epoch, stop_batch
     n_batches = 3
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             if self.trainer.current_epoch == stop_epoch and batch_idx == stop_batch:
                 raise CustomException
@@ -429,6 +437,7 @@ def test_loop_state_on_complete_run(tmp_path):
     accumulate_grad_batches = 1
 
     class TestModel(BoringModel):
+        @override
         def train_dataloader(self):
             # override to test the `is_last_batch` value
             return DataLoader(RandomDataset(32, n_batches))
@@ -669,6 +678,7 @@ class RangeDataset(torch.utils.data.Dataset):
         data = torch.arange(0, size) / size
         self.data = data.unsqueeze(0).repeat(length, 1)
 
+    @override
     def __getitem__(self, index: int) -> torch.Tensor:
         return self.data[index]
 
@@ -681,18 +691,23 @@ class PredictableBoringModel(BoringModel):
         super().__init__()
         self.last_loss = float("inf")
 
+    @override
     def train_dataloader(self) -> DataLoader:
         return DataLoader(RangeDataset(32, 64))
 
+    @override
     def val_dataloader(self) -> DataLoader:
         return DataLoader(RangeDataset(32, 64))
 
+    @override
     def test_dataloader(self) -> DataLoader:
         return DataLoader(RangeDataset(32, 64))
 
+    @override
     def predict_dataloader(self) -> DataLoader:
         return DataLoader(RangeDataset(32, 64))
 
+    @override
     def training_step(self, batch: Any, batch_idx: int) -> STEP_OUTPUT:
         loss = self.step(batch)
         self.last_loss = loss
@@ -947,20 +962,25 @@ def test_fit_can_fail_during_validation(train_datasets, val_datasets, val_check_
         def step(self, batch):
             return sum(self.layer(b).sum() for b in batch)
 
+        @override
         def training_step(self, batch, batch_idx):
             return self.step(batch)
 
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx=0):
             if self.should_fail and dataloader_idx == stop_dataloader and batch_idx == stop_batch:
                 raise CustomException
             return self.step(batch)
 
+        @override
         def configure_optimizers(self):
             return torch.optim.SGD(self.layer.parameters(), lr=0.1)
 
+        @override
         def train_dataloader(self):
             return [DataLoader(cls(size, n_batches)) for cls in train_datasets]
 
+        @override
         def val_dataloader(self):
             return [DataLoader(cls(size, n_batches)) for cls in val_datasets]
 
@@ -1087,6 +1107,7 @@ def test_workers_are_shutdown(tmp_path, should_fail, persistent_workers):
     # `persistent_workers` makes sure `self._iterator` gets set on the `DataLoader` instance
 
     class TestCallback(Callback):
+        @override
         def on_train_epoch_end(self, trainer, *_):
             if trainer.current_epoch == 1:
                 raise CustomException
@@ -1111,6 +1132,7 @@ def test_workers_are_shutdown(tmp_path, should_fail, persistent_workers):
             super().__init__(*args, **kwargs)
             self.dataloader = dataloader
 
+        @override
         def __del__(self):
             self.dataloader.shutdown_workers_epochs.append(trainer.current_epoch)
             super().__del__()
@@ -1120,6 +1142,7 @@ def test_workers_are_shutdown(tmp_path, should_fail, persistent_workers):
             super().__init__(*args, **kwargs)
             self.shutdown_workers_epochs = []
 
+        @override
         def _get_iterator(self):
             if self.num_workers == 0:
                 return super()._get_iterator()
@@ -1179,6 +1202,7 @@ def test_validation_during_gradient_accumulation_window(tmp_path):
     phase."""
 
     class ValidationModel(BoringModel):
+        @override
         def on_validation_start(self):
             batch_idx = self.trainer.fit_loop.epoch_loop.batch_progress.current.completed
             grad_expected = batch_idx % self.trainer.accumulate_grad_batches != 0
@@ -1258,10 +1282,12 @@ def test_fit_loop_save_and_restore_dataloaders(
             super().__init__()
             self.seen_data = []
 
+        @override
         def training_step(self, batch, batch_idx):
             self.seen_data.append(batch)
             print(batch)
 
+        @override
         def train_dataloader(self):
             return train_dataloader_factory()
 

--- a/tests/tests_pytorch/loops/test_loops.py
+++ b/tests/tests_pytorch/loops/test_loops.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from collections.abc import Iterator
 from copy import deepcopy
@@ -22,6 +21,7 @@ from unittest.mock import ANY, Mock
 import pytest
 import torch
 from torch.utils.data.dataloader import DataLoader, _MultiProcessingDataLoaderIter
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.callbacks import Callback, ModelCheckpoint, OnExceptionCheckpoint

--- a/tests/tests_pytorch/loops/test_prediction_loop.py
+++ b/tests/tests_pytorch/loops/test_prediction_loop.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import itertools
 
 import pytest
 from torch.utils.data import DataLoader, DistributedSampler, SequentialSampler
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel, RandomDataset

--- a/tests/tests_pytorch/loops/test_prediction_loop.py
+++ b/tests/tests_pytorch/loops/test_prediction_loop.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import itertools
 
 import pytest
@@ -24,6 +25,7 @@ from tests_pytorch.helpers.runif import _xfail_gloo_windows
 
 def test_prediction_loop_stores_predictions(tmp_path):
     class MyModel(BoringModel):
+        @override
         def predict_step(self, batch, batch_idx):
             return batch_idx
 
@@ -69,6 +71,7 @@ def test_prediction_loop_batch_sampler_set_epoch_called(tmp_path, use_distribute
     )
 
     class MyModel(BoringModel):
+        @override
         def predict_dataloader(self):
             dataset = RandomDataset(32, 64)
             sampler = None
@@ -90,6 +93,7 @@ def test_prediction_loop_batch_sampler_set_epoch_called(tmp_path, use_distribute
 
 def test_prediction_loop_with_iterable_dataset(tmp_path):
     class MyModel(BoringModel):
+        @override
         def predict_step(self, batch, batch_idx, dataloader_idx=0):
             return (batch, batch_idx, dataloader_idx)
 
@@ -119,12 +123,15 @@ def test_prediction_loop_with_iterable_dataset(tmp_path):
         step_outs = []
         batch_end_ins = []
 
+        @override
         def on_predict_batch_start(self, batch, batch_idx, dataloader_idx):
             self.batch_start_ins.append((batch, batch_idx, dataloader_idx))
 
+        @override
         def predict_step(self, dataloader_iter):
             self.step_outs.append(next(dataloader_iter))
 
+        @override
         def on_predict_batch_end(self, outputs, batch, batch_idx, dataloader_idx):
             self.batch_end_ins.append((batch, batch_idx, dataloader_idx))
 
@@ -140,6 +147,7 @@ def test_invalid_dataloader_idx_raises_step(tmp_path):
     trainer = Trainer(default_root_dir=tmp_path, fast_dev_run=True)
 
     class ExtraDataloaderIdx(BoringModel):
+        @override
         def predict_step(self, batch, batch_idx, dataloader_idx): ...
 
     model = ExtraDataloaderIdx()
@@ -147,12 +155,14 @@ def test_invalid_dataloader_idx_raises_step(tmp_path):
         trainer.predict(model)
 
     class GoodDefault(BoringModel):
+        @override
         def predict_step(self, batch, batch_idx, dataloader_idx=0): ...
 
     model = GoodDefault()
     trainer.predict(model)
 
     class ExtraDlIdxOtherName(BoringModel):
+        @override
         def predict_step(self, batch, batch_idx, dl_idx): ...
 
     model = ExtraDlIdxOtherName()
@@ -161,8 +171,10 @@ def test_invalid_dataloader_idx_raises_step(tmp_path):
         trainer.predict(model)
 
     class MultipleDataloader(BoringModel):
+        @override
         def predict_step(self, batch, batch_idx): ...
 
+        @override
         def predict_dataloader(self):
             return [super().predict_dataloader(), super().predict_dataloader()]
 
@@ -171,12 +183,14 @@ def test_invalid_dataloader_idx_raises_step(tmp_path):
         trainer.predict(model)
 
     class IgnoringModel(MultipleDataloader):
+        @override
         def predict_step(self, batch, batch_idx, *_): ...
 
     model = IgnoringModel()
     trainer.predict(model)
 
     class IgnoringModel2(MultipleDataloader):
+        @override
         def predict_step(self, batch, batch_idx, **_): ...
 
     model = IgnoringModel2()
@@ -188,6 +202,7 @@ def test_invalid_dataloader_idx_raises_batch_start(tmp_path):
     trainer = Trainer(default_root_dir=tmp_path, fast_dev_run=True)
 
     class ExtraDataloaderIdx(BoringModel):
+        @override
         def on_predict_batch_start(self, batch, batch_idx, dataloader_idx): ...
 
     model = ExtraDataloaderIdx()
@@ -197,12 +212,14 @@ def test_invalid_dataloader_idx_raises_batch_start(tmp_path):
         trainer.predict(model)
 
     class GoodDefault(BoringModel):
+        @override
         def on_predict_batch_start(self, batch, batch_idx, dataloader_idx=0): ...
 
     model = GoodDefault()
     trainer.predict(model)
 
     class ExtraDlIdxOtherName(BoringModel):
+        @override
         def on_predict_batch_start(self, batch, batch_idx, dl_idx): ...
 
     model = ExtraDlIdxOtherName()
@@ -211,8 +228,10 @@ def test_invalid_dataloader_idx_raises_batch_start(tmp_path):
         trainer.predict(model)
 
     class MultipleDataloader(BoringModel):
+        @override
         def on_predict_batch_start(self, batch, batch_idx): ...
 
+        @override
         def predict_dataloader(self):
             return [super().predict_dataloader(), super().predict_dataloader()]
 
@@ -223,12 +242,14 @@ def test_invalid_dataloader_idx_raises_batch_start(tmp_path):
         trainer.predict(model)
 
     class IgnoringModel(MultipleDataloader):
+        @override
         def on_predict_batch_start(self, batch, batch_idx, *_): ...
 
     model = IgnoringModel()
     trainer.predict(model)
 
     class IgnoringModel2(MultipleDataloader):
+        @override
         def on_predict_batch_start(self, batch, batch_idx, **_): ...
 
     model = IgnoringModel2()
@@ -240,6 +261,7 @@ def test_invalid_dataloader_idx_raises_batch_end(tmp_path):
     trainer = Trainer(default_root_dir=tmp_path, fast_dev_run=True)
 
     class ExtraDataloaderIdx(BoringModel):
+        @override
         def on_predict_batch_end(self, outputs, batch, batch_idx, dataloader_idx): ...
 
     model = ExtraDataloaderIdx()
@@ -249,12 +271,14 @@ def test_invalid_dataloader_idx_raises_batch_end(tmp_path):
         trainer.predict(model)
 
     class GoodDefault(BoringModel):
+        @override
         def on_predict_batch_end(self, outputs, batch, batch_idx, dataloader_idx=0): ...
 
     model = GoodDefault()
     trainer.predict(model)
 
     class ExtraDlIdxOtherName(BoringModel):
+        @override
         def on_predict_batch_end(self, outputs, batch, batch_idx, dl_idx): ...
 
     model = ExtraDlIdxOtherName()
@@ -263,8 +287,10 @@ def test_invalid_dataloader_idx_raises_batch_end(tmp_path):
         trainer.predict(model)
 
     class MultipleDataloader(BoringModel):
+        @override
         def on_predict_batch_end(self, outputs, batch, batch_idx): ...
 
+        @override
         def predict_dataloader(self):
             return [super().predict_dataloader(), super().predict_dataloader()]
 
@@ -273,12 +299,14 @@ def test_invalid_dataloader_idx_raises_batch_end(tmp_path):
         trainer.predict(model)
 
     class IgnoringModel(MultipleDataloader):
+        @override
         def on_predict_batch_end(self, outputs, batch, batch_idx, *_): ...
 
     model = IgnoringModel()
     trainer.predict(model)
 
     class IgnoringModel2(MultipleDataloader):
+        @override
         def on_predict_batch_end(self, outputs, batch, batch_idx, **_): ...
 
     model = IgnoringModel2()
@@ -292,6 +320,7 @@ def test_prediction_loop_when_batch_idx_argument_is_not_given(tmp_path):
             super().__init__()
             self.predict_step_called = False
 
+        @override
         def predict_step(self, batch):
             self.predict_step_called = True
             return self.step(batch)

--- a/tests/tests_pytorch/loops/test_training_epoch_loop.py
+++ b/tests/tests_pytorch/loops/test_training_epoch_loop.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import logging
 from unittest.mock import Mock, patch
 
@@ -94,6 +95,7 @@ def test_should_stop_triggers_validation_once(min_epochs, min_steps, val_count, 
     """
 
     class NewBoring(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             self.log("loss", self.step(batch))
             return {"loss": self.step(batch)}
@@ -136,12 +138,15 @@ def test_training_loop_dataloader_iter_multiple_dataloaders(tmp_path):
         step_outs = []
         batch_end_ins = []
 
+        @override
         def on_train_batch_start(self, batch, batch_idx, dataloader_idx=0):
             self.batch_start_ins.append((batch, batch_idx, dataloader_idx))
 
+        @override
         def training_step(self, dataloader_iter):
             self.step_outs.append(next(dataloader_iter))
 
+        @override
         def on_train_batch_end(self, outputs, batch, batch_idx, dataloader_idx=0):
             self.batch_end_ins.append((batch, batch_idx, dataloader_idx))
 
@@ -160,9 +165,11 @@ def test_no_batch_idx_gradient_accumulation():
     class MyModel(BoringModel):
         last_batch_idx = -1
 
+        @override
         def training_step(self, batch):  # no batch_idx
             return self.step(batch)
 
+        @override
         def optimizer_step(self, epoch, batch_idx, *args, **kwargs):
             assert batch_idx in (1, 3)
             self.last_batch_idx = batch_idx

--- a/tests/tests_pytorch/loops/test_training_epoch_loop.py
+++ b/tests/tests_pytorch/loops/test_training_epoch_loop.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import logging
 from unittest.mock import Mock, patch
 
 import pytest
 import torch
 from lightning_utilities.test.warning import no_warning_call
+from typing_extensions import override
 
 from lightning.fabric.utilities.warnings import PossibleUserWarning
 from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint

--- a/tests/tests_pytorch/loops/test_training_loop.py
+++ b/tests/tests_pytorch/loops/test_training_loop.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import itertools
 import logging
 import warnings
@@ -20,6 +19,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.fabric.utilities.warnings import PossibleUserWarning
 from lightning.pytorch import Trainer, seed_everything

--- a/tests/tests_pytorch/loops/test_training_loop.py
+++ b/tests/tests_pytorch/loops/test_training_loop.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import itertools
 import logging
 import warnings
@@ -30,6 +31,7 @@ def test_outputs_format(tmp_path):
     """Tests that outputs objects passed to model hooks and methods are consistent and in the correct format."""
 
     class HookedModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             output = super().training_step(batch, batch_idx)
             self.log("foo", 123)
@@ -42,6 +44,7 @@ def test_outputs_format(tmp_path):
             assert "foo" in output
             assert output["foo"] == 123
 
+        @override
         def on_train_batch_end(self, outputs, *_):
             HookedModel._check_output(outputs)
 
@@ -70,6 +73,7 @@ def test_training_starts_with_seed(tmp_path, seed_once):
             super().__init__()
             self.seen_batches = []
 
+        @override
         def training_step(self, batch, batch_idx):
             self.seen_batches.append(batch.view(-1))
             return super().training_step(batch, batch_idx)
@@ -96,6 +100,7 @@ def test_training_starts_with_seed(tmp_path, seed_once):
 @pytest.mark.parametrize(("max_epochs", "batch_idx_"), [(2, 5), (3, 8), (4, 12)])
 def test_on_train_batch_start_return_minus_one(max_epochs, batch_idx_, tmp_path):
     class CurrentModel(BoringModel):
+        @override
         def on_train_batch_start(self, batch, batch_idx):
             if batch_idx == batch_idx_:
                 return -1
@@ -122,11 +127,13 @@ def test_should_stop_mid_epoch(tmp_path):
             super().__init__()
             self.validation_called_at = None
 
+        @override
         def training_step(self, batch, batch_idx):
             if batch_idx == 4:
                 self.trainer.should_stop = True
             return super().training_step(batch, batch_idx)
 
+        @override
         def validation_step(self, *args):
             self.validation_called_at = (self.trainer.current_epoch, self.trainer.global_step)
             return super().validation_step(*args)
@@ -258,6 +265,7 @@ def test_progress_bar_steps(tmp_path, max_steps):
             super().__init__()
             self.data = data
 
+        @override
         def __iter__(self):
             yield from self.data  # yield just a tensor, not a tuple
 
@@ -315,6 +323,7 @@ def test_lr_updated_on_train_batch_start_returns_minus_one(tmp_path, max_epochs,
     still updated when it should, at the end of the epoch."""
 
     class TestModel(BoringModel):
+        @override
         def on_train_batch_start(self, batch, batch_idx):
             if batch_idx == batch_idx_:
                 return -1

--- a/tests/tests_pytorch/loops/test_training_loop_flow_dict.py
+++ b/tests/tests_pytorch/loops/test_training_loop_flow_dict.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests to ensure that the training loop works with a dict (1.0)"""
 
+from typing_extensions import override
 import torch
 
 from lightning.pytorch import Trainer
@@ -24,12 +25,14 @@ def test__training_step__flow_dict(tmp_path):
     """Tests that only training_step can be used."""
 
     class TestModel(DeterministicModel):
+        @override
         def training_step(self, batch, batch_idx):
             acc = self.step(batch, batch_idx)
             acc = acc + batch_idx
             self.training_step_called = True
             return {"loss": acc, "random_things": [1, "a", torch.tensor(2)]}
 
+        @override
         def backward(self, loss):
             return LightningModule.backward(self, loss)
 
@@ -54,6 +57,7 @@ def test__training_step__tr_batch_end__flow_dict(tmp_path):
     """Tests that only training_step can be used."""
 
     class TestModel(DeterministicModel):
+        @override
         def training_step(self, batch, batch_idx):
             acc = self.step(batch, batch_idx)
             acc = acc + batch_idx
@@ -61,9 +65,11 @@ def test__training_step__tr_batch_end__flow_dict(tmp_path):
             self.out = {"loss": acc, "random_things": [1, "a", torch.tensor(2)]}
             return self.out
 
+        @override
         def on_train_batch_end(self, tr_step_output, *_):
             assert self.count_num_graphs(tr_step_output) == 0
 
+        @override
         def backward(self, loss):
             return LightningModule.backward(self, loss)
 
@@ -88,6 +94,7 @@ def test__training_step__epoch_end__flow_dict(tmp_path):
     """Tests that only training_step can be used."""
 
     class TestModel(DeterministicModel):
+        @override
         def training_step(self, batch, batch_idx):
             acc = self.step(batch, batch_idx)
             acc = acc + batch_idx
@@ -95,6 +102,7 @@ def test__training_step__epoch_end__flow_dict(tmp_path):
             self.training_step_called = True
             return {"loss": acc, "random_things": [1, "a", torch.tensor(2)], "batch_idx": batch_idx}
 
+        @override
         def backward(self, loss):
             return LightningModule.backward(self, loss)
 
@@ -119,6 +127,7 @@ def test__training_step__batch_end__epoch_end__flow_dict(tmp_path):
     """Tests that only training_step can be used."""
 
     class TestModel(DeterministicModel):
+        @override
         def training_step(self, batch, batch_idx):
             acc = self.step(batch, batch_idx)
             acc = acc + batch_idx
@@ -127,9 +136,11 @@ def test__training_step__batch_end__epoch_end__flow_dict(tmp_path):
             self.out = {"loss": acc, "random_things": [1, "a", torch.tensor(2)], "batch_idx": batch_idx}
             return self.out
 
+        @override
         def on_train_batch_end(self, tr_step_output, *_):
             assert self.count_num_graphs(tr_step_output) == 0
 
+        @override
         def backward(self, loss):
             return LightningModule.backward(self, loss)
 

--- a/tests/tests_pytorch/loops/test_training_loop_flow_dict.py
+++ b/tests/tests_pytorch/loops/test_training_loop_flow_dict.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """Tests to ensure that the training loop works with a dict (1.0)"""
 
-from typing_extensions import override
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.core.module import LightningModule

--- a/tests/tests_pytorch/loops/test_training_loop_flow_scalar.py
+++ b/tests/tests_pytorch/loops/test_training_loop_flow_scalar.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pytest
 from lightning_utilities.test.warning import no_warning_call
 from torch import Tensor
 from torch.utils.data import DataLoader
 from torch.utils.data._utils.collate import default_collate
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.core.module import LightningModule

--- a/tests/tests_pytorch/loops/test_training_loop_flow_scalar.py
+++ b/tests/tests_pytorch/loops/test_training_loop_flow_scalar.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pytest
 from lightning_utilities.test.warning import no_warning_call
 from torch import Tensor
@@ -29,12 +30,14 @@ def test__training_step__flow_scalar(tmp_path):
     """Tests that only training_step can be used."""
 
     class TestModel(DeterministicModel):
+        @override
         def training_step(self, batch, batch_idx):
             acc = self.step(batch, batch_idx)
             acc = acc + batch_idx
             self.training_step_called = True
             return acc
 
+        @override
         def backward(self, loss):
             return LightningModule.backward(self, loss)
 
@@ -59,6 +62,7 @@ def test__training_step__tr_batch_end__flow_scalar(tmp_path):
     """Tests that only training_step can be used."""
 
     class TestModel(DeterministicModel):
+        @override
         def training_step(self, batch, batch_idx):
             acc = self.step(batch, batch_idx)
             acc = acc + batch_idx
@@ -66,9 +70,11 @@ def test__training_step__tr_batch_end__flow_scalar(tmp_path):
             self.out = acc
             return acc
 
+        @override
         def on_train_batch_end(self, tr_step_output, *_):
             assert self.count_num_graphs({"loss": tr_step_output}) == 0
 
+        @override
         def backward(self, loss):
             return LightningModule.backward(self, loss)
 
@@ -93,6 +99,7 @@ def test__training_step__epoch_end__flow_scalar(tmp_path):
     """Tests that only training_step can be used."""
 
     class TestModel(DeterministicModel):
+        @override
         def training_step(self, batch, batch_idx):
             acc = self.step(batch, batch_idx)
             acc = acc + batch_idx
@@ -100,6 +107,7 @@ def test__training_step__epoch_end__flow_scalar(tmp_path):
             self.training_step_called = True
             return acc
 
+        @override
         def backward(self, loss):
             return LightningModule.backward(self, loss)
 
@@ -141,11 +149,13 @@ def test_train_step_no_return(tmp_path):
     """Tests that only training_step raises a warning when nothing is returned in case of automatic_optimization."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch):
             self.training_step_called = True
             loss = self.step(batch[0])
             self.log("a", loss, on_step=True, on_epoch=True)
 
+        @override
         def validation_step(self, batch, batch_idx):
             self.validation_step_called = True
 
@@ -175,6 +185,7 @@ def test_training_step_no_return_when_even(tmp_path):
     """Tests correctness when some training steps have been skipped."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             self.training_step_called = True
             loss = self.step(batch[0])
@@ -220,9 +231,11 @@ def test_training_step_none_batches(tmp_path):
             self.counter += 1
             return result
 
+        @override
         def train_dataloader(self):
             return DataLoader(RandomDataset(32, 4), collate_fn=self.collate_none_when_even)
 
+        @override
         def on_train_batch_end(self, outputs, batch, batch_idx):
             if batch_idx % 2 == 0:
                 assert outputs is None

--- a/tests/tests_pytorch/models/test_amp.py
+++ b/tests/tests_pytorch/models/test_amp.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from unittest import mock
 
 import pytest
 import torch
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 import tests_pytorch.helpers.utils as tutils
 from lightning.fabric.plugins.environments import SLURMEnvironment

--- a/tests/tests_pytorch/models/test_amp.py
+++ b/tests/tests_pytorch/models/test_amp.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from unittest import mock
 
@@ -26,6 +27,7 @@ from tests_pytorch.helpers.runif import RunIf, _xfail_gloo_windows
 
 
 class AMPTestModel(BoringModel):
+    @override
     def step(self, batch):
         self._assert_autocast_enabled()
         output = self(batch)
@@ -33,6 +35,7 @@ class AMPTestModel(BoringModel):
         assert output.dtype == torch.float16 if not is_bfloat16 else torch.bfloat16
         return self.loss(output)
 
+    @override
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
         self._assert_autocast_enabled()
         output = self(batch)

--- a/tests/tests_pytorch/models/test_cpu.py
+++ b/tests/tests_pytorch/models/test_cpu.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from unittest import mock
 
 import torch
+from typing_extensions import override
 
 import tests_pytorch.helpers.pipelines as tpipes
 import tests_pytorch.helpers.utils as tutils

--- a/tests/tests_pytorch/models/test_cpu.py
+++ b/tests/tests_pytorch/models/test_cpu.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from unittest import mock
 
@@ -81,6 +82,7 @@ def test_cpu_slurm_save_load(_, tmp_path):
 
     class _StartCallback(Callback):
         # set the epoch start hook so we can predict before the model does the full training
+        @override
         def on_train_epoch_start(self, trainer, model):
             assert trainer.global_step == real_global_step
             assert trainer.global_step > 0
@@ -106,6 +108,7 @@ def test_early_stopping_cpu_model(tmp_path):
     seed_everything(42)
 
     class ModelTrainVal(BoringModel):
+        @override
         def validation_step(self, *args, **kwargs):
             output = super().validation_step(*args, **kwargs)
             self.log("val_loss", output["x"])
@@ -205,11 +208,13 @@ def test_running_test_after_fitting(tmp_path):
     seed_everything(42)
 
     class ModelTrainValTest(BoringModel):
+        @override
         def validation_step(self, *args, **kwargs):
             output = super().validation_step(*args, **kwargs)
             self.log("val_loss", output["x"])
             return output
 
+        @override
         def test_step(self, *args, **kwargs):
             output = super().test_step(*args, **kwargs)
             self.log("test_loss", output["y"])
@@ -253,6 +258,7 @@ def test_running_test_no_val(tmp_path):
     seed_everything(42)
 
     class ModelTrainTest(BoringModel):
+        @override
         def test_step(self, *args, **kwargs):
             output = super().test_step(*args, **kwargs)
             self.log("test_loss", output["y"])

--- a/tests/tests_pytorch/models/test_fabric_integration.py
+++ b/tests/tests_pytorch/models/test_fabric_integration.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 from copy import deepcopy
 from unittest.mock import Mock
 
@@ -65,6 +66,7 @@ def test_fabric_call_lightning_module_hooks():
     """Test that `Fabric.call` can call hooks on the LightningModule."""
 
     class HookedModel(BoringModel):
+        @override
         def on_train_start(self):
             pass
 

--- a/tests/tests_pytorch/models/test_fabric_integration.py
+++ b/tests/tests_pytorch/models/test_fabric_integration.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 from copy import deepcopy
 from unittest.mock import Mock
 
 import torch
+from typing_extensions import override
 
 from lightning.fabric import Fabric
 from lightning.pytorch.demos.boring_classes import BoringModel, ManualOptimBoringModel

--- a/tests/tests_pytorch/models/test_gpu.py
+++ b/tests/tests_pytorch/models/test_gpu.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from collections import namedtuple
 from unittest import mock
@@ -222,6 +223,7 @@ def test_non_blocking():
 )
 def test_input_tensors_cast_before_transfer_to_device(strategy, precision, expected_dtype):
     class CustomBoringModel(BoringModel):
+        @override
         def transfer_batch_to_device(self, batch, *args, **kwargs):
             assert batch.dtype == expected_dtype
             return super().transfer_batch_to_device(batch, *args, **kwargs)

--- a/tests/tests_pytorch/models/test_gpu.py
+++ b/tests/tests_pytorch/models/test_gpu.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from collections import namedtuple
 from unittest import mock
@@ -19,6 +18,7 @@ from unittest.mock import patch
 
 import pytest
 import torch
+from typing_extensions import override
 
 import tests_pytorch.helpers.pipelines as tpipes
 from lightning.fabric.plugins.environments import TorchElasticEnvironment

--- a/tests/tests_pytorch/models/test_hooks.py
+++ b/tests/tests_pytorch/models/test_hooks.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from functools import partial, update_wrapper
 from inspect import getmembers, isfunction
 from unittest import mock
@@ -21,6 +20,7 @@ import pytest
 import torch
 from torch import Tensor
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.pytorch import Callback, LightningDataModule, LightningModule, Trainer, __version__
 from lightning.pytorch.demos.boring_classes import BoringDataModule, BoringModel, RandomDataset

--- a/tests/tests_pytorch/models/test_hooks.py
+++ b/tests/tests_pytorch/models/test_hooks.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from functools import partial, update_wrapper
 from inspect import getmembers, isfunction
 from unittest import mock
@@ -48,6 +49,7 @@ class HookedDataModule(BoringDataModule):
             setattr(self, h, partial_h)
 
     # override so that it gets called
+    @override
     def prepare_data(self): ...
 
 
@@ -56,6 +58,7 @@ def test_on_before_zero_grad_called(tmp_path, max_steps):
     class CurrentTestModel(BoringModel):
         on_before_zero_grad_called = 0
 
+        @override
         def on_before_zero_grad(self, optimizer):
             self.on_before_zero_grad_called += 1
 
@@ -76,11 +79,13 @@ def test_on_train_epoch_end_metrics_collection(tmp_path):
     num_epochs = 3
 
     class CurrentModel(BoringModel):
+        @override
         def training_step(self, *args, **kwargs):
             output = super().training_step(*args, **kwargs)
             self.log_dict({"step_metric": torch.tensor(-1), "shared_metric": 100}, logger=False, prog_bar=True)
             return output
 
+        @override
         def on_train_epoch_end(self):
             epoch = self.current_epoch
             # both scalar tensors and Python numbers are accepted
@@ -127,6 +132,7 @@ def test_apply_batch_transfer_handler(model_getter_mock, accelerator, expected_d
         transfer_batch_to_device_hook_rank = None
         on_after_batch_transfer_hook_rank = None
 
+        @override
         def on_after_batch_transfer(self, batch, dataloader_idx):
             assert dataloader_idx == 0
             assert batch.samples.device == batch.targets.device == expected_device
@@ -135,6 +141,7 @@ def test_apply_batch_transfer_handler(model_getter_mock, accelerator, expected_d
             batch.targets *= 2
             return batch
 
+        @override
         def transfer_batch_to_device(self, batch, device, dataloader_idx):
             assert dataloader_idx == 0
             self.transfer_batch_to_device_hook_rank = self.rank
@@ -175,12 +182,14 @@ def test_transfer_batch_hook_ddp(tmp_path):
         return CustomBatch(batch)
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             assert batch.samples.device == self.device
             assert isinstance(batch_idx, int)
             # the actual training step is not needed for the assertions
             return super().training_step(torch.rand(1, 32, device=self.device), batch_idx)
 
+        @override
         def train_dataloader(self):
             return torch.utils.data.DataLoader(RandomDataset(32, 64), collate_fn=collate_fn)
 
@@ -222,6 +231,7 @@ class HookedCallback(Callback):
             update_wrapper(partial_h, attr)
             setattr(self, h, partial_h)
 
+    @override
     def state_dict(*args, **kwargs):
         return {"foo": True}
 
@@ -388,18 +398,22 @@ class HookedModel(BoringModel):
         return out
 
     # override so that it gets called
+    @override
     def configure_model(self): ...
 
     # override so that it gets called
+    @override
     def on_validation_model_train(self): ...
 
     # override so that it gets called
+    @override
     def on_test_model_train(self): ...
 
     # override so that it gets called
     def on_predict_model_train(self): ...
 
     # override so that it gets called
+    @override
     def prepare_data(self): ...
 
 
@@ -425,6 +439,7 @@ def test_trainer_model_hook_system_fit(override_on_validation_model_train, autom
             super().__init__(*args)
             self.automatic_optimization = automatic_optimization
 
+        @override
         def training_step(self, batch, batch_idx):
             if self.automatic_optimization:
                 return super().training_step(batch, batch_idx)
@@ -778,29 +793,35 @@ def test_hooks_with_different_argument_names(tmp_path):
             assert x.size() == (1, 32)
             assert isinstance(batch_nb, int)
 
+        @override
         def training_step(self, x1, batch_nb1):
             self.assert_args(x1, batch_nb1)
             return super().training_step(x1, batch_nb1)
 
+        @override
         def validation_step(self, x2, batch_nb2):
             self.assert_args(x2, batch_nb2)
             return super().validation_step(x2, batch_nb2)
 
         # we don't support a different name for `dataloader_idx`
+        @override
         def test_step(self, x3, batch_nb3, dataloader_idx):
             self.assert_args(x3, batch_nb3)
             assert isinstance(dataloader_idx, int)
             return super().test_step(x3, batch_nb3)
 
         # we don't support a different name for `dataloader_idx`
+        @override
         def predict_step(self, x4, batch_nb4, dataloader_idx):
             self.assert_args(x4, batch_nb4)
             assert isinstance(dataloader_idx, int)
             return super().predict_step(x4, batch_nb4, dataloader_idx)
 
+        @override
         def test_dataloader(self):
             return [DataLoader(RandomDataset(32, 64)), DataLoader(RandomDataset(32, 64))]
 
+        @override
         def predict_dataloader(self):
             return [DataLoader(RandomDataset(32, 64)), DataLoader(RandomDataset(32, 64))]
 
@@ -883,6 +904,7 @@ def test_trainer_datamodule_hook_system(tmp_path):
 @pytest.mark.parametrize("override_configure_model", [True, False])
 def test_load_from_checkpoint_hook_calls(override_configure_model, tmp_path):
     class CustomHookedDataModule(HookedDataModule):
+        @override
         def state_dict(self):
             return {"foo": "bar"}
 
@@ -940,6 +962,7 @@ def test_train_eval_mode_restored(tmp_path):
             self.frozen.eval()
             self.frozen.requires_grad_(False)
 
+        @override
         def training_step(self, *args, **kwargs):
             assert self.layer.weight.requires_grad
             assert self.layer.training
@@ -947,6 +970,7 @@ def test_train_eval_mode_restored(tmp_path):
             assert not self.frozen.weight.requires_grad
             return super().training_step(*args, **kwargs)
 
+        @override
         def validation_step(self, *args, **kwargs):
             assert self.layer.weight.requires_grad
             assert not self.layer.training
@@ -954,6 +978,7 @@ def test_train_eval_mode_restored(tmp_path):
             assert not self.frozen.weight.requires_grad
             return super().validation_step(*args, **kwargs)
 
+        @override
         def test_step(self, *args, **kwargs):
             assert self.layer.weight.requires_grad
             assert not self.layer.training
@@ -961,6 +986,7 @@ def test_train_eval_mode_restored(tmp_path):
             assert not self.frozen.weight.requires_grad
             return super().test_step(*args, **kwargs)
 
+        @override
         def predict_step(self, *args, **kwargs):
             assert self.layer.weight.requires_grad
             assert not self.layer.training

--- a/tests/tests_pytorch/models/test_hparams.py
+++ b/tests/tests_pytorch/models/test_hparams.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import copy
 import functools
 import os
@@ -30,6 +29,7 @@ from fsspec.implementations.local import LocalFileSystem
 from lightning_utilities.core.imports import RequirementCache
 from lightning_utilities.test.warning import no_warning_call
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_6
 from lightning.pytorch import LightningModule, Trainer

--- a/tests/tests_pytorch/models/test_hparams.py
+++ b/tests/tests_pytorch/models/test_hparams.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import copy
 import functools
 import os
@@ -267,6 +268,7 @@ def test_explicit_missing_args_hparams(tmp_path):
 
 def test_class_nesting():
     class MyModule(LightningModule):
+        @override
         def forward(self): ...
 
     # make sure PL modules are always nn.Module
@@ -349,6 +351,7 @@ class UnconventionalArgsBoringModel(CustomBoringModel):
 
 
 class _MetaType(type):
+    @override
     def __call__(cls, *args, **kwargs):
         instance = super().__call__(*args, **kwargs)  # Create the instance
         if hasattr(instance, "_after_init"):
@@ -453,6 +456,7 @@ def test_collect_init_arguments_in_other_methods():
             return self.model
 
     class ConcreteModelCreator(_ABCModelCreator):
+        @override
         def init(self, model=None, **kwargs) -> LightningModule:
             return super().init(model=model or CustomBoringModel(**kwargs))
 
@@ -979,6 +983,7 @@ class NoHparamsModel(BoringModel):
 
 
 class DataModuleWithoutHparams(LightningDataModule):
+    @override
     def train_dataloader(self, *args, **kwargs) -> DataLoader:
         return DataLoader(RandomDataset(32, 64), batch_size=32)
 
@@ -988,6 +993,7 @@ class DataModuleWithHparams(LightningDataModule):
         super().__init__()
         self.save_hyperparameters(hparams)
 
+    @override
     def train_dataloader(self, *args, **kwargs) -> DataLoader:
         return DataLoader(RandomDataset(32, 64), batch_size=32)
 

--- a/tests/tests_pytorch/models/test_restore.py
+++ b/tests/tests_pytorch/models/test_restore.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import glob
 import logging as log
 import os
@@ -43,15 +44,19 @@ class ModelTrainerPropertyParity(Callback):
         assert trainer.global_step == pl_module.global_step
         assert trainer.current_epoch == pl_module.current_epoch
 
+    @override
     def on_train_start(self, trainer, pl_module):
         self._check_properties(trainer, pl_module)
 
+    @override
     def on_train_batch_start(self, trainer, pl_module, *_):
         self._check_properties(trainer, pl_module)
 
+    @override
     def on_train_batch_end(self, trainer, pl_module, *_):
         self._check_properties(trainer, pl_module)
 
+    @override
     def on_train_end(self, trainer, pl_module):
         self._check_properties(trainer, pl_module)
 
@@ -61,11 +66,13 @@ class ValTestLossBoringModel(BoringModel):
         super().__init__()
         self.save_hyperparameters()
 
+    @override
     def validation_step(self, batch, batch_idx):
         out = super().validation_step(batch, batch_idx)
         self.log("val_loss", out["x"])
         return out
 
+    @override
     def test_step(self, batch, batch_idx):
         out = super().test_step(batch, batch_idx)
         self.log("test_loss", out["y"])
@@ -109,6 +116,7 @@ def test_trainer_properties_restore_ckpt_path(tmp_path):
     """Test that required trainer properties are set correctly when resuming from checkpoint in different phases."""
 
     class CustomClassifModel(ClassificationModel):
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.Adam(self.parameters(), lr=self.lr)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
@@ -169,6 +177,7 @@ def test_trainer_properties_restore_ckpt_path(tmp_path):
             assert self.trainer.global_step == 0
             assert self._check_model_state_dict()
 
+        @override
         def on_train_start(self):
             assert self.trainer.current_epoch == state_dict["epoch"] + 1
             assert self.trainer.global_step == state_dict["global_step"]
@@ -176,10 +185,12 @@ def test_trainer_properties_restore_ckpt_path(tmp_path):
             assert self._check_optimizers()
             assert self._check_schedulers()
 
+        @override
         def on_validation_start(self):
             if self.trainer.state.fn == TrainerFn.VALIDATING:
                 self._test_on_val_test_predict_start()
 
+        @override
         def on_test_start(self):
             self._test_on_val_test_predict_start()
 
@@ -222,6 +233,7 @@ def test_correct_step_and_epoch(tmp_path):
     assert trainer.global_step == 0
 
     class TestModel(BoringModel):
+        @override
         def on_train_start(self) -> None:
             assert self.trainer.current_epoch == first_max_epochs
             assert self.trainer.global_step == first_max_epochs * train_batches
@@ -237,6 +249,7 @@ def test_fit_twice(tmp_path):
     epochs = []
 
     class TestModel(BoringModel):
+        @override
         def on_train_epoch_end(self, *_):
             epochs.append(self.current_epoch)
 
@@ -268,6 +281,7 @@ def test_try_resume_from_non_existing_checkpoint(tmp_path):
 class CaptureCallbacksBeforeTraining(Callback):
     callbacks = []
 
+    @override
     def on_fit_start(self, trainer, pl_module):
         self.callbacks = deepcopy(trainer.callbacks)
 
@@ -621,6 +635,7 @@ class ExceptionModel(BoringModel):
         super().__init__()
         self.stop_batch_idx = stop_batch_idx
 
+    @override
     def training_step(self, batch, batch_idx):
         if batch_idx == self.stop_batch_idx:
             raise CustomException()
@@ -628,6 +643,7 @@ class ExceptionModel(BoringModel):
 
 
 class ShouldStopModel(ExceptionModel):
+    @override
     def training_step(self, batch, batch_idx):
         if batch_idx == self.stop_batch_idx:
             # setting should_stop is treated differently to raising an exception.

--- a/tests/tests_pytorch/models/test_restore.py
+++ b/tests/tests_pytorch/models/test_restore.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import glob
 import logging as log
 import os
@@ -25,6 +24,7 @@ import pytest
 import torch
 from lightning_utilities.test.warning import no_warning_call
 from torch import Tensor
+from typing_extensions import override
 
 import tests_pytorch.helpers.pipelines as tpipes
 import tests_pytorch.helpers.utils as tutils

--- a/tests/tests_pytorch/models/test_torchscript.py
+++ b/tests/tests_pytorch/models/test_torchscript.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import os
 
 import fsspec
 import pytest
 import torch
 from fsspec.implementations.local import LocalFileSystem
+from typing_extensions import override
 
 from lightning.fabric.utilities.cloud_io import get_filesystem
 from lightning.fabric.utilities.imports import _IS_WINDOWS, _TORCH_GREATER_EQUAL_2_4

--- a/tests/tests_pytorch/models/test_torchscript.py
+++ b/tests/tests_pytorch/models/test_torchscript.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import os
 
 import fsspec
@@ -220,6 +221,7 @@ def test_torchscript_script_recursively():
             super().__init__()
             self.model = torch.nn.Linear(1, 1)
 
+        @override
         def forward(self, inputs):
             return self.model(inputs)
 
@@ -228,6 +230,7 @@ def test_torchscript_script_recursively():
             super().__init__()
             self.model = torch.nn.Sequential(GrandChild(), GrandChild())
 
+        @override
         def forward(self, inputs):
             return self.model(inputs)
 
@@ -236,6 +239,7 @@ def test_torchscript_script_recursively():
             super().__init__()
             self.model = Child()
 
+        @override
         def forward(self, inputs):
             return self.model(inputs)
 

--- a/tests/tests_pytorch/models/test_tpu.py
+++ b/tests/tests_pytorch/models/test_tpu.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from functools import partial
 from unittest import mock
@@ -32,9 +33,11 @@ from tests_pytorch.helpers.runif import RunIf
 
 
 class SerialLoaderBoringModel(BoringModel):
+    @override
     def train_dataloader(self):
         return DataLoader(RandomDataset(32, 2000), batch_size=32)
 
+    @override
     def val_dataloader(self):
         return DataLoader(RandomDataset(32, 2000), batch_size=32)
 
@@ -155,6 +158,7 @@ def test_model_16bit_multiple_tpu_devices(tmp_path):
 
 
 class CustomBoringModel(BoringModel):
+    @override
     def validation_step(self, *args, **kwargs):
         out = super().validation_step(*args, **kwargs)
         self.log("val_loss", out["x"])
@@ -302,9 +306,11 @@ def test_tpu_sync_dist():
 
 
 class AssertXLADebugModel(BoringModel):
+    @override
     def on_train_start(self):
         assert os.environ.get("PT_XLA_DEBUG") == "1", "PT_XLA_DEBUG was not set in environment variables"
 
+    @override
     def teardown(self, stage):
         assert "PT_XLA_DEBUG" not in os.environ
 

--- a/tests/tests_pytorch/models/test_tpu.py
+++ b/tests/tests_pytorch/models/test_tpu.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from functools import partial
 from unittest import mock
@@ -19,6 +18,7 @@ from unittest import mock
 import pytest
 import torch
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 import tests_pytorch.helpers.pipelines as tpipes
 from lightning.pytorch import Trainer

--- a/tests/tests_pytorch/overrides/test_distributed.py
+++ b/tests/tests_pytorch/overrides/test_distributed.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from collections.abc import Iterable
 
 import pytest
 import torch
 from torch.utils.data import BatchSampler, SequentialSampler
+from typing_extensions import override
 
 from lightning.fabric.utilities.data import has_len
 from lightning.pytorch import LightningModule, Trainer, seed_everything

--- a/tests/tests_pytorch/overrides/test_distributed.py
+++ b/tests/tests_pytorch/overrides/test_distributed.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from collections.abc import Iterable
 
 import pytest
@@ -24,11 +25,13 @@ from tests_pytorch.helpers.runif import RunIf
 
 
 class MyModel(LightningModule):
+    @override
     def setup(self, stage: str) -> None:
         self.layer = torch.nn.Linear(1, 1)
         weights = self.layer.weight.item(), self.layer.bias.item()
         self.rank_0_weights = self.trainer.strategy.broadcast(weights)
 
+    @override
     def test_step(self, batch, batch_idx):
         current = self.layer.weight.item(), self.layer.bias.item()
         assert self.rank_0_weights == current

--- a/tests/tests_pytorch/plugins/precision/test_amp_integration.py
+++ b/tests/tests_pytorch/plugins/precision/test_amp_integration.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from unittest.mock import Mock
 
 import torch
@@ -28,6 +29,7 @@ class FusedOptimizerParityModel(BoringModel):
         super().__init__()
         self.fused = fused
 
+    @override
     def configure_optimizers(self):
         scaler_cls = torch.amp.GradScaler if _TORCH_GREATER_EQUAL_2_4 else torch.cuda.amp.GradScaler
         assert isinstance(self.trainer.precision_plugin.scaler, scaler_cls)
@@ -66,6 +68,7 @@ def test_skip_training_step_with_grad_scaler():
     """Test that the grad scaler gets skipped when skipping a training step."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             if batch_idx % 2:
                 return None  # skipping the backward should skip the grad scaler too

--- a/tests/tests_pytorch/plugins/precision/test_amp_integration.py
+++ b/tests/tests_pytorch/plugins/precision/test_amp_integration.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from unittest.mock import Mock
 
 import torch
+from typing_extensions import override
 
 from lightning.fabric import seed_everything
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4

--- a/tests/tests_pytorch/plugins/precision/test_bitsandbytes.py
+++ b/tests/tests_pytorch/plugins/precision/test_bitsandbytes.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+from typing_extensions import override
 import platform
 import sys
 from unittest.mock import Mock
@@ -49,9 +50,11 @@ def test_bitsandbytes_plugin(monkeypatch):
     _NF4Linear.quantize = quantize_mock
 
     class MyModel(LightningModule):
+        @override
         def configure_model(self):
             self.l = torch.nn.Linear(1, 3)
 
+        @override
         def test_step(self, *_): ...
 
     model = MyModel()

--- a/tests/tests_pytorch/plugins/precision/test_bitsandbytes.py
+++ b/tests/tests_pytorch/plugins/precision/test_bitsandbytes.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from typing_extensions import override
 import platform
 import sys
 from unittest.mock import Mock
@@ -19,6 +18,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 import torch.distributed
+from typing_extensions import override
 
 import lightning.fabric
 from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE

--- a/tests/tests_pytorch/plugins/precision/test_double.py
+++ b/tests/tests_pytorch/plugins/precision/test_double.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pickle
 from unittest.mock import MagicMock
 
@@ -30,6 +31,7 @@ class RandomFloatIntDataset(Dataset):
         self.float_data = torch.randn(length, size)
         self.int_data = torch.randint(10, (length, 1))
 
+    @override
     def __getitem__(self, index):
         return self.float_data[index], self.int_data[index]
 
@@ -38,6 +40,7 @@ class RandomFloatIntDataset(Dataset):
 
 
 class DoublePrecisionBoringModel(BoringModel):
+    @override
     def training_step(self, batch, batch_idx):
         float_data, _ = batch
         assert torch.tensor([0.0]).dtype == torch.float64
@@ -45,43 +48,52 @@ class DoublePrecisionBoringModel(BoringModel):
         assert float_data.dtype == torch.float64
         return super().training_step(float_data, batch_idx)
 
+    @override
     def on_train_epoch_end(self):
         assert torch.tensor([0.0]).dtype == torch.float32
 
+    @override
     def validation_step(self, batch, batch_idx):
         assert batch.dtype == torch.float64
         assert torch.tensor([0.0]).dtype == torch.float64
         assert torch.tensor([0.0], dtype=torch.float16).dtype == torch.float16
         return super().validation_step(batch, batch_idx)
 
+    @override
     def test_step(self, batch, batch_idx):
         assert batch.dtype == torch.float64
         assert torch.tensor([0.0]).dtype == torch.float64
         assert torch.tensor([0.0], dtype=torch.float16).dtype == torch.float16
         return super().test_step(batch, batch_idx)
 
+    @override
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
         assert batch.dtype == torch.float64
         assert torch.tensor([0.0]).dtype == torch.float64
         assert torch.tensor([0.0], dtype=torch.float16).dtype == torch.float16
         return self(batch)
 
+    @override
     def on_fit_start(self):
         assert self.layer.weight.dtype == torch.float64
 
+    @override
     def on_after_backward(self):
         assert self.layer.weight.grad.dtype == torch.float64
 
+    @override
     def train_dataloader(self):
         dataset = RandomFloatIntDataset(32, 64)
         assert dataset.float_data.dtype == torch.float32  # Don't start with double data
         return DataLoader(dataset)
 
+    @override
     def predict_dataloader(self):
         return DataLoader(RandomDataset(32, 64))
 
 
 class DoublePrecisionBoringModelNoForward(BoringModel):
+    @override
     def training_step(self, batch, batch_idx):
         assert batch.dtype == torch.float64
         output = self.layer(batch)
@@ -89,6 +101,7 @@ class DoublePrecisionBoringModelNoForward(BoringModel):
         loss = self.loss(output)
         return {"loss": loss}
 
+    @override
     def validation_step(self, batch, batch_idx):
         assert batch.dtype == torch.float64
         output = self.layer(batch)
@@ -96,6 +109,7 @@ class DoublePrecisionBoringModelNoForward(BoringModel):
         loss = self.loss(output)
         return {"x": loss}
 
+    @override
     def test_step(self, batch, batch_idx):
         assert batch.dtype == torch.float64
         output = self.layer(batch)
@@ -103,12 +117,14 @@ class DoublePrecisionBoringModelNoForward(BoringModel):
         loss = self.loss(output)
         return {"y": loss}
 
+    @override
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
         assert batch.dtype == torch.float64
         output = self.layer(batch)
         assert output.dtype == torch.float64
         return output
 
+    @override
     def predict_dataloader(self):
         return DataLoader(RandomDataset(32, 64))
 
@@ -118,9 +134,11 @@ class DoublePrecisionBoringModelComplexBuffer(BoringModel):
         super().__init__()
         self.register_buffer("complex_buffer_wrong", torch.complex(torch.rand(10), torch.rand(10)), persistent=False)
 
+    @override
     def configure_model(self) -> None:
         self.register_buffer("complex_buffer_right", torch.complex(torch.rand(10), torch.rand(10)), persistent=False)
 
+    @override
     def on_fit_start(self):
         # when the default floating point type is float64 the default complex type is complex128, as long as it is
         # initialized under the precision context manager, because `model.to(double)` will not convert properly
@@ -129,6 +147,7 @@ class DoublePrecisionBoringModelComplexBuffer(BoringModel):
         # this hook is not wrapped
         assert torch.tensor([1.2, 3.4j]).dtype == torch.complex64
 
+    @override
     def training_step(self, batch, batch_idx):
         assert torch.tensor([1.2, 3.4j]).dtype == torch.complex128
         return super().training_step(batch, batch_idx)

--- a/tests/tests_pytorch/plugins/precision/test_double.py
+++ b/tests/tests_pytorch/plugins/precision/test_double.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pickle
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 from torch.utils.data import DataLoader, Dataset
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel, RandomDataset

--- a/tests/tests_pytorch/plugins/precision/test_half.py
+++ b/tests/tests_pytorch/plugins/precision/test_half.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.plugins import HalfPrecision

--- a/tests/tests_pytorch/plugins/precision/test_half.py
+++ b/tests/tests_pytorch/plugins/precision/test_half.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import pytest
 import torch
 
@@ -86,11 +87,13 @@ def test_convert_module(precision, expected_dtype):
 )
 def test_configure_model(precision, expected_dtype):
     class MyModel(LightningModule):
+        @override
         def configure_model(self):
             self.l = torch.nn.Linear(1, 3)
             # this is under the `module_init_context`
             assert self.l.weight.dtype == expected_dtype
 
+        @override
         def test_step(self, *_): ...
 
     model = MyModel()

--- a/tests/tests_pytorch/plugins/precision/test_transformer_engine.py
+++ b/tests/tests_pytorch/plugins/precision/test_transformer_engine.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+from typing_extensions import override
 import sys
 from contextlib import nullcontext
 from unittest.mock import ANY, Mock
@@ -61,10 +62,12 @@ def test_configure_model(monkeypatch):
     monkeypatch.setitem(sys.modules, "transformer_engine.common.recipe", te_mock)
 
     class MyModel(LightningModule):
+        @override
         def configure_model(self):
             self.l = torch.nn.Linear(8, 16)
             assert self.l.weight.dtype == torch.float16
 
+        @override
         def test_step(self, *_): ...
 
     model = MyModel()

--- a/tests/tests_pytorch/plugins/precision/test_transformer_engine.py
+++ b/tests/tests_pytorch/plugins/precision/test_transformer_engine.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from typing_extensions import override
 import sys
 from contextlib import nullcontext
 from unittest.mock import ANY, Mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 import lightning.fabric
 from lightning.pytorch import LightningModule, Trainer

--- a/tests/tests_pytorch/plugins/test_amp_plugins.py
+++ b/tests/tests_pytorch/plugins/test_amp_plugins.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import os
 import re
 from unittest import mock
@@ -71,6 +72,7 @@ def test_amp_ddp(cuda_count_2, strategy, devices, custom_plugin, plugin_cls):
 
 
 class TestClippingOptimizer(torch.optim.SGD):
+    @override
     def step(self, *args, pl_module=None):
         pl_module.check_grads_clipped()
         return super().step(*args)
@@ -78,6 +80,7 @@ class TestClippingOptimizer(torch.optim.SGD):
 
 class TestPrecisionModel(BoringModel):
     # sister test: tests/trainer/optimization/test_manual_optimization.py::test_multiple_optimizers_step
+    @override
     def on_after_backward(self) -> None:
         # check grads are scaled
         scale = self.trainer.precision_plugin.scaler.get_scale()
@@ -103,6 +106,7 @@ class TestPrecisionModel(BoringModel):
         for actual, expected in zip(parameters, self.clipped_parameters):
             torch.testing.assert_close(actual.grad, expected.grad, equal_nan=True)
 
+    @override
     def on_before_optimizer_step(self, optimizer, *_):
         self.check_grads_unscaled(optimizer)
         # manually clip
@@ -114,16 +118,19 @@ class TestPrecisionModel(BoringModel):
         clip_val = self.trainer.gradient_clip_val
         torch.nn.utils.clip_grad_value_(self.clipped_parameters, clip_val)
 
+    @override
     def configure_gradient_clipping(self, *args, **kwargs):
         # let lightning clip
         super().configure_gradient_clipping(*args, **kwargs)
         # check clipping worked as expected
         self.check_grads_clipped()
 
+    @override
     def optimizer_step(self, epoch, batch_idx, optimizer, closure, **_):
         # pass self as a kwarg
         optimizer.step(closure, pl_module=self)
 
+    @override
     def configure_optimizers(self):
         return TestClippingOptimizer(self.layer.parameters(), lr=0.1)
 
@@ -163,10 +170,12 @@ def test_amp_skip_optimizer(tmp_path):
             self.layer1 = torch.nn.Linear(32, 32)
             self.layer2 = torch.nn.Linear(32, 2)
 
+        @override
         def forward(self, x: Tensor):
             x = self.layer1(x)
             return self.layer2(x)
 
+        @override
         def training_step(self, batch, batch_idx):
             _, opt2 = self.optimizers()
             output = self(batch)
@@ -176,6 +185,7 @@ def test_amp_skip_optimizer(tmp_path):
             # only optimizer 2 steps
             opt2.step()
 
+        @override
         def configure_optimizers(self):
             return [
                 torch.optim.SGD(self.layer1.parameters(), lr=0.1),

--- a/tests/tests_pytorch/plugins/test_amp_plugins.py
+++ b/tests/tests_pytorch/plugins/test_amp_plugins.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import os
 import re
 from unittest import mock
@@ -20,6 +19,7 @@ from unittest import mock
 import pytest
 import torch
 from torch import Tensor
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/plugins/test_async_checkpoint.py
+++ b/tests/tests_pytorch/plugins/test_async_checkpoint.py
@@ -1,9 +1,9 @@
-from typing_extensions import override
 import time
 from typing import Any, Optional
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.fabric.plugins.io.checkpoint_io import CheckpointIO
 from lightning.pytorch.plugins.io.async_plugin import AsyncCheckpointIO

--- a/tests/tests_pytorch/plugins/test_async_checkpoint.py
+++ b/tests/tests_pytorch/plugins/test_async_checkpoint.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import time
 from typing import Any, Optional
 
@@ -12,15 +13,18 @@ class _CaptureCheckpointIO(CheckpointIO):
     def __init__(self) -> None:
         self.saved: Optional[dict[str, Any]] = None
 
+    @override
     def save_checkpoint(self, checkpoint: dict[str, Any], path: str, storage_options: Optional[Any] = None) -> None:
         # Simulate some delay to increase race window
         time.sleep(0.05)
         # Store the received checkpoint object (not a deep copy) to inspect tensor values
         self.saved = checkpoint
 
+    @override
     def load_checkpoint(self, path: str, map_location: Optional[Any] = None) -> dict[str, Any]:
         raise NotImplementedError
 
+    @override
     def remove_checkpoint(self, path: str) -> None:
         pass
 

--- a/tests/tests_pytorch/plugins/test_checkpoint_io_plugin.py
+++ b/tests/tests_pytorch/plugins/test_checkpoint_io_plugin.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from pathlib import Path
 from typing import Any, Optional
@@ -19,6 +18,7 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.fabric.plugins import CheckpointIO, TorchCheckpointIO
 from lightning.fabric.utilities.types import _PATH

--- a/tests/tests_pytorch/plugins/test_checkpoint_io_plugin.py
+++ b/tests/tests_pytorch/plugins/test_checkpoint_io_plugin.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from pathlib import Path
 from typing import Any, Optional
@@ -29,14 +30,17 @@ from lightning.pytorch.strategies import SingleDeviceStrategy
 
 
 class CustomCheckpointIO(CheckpointIO):
+    @override
     def save_checkpoint(self, checkpoint: dict[str, Any], path: _PATH, storage_options: Optional[Any] = None) -> None:
         torch.save(checkpoint, path)
 
+    @override
     def load_checkpoint(
         self, path: _PATH, storage_options: Optional[Any] = None, weights_only: bool = True
     ) -> dict[str, Any]:
         return torch.load(path, weights_only=True)
 
+    @override
     def remove_checkpoint(self, path: _PATH) -> None:
         os.remove(path)
 
@@ -111,6 +115,7 @@ def test_async_checkpoint_plugin(tmp_path):
     checkpoint_plugin.remove_checkpoint = Mock(wraps=checkpoint_plugin.remove_checkpoint)
 
     class CustomBoringModel(BoringModel):
+        @override
         def on_fit_start(self):
             base_ckpt_io = self.trainer.strategy.checkpoint_io.checkpoint_io
             base_ckpt_io.save_checkpoint = Mock(wraps=base_ckpt_io.save_checkpoint)

--- a/tests/tests_pytorch/profilers/test_profiler.py
+++ b/tests/tests_pytorch/profilers/test_profiler.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import logging
 import os
 import platform
@@ -601,6 +602,7 @@ def test_profiler_teardown(tmp_path, cls):
     """This test checks if profiler teardown method is called when trainer is exiting."""
 
     class TestCallback(Callback):
+        @override
         def on_fit_end(self, trainer, *args, **kwargs) -> None:
             # describe sets it to None
             assert trainer.profiler._output_file is None

--- a/tests/tests_pytorch/profilers/test_profiler.py
+++ b/tests/tests_pytorch/profilers/test_profiler.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import logging
 import os
 import platform
@@ -23,6 +22,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_4
 from lightning.pytorch import Callback, Trainer

--- a/tests/tests_pytorch/serve/test_servable_module_validator.py
+++ b/tests/tests_pytorch/serve/test_servable_module_validator.py
@@ -1,7 +1,7 @@
-from typing_extensions import override
 import pytest
 import torch
 from torch import Tensor
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/serve/test_servable_module_validator.py
+++ b/tests/tests_pytorch/serve/test_servable_module_validator.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import pytest
 import torch
 from torch import Tensor
@@ -9,9 +10,11 @@ from tests_pytorch.helpers.runif import _xfail_gloo_windows
 
 
 class ServableBoringModel(BoringModel, ServableModule):
+    @override
     def configure_payload(self):
         return {"body": {"x": list(range(32))}}
 
+    @override
     def configure_serialization(self):
         def deserialize(x):
             return torch.tensor(x, dtype=torch.float)
@@ -21,10 +24,12 @@ class ServableBoringModel(BoringModel, ServableModule):
 
         return {"x": deserialize}, {"output": serialize}
 
+    @override
     def serve_step(self, x: Tensor) -> dict[str, Tensor]:
         assert torch.equal(x, torch.arange(32, dtype=torch.float))
         return {"output": torch.tensor([0, 1])}
 
+    @override
     def configure_response(self):
         return {"output": [0, 1]}
 

--- a/tests/tests_pytorch/strategies/launchers/test_multiprocessing.py
+++ b/tests/tests_pytorch/strategies/launchers/test_multiprocessing.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from multiprocessing import Process
 from unittest import mock
@@ -184,6 +185,7 @@ class SimpleModel(BoringModel):
         self.tied_layer.weight = self.layer.weight
         self.register_buffer("buffer", torch.ones(3))
 
+    @override
     def on_fit_start(self) -> None:
         assert not self.layer.weight.is_shared()
         assert not self.tied_layer.weight.is_shared()

--- a/tests/tests_pytorch/strategies/launchers/test_multiprocessing.py
+++ b/tests/tests_pytorch/strategies/launchers/test_multiprocessing.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from multiprocessing import Process
 from unittest import mock
@@ -19,6 +18,7 @@ from unittest.mock import ANY, Mock, call, patch
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.fabric.plugins import ClusterEnvironment
 from lightning.pytorch import Trainer

--- a/tests/tests_pytorch/strategies/test_custom_strategy.py
+++ b/tests/tests_pytorch/strategies/test_custom_strategy.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from collections.abc import Mapping
 from typing import Any
@@ -28,10 +29,12 @@ def test_strategy_lightning_restore_optimizer_and_schedulers(tmp_path, restore_o
     class TestStrategy(SingleDeviceStrategy):
         load_optimizer_state_dict_called = False
 
+        @override
         @property
         def lightning_restore_optimizer(self) -> bool:
             return restore_optimizer_and_schedulers
 
+        @override
         def load_optimizer_state_dict(self, checkpoint: Mapping[str, Any]) -> None:
             self.load_optimizer_state_dict_called = True
 

--- a/tests/tests_pytorch/strategies/test_custom_strategy.py
+++ b/tests/tests_pytorch/strategies/test_custom_strategy.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from collections.abc import Mapping
 from typing import Any
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/strategies/test_ddp.py
+++ b/tests/tests_pytorch/strategies/test_ddp.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from datetime import timedelta
 from unittest import mock
@@ -19,6 +18,7 @@ from unittest import mock
 import pytest
 import torch
 from torch.nn.parallel import DistributedDataParallel
+from typing_extensions import override
 
 from lightning.fabric.plugins.environments import LightningEnvironment
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_3

--- a/tests/tests_pytorch/strategies/test_ddp.py
+++ b/tests/tests_pytorch/strategies/test_ddp.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from datetime import timedelta
 from unittest import mock
@@ -46,6 +47,7 @@ def test_ddp_process_group_backend(process_group_backend, device_str, expected_p
             self._root_device = root_device
             super().__init__(process_group_backend=process_group_backend)
 
+        @override
         @property
         def root_device(self):
             return self._root_device

--- a/tests/tests_pytorch/strategies/test_ddp_integration.py
+++ b/tests/tests_pytorch/strategies/test_ddp_integration.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from unittest import mock
 from unittest.mock import Mock
@@ -74,6 +75,7 @@ def test_ddp_torch_dist_is_available_in_setup(_, __, ___, cuda_count_1, mps_coun
     """Test to ensure torch distributed is available within the setup hook using ddp."""
 
     class TestModel(BoringModel):
+        @override
         def setup(self, stage: str) -> None:
             assert _distributed_is_initialized()
             raise SystemExit()
@@ -96,6 +98,7 @@ def test_ddp_wrapper(tmp_path, precision):
     """Test parameters to ignore are carried over for DDP."""
 
     class WeirdModule(torch.nn.Module):
+        @override
         def _save_to_state_dict(self, destination, prefix, keep_vars):
             return {"something": "something"}
 
@@ -108,6 +111,7 @@ def test_ddp_wrapper(tmp_path, precision):
             self._ddp_params_and_buffers_to_ignore = ["something"]
 
     class CustomCallback(Callback):
+        @override
         def on_train_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
             assert isinstance(trainer.strategy.model, DistributedDataParallel)
             expected = ["something"]
@@ -192,6 +196,7 @@ class UnusedParametersModel(BoringModel):
         super().__init__()
         self.intermediate_layer = torch.nn.Linear(32, 32)
 
+    @override
     def training_step(self, batch, batch_idx):
         with torch.no_grad():
             batch = self.intermediate_layer(batch)
@@ -222,23 +227,27 @@ class BoringCallbackDDPSpawnModel(BoringModel):
         self.name = name
         self.val = val
 
+    @override
     def validation_step(self, batch, batch_idx):
         self.log(self.name, self.val)
         return super().validation_step(batch, batch_idx)
 
 
 class CustomMultiProcessingLauncher(_MultiProcessingLauncher):
+    @override
     def get_extra_results(self, trainer):
         extra = super().get_extra_results(trainer)
         extra["test_val"] = "test_val"
         return extra
 
+    @override
     def update_main_process_results(self, trainer, extra) -> None:
         trainer.strategy.test_val = extra.pop("test_val")
         return super().update_main_process_results(trainer, extra)
 
 
 class TestDDPSpawnStrategy(DDPStrategy):
+    @override
     def _configure_launcher(self):
         self._launcher = CustomMultiProcessingLauncher(self)
 
@@ -261,6 +270,7 @@ def test_ddp_spawn_add_get_queue(tmp_path):
 
 
 class BoringModelDDPCPU(BoringModel):
+    @override
     def on_train_start(self) -> None:
         # make sure that the model is on CPU when training
         assert self.device == torch.device("cpu")
@@ -278,6 +288,7 @@ def test_ddp_cpu():
 
 
 class BoringZeroRedundancyOptimizerModel(BoringModel):
+    @override
     def configure_optimizers(self):
         return ZeroRedundancyOptimizer(self.layer.parameters(), optimizer_class=torch.optim.Adam, lr=0.1)
 
@@ -306,37 +317,47 @@ def test_ddp_strategy_checkpoint_zero_redundancy_optimizer(strategy, tmp_path):
 
 def test_configure_launcher_create_processes_externally():
     class MyClusterEnvironment(ClusterEnvironment):
+        @override
         @property
         def creates_processes_externally(self):
             return True
 
+        @override
         @property
         def main_address(self):
             return ""
 
+        @override
         @property
         def main_port(self):
             return 8080
 
         @staticmethod
+        @override
         def detect():
             return True
 
+        @override
         def world_size(self):
             return 1
 
+        @override
         def set_world_size(self):
             pass
 
+        @override
         def global_rank(self):
             return 0
 
+        @override
         def set_global_rank(self):
             pass
 
+        @override
         def local_rank(self):
             return 0
 
+        @override
         def node_rank(self):
             return 0
 
@@ -353,6 +374,7 @@ def test_configure_launcher_create_processes_externally():
 
 
 class CheckOptimizerDeviceModel(BoringModel):
+    @override
     def configure_optimizers(self):
         assert all(param.device.type == "cuda" for param in self.parameters())
         super().configure_optimizers()
@@ -374,6 +396,7 @@ def test_model_parameters_on_device_for_optimizer(strategy):
 
 
 class BoringModelGPU(BoringModel):
+    @override
     def on_train_start(self) -> None:
         # make sure that the model is on GPU when training
         assert self.device == torch.device(f"cuda:{self.trainer.strategy.local_rank}")
@@ -430,6 +453,7 @@ def test_incorrect_ddp_script_spawning(tmp_path):
     """Test an error message when user accidentally instructs Lightning to spawn children processes on rank > 0."""
 
     class WronglyImplementedEnvironment(LightningEnvironment):
+        @override
         @property
         def creates_processes_externally(self):
             # returning false no matter what means Lightning would spawn also on ranks > 0 new processes
@@ -461,6 +485,7 @@ def test_ddp_gradients_synced(tmp_path, automatic_optimization, static_graph):
             super().__init__()
             self.automatic_optimization = automatic_optimization
 
+        @override
         def training_step(self, batch, batch_idx):
             if self.automatic_optimization:
                 return super().training_step(batch, batch_idx)
@@ -474,6 +499,7 @@ def test_ddp_gradients_synced(tmp_path, automatic_optimization, static_graph):
             opt.step()
             return out
 
+        @override
         def on_train_batch_end(self, *args, **kwargs):
             # record grad sum for sync check
             grad_sum = self.layer.bias.grad.detach().sum()

--- a/tests/tests_pytorch/strategies/test_ddp_integration.py
+++ b/tests/tests_pytorch/strategies/test_ddp_integration.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from unittest import mock
 from unittest.mock import Mock
@@ -21,6 +20,7 @@ import torch
 from torch.distributed.optim import ZeroRedundancyOptimizer
 from torch.multiprocessing import ProcessRaisedException
 from torch.nn.parallel.distributed import DistributedDataParallel
+from typing_extensions import override
 
 import lightning.pytorch as pl
 import tests_pytorch.helpers.pipelines as tpipes

--- a/tests/tests_pytorch/strategies/test_ddp_integration_comm_hook.py
+++ b/tests/tests_pytorch/strategies/test_ddp_integration_comm_hook.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from unittest import mock
 
 import pytest
@@ -32,6 +33,7 @@ class TestDDPStrategy(DDPStrategy):
         self.expected_ddp_comm_hook_name = expected_ddp_comm_hook_name
         super().__init__(*args, **kwargs)
 
+    @override
     def teardown(self):
         # check here before unwrapping DistributedDataParallel in self.teardown
         attached_ddp_comm_hook_name = self.model._get_ddp_logging_data()["comm_hook"]
@@ -212,6 +214,7 @@ def test_post_local_sgd_model_averaging_raises(average_parameters_mock, tmp_path
     from torch.distributed.optim import ZeroRedundancyOptimizer
 
     class OptimizerModel(BoringModel):
+        @override
         def configure_optimizers(self):
             return ZeroRedundancyOptimizer(params=self.parameters(), optimizer_class=torch.optim.Adam, lr=0.01)
 

--- a/tests/tests_pytorch/strategies/test_ddp_integration_comm_hook.py
+++ b/tests/tests_pytorch/strategies/test_ddp_integration_comm_hook.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from unittest import mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/strategies/test_deepspeed.py
+++ b/tests/tests_pytorch/strategies/test_deepspeed.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import contextlib
 import json
 import os
@@ -44,15 +45,18 @@ class ModelParallelBoringModel(BoringModel):
         super().__init__()
         self.layer = None
 
+    @override
     def configure_model(self) -> None:
         if self.layer is None:
             self.layer = torch.nn.Linear(32, 2)
 
+    @override
     def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
         self.configure_model()
 
 
 class ModelParallelBoringModelNoSchedulers(ModelParallelBoringModel):
+    @override
     def configure_optimizers(self):
         return torch.optim.SGD(self.layer.parameters(), lr=0.1)
 
@@ -62,6 +66,7 @@ class ModelParallelBoringModelManualOptim(BoringModel):
         super().__init__()
         self.layer = None
 
+    @override
     def training_step(self, batch, batch_idx):
         opt = self.optimizers()
         loss = self.step(batch)
@@ -69,13 +74,16 @@ class ModelParallelBoringModelManualOptim(BoringModel):
         self.manual_backward(loss)
         opt.step()
 
+    @override
     def configure_model(self) -> None:
         if self.layer is None:
             self.layer = torch.nn.Linear(32, 2)
 
+    @override
     def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
         self.configure_model()
 
+    @override
     @property
     def automatic_optimization(self) -> bool:
         return False
@@ -180,6 +188,7 @@ def test_deepspeed_defaults():
 @RunIf(min_cuda_gpus=1, standalone=True, deepspeed=True)
 def test_warn_deepspeed_ignored(tmp_path):
     class TestModel(BoringModel):
+        @override
         def backward(self, loss: Tensor, *args, **kwargs) -> None:
             return loss.backward()
 
@@ -209,9 +218,11 @@ def test_deepspeed_auto_batch_size_config_select(_, __, tmp_path, dataset_cls, v
     """Test to ensure that the batch size is correctly set as expected for deepspeed logging purposes."""
 
     class TestModel(BoringModel):
+        @override
         def train_dataloader(self):
             return DataLoader(dataset_cls(32, 64))
 
+        @override
         def configure_model(self) -> None:
             assert isinstance(self.trainer.strategy, DeepSpeedStrategy)
             config = self.trainer.strategy.config
@@ -243,6 +254,7 @@ def test_deepspeed_run_configure_optimizers(tmp_path):
     from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
 
     class TestCB(Callback):
+        @override
         def on_train_start(self, trainer, pl_module) -> None:
             assert isinstance(trainer.optimizers[0], DeepSpeedZeroOptimizer)
             assert isinstance(trainer.optimizers[0].optimizer, torch.optim.SGD)
@@ -251,6 +263,7 @@ def test_deepspeed_run_configure_optimizers(tmp_path):
             assert trainer.lr_scheduler_configs[0].name == "Sean"
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             [optimizer], [scheduler] = super().configure_optimizers()
             return {"optimizer": optimizer, "lr_scheduler": {"scheduler": scheduler, "name": "Sean"}}
@@ -283,6 +296,7 @@ def test_deepspeed_config(tmp_path, deepspeed_zero_config):
     from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
 
     class TestCB(Callback):
+        @override
         def on_train_start(self, trainer, pl_module) -> None:
             from deepspeed.runtime.lr_schedules import WarmupLR
 
@@ -322,6 +336,7 @@ def test_deepspeed_custom_precision_params(tmp_path):
     changes."""
 
     class TestCB(Callback):
+        @override
         def on_train_start(self, trainer, pl_module) -> None:
             assert trainer.strategy.config["fp16"]["loss_scale"] == 10
             assert trainer.strategy.config["fp16"]["initial_scale_power"] == 11
@@ -355,6 +370,7 @@ def test_deepspeed_inference_precision_during_inference(precision, tmp_path):
     changes."""
 
     class TestCB(Callback):
+        @override
         def on_validation_start(self, trainer, pl_module) -> None:
             assert trainer.strategy.config[precision]
             raise SystemExit()
@@ -430,6 +446,7 @@ def test_deepspeed_assert_config_zero_offload_disabled(tmp_path, deepspeed_zero_
     deepspeed_zero_config["zero_optimization"]["offload_optimizer"] = False
 
     class TestCallback(Callback):
+        @override
         def setup(self, trainer, pl_module, stage=None) -> None:
             assert trainer.strategy.config["zero_optimization"]["offload_optimizer"] is False
             raise SystemExit()
@@ -571,12 +588,14 @@ def test_deepspeed_strategy_exclude_frozen_parameters_integration(tmp_path):
             super().__init__()
             self.frozen_layer = torch.nn.Linear(32, 32)
 
+        @override
         def configure_model(self) -> None:
             super().configure_model()
             # Freeze the additional layer parameters
             for param in self.frozen_layer.parameters():
                 param.requires_grad = False
 
+        @override
         def forward(self, x):
             x = self.frozen_layer(x)
             return super().forward(x)
@@ -614,6 +633,7 @@ class ModelParallelClassificationModel(LightningModule):
     def make_block(self):
         return nn.Sequential(nn.Linear(32, 32, bias=False), nn.ReLU())
 
+    @override
     def configure_model(self) -> None:
         # As of deepspeed v0.9.3, in ZeRO stage 3 all submodules need to be created within this hook,
         # including the metrics. Otherwise, modules that aren't affected by `deepspeed.zero.Init()`
@@ -625,12 +645,14 @@ class ModelParallelClassificationModel(LightningModule):
             self.test_acc = metric.clone()
             self.model = nn.Sequential(*(self.make_block() for x in range(self.num_blocks)), nn.Linear(32, 3))
 
+    @override
     def forward(self, x):
         x = self.model(x)
         # Ensure output is in float32 for softmax operation
         x = x.float()
         return F.softmax(x, dim=1)
 
+    @override
     def training_step(self, batch, batch_idx):
         x, y = batch
         logits = self.forward(x)
@@ -639,30 +661,35 @@ class ModelParallelClassificationModel(LightningModule):
         self.log("train_acc", self.train_acc(logits, y), prog_bar=True, sync_dist=True)
         return {"loss": loss}
 
+    @override
     def validation_step(self, batch, batch_idx):
         x, y = batch
         logits = self.forward(x)
         self.log("val_loss", F.cross_entropy(logits, y), prog_bar=False, sync_dist=True)
         self.log("val_acc", self.valid_acc(logits, y), prog_bar=True, sync_dist=True)
 
+    @override
     def test_step(self, batch, batch_idx):
         x, y = batch
         logits = self.forward(x)
         self.log("test_loss", F.cross_entropy(logits, y), prog_bar=False, sync_dist=True)
         self.log("test_acc", self.test_acc(logits, y), prog_bar=True, sync_dist=True)
 
+    @override
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
         x, y = batch
         logits = self.forward(x)
         self.test_acc(logits, y)
         return self.test_acc.compute()
 
+    @override
     def configure_optimizers(self):
         optimizer = torch.optim.Adam(self.parameters(), lr=self.lr)
 
         lr_scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.99)
         return [optimizer], [{"scheduler": lr_scheduler, "interval": "step"}]
 
+    @override
     def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
         if not hasattr(self, "model"):
             self.configure_model()
@@ -673,10 +700,12 @@ class ModelParallelClassificationModel(LightningModule):
 
 
 class ManualModelParallelClassificationModel(ModelParallelClassificationModel):
+    @override
     @property
     def automatic_optimization(self) -> bool:
         return False
 
+    @override
     def training_step(self, batch, batch_idx):
         x, y = batch
         logits = self.forward(x)
@@ -828,6 +857,7 @@ def test_deepspeed_multigpu_stage_3_resume_training(tmp_path):
     initial_trainer.fit(initial_model, datamodule=dm)
 
     class TestCallback(Callback):
+        @override
         def on_train_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
             original_deepspeed_strategy = initial_trainer.strategy
             current_deepspeed_strategy = trainer.strategy
@@ -878,6 +908,7 @@ def test_deepspeed_multigpu_stage_2_accumulated_grad_batches(tmp_path, offload_o
         def __init__(self):
             self.on_train_batch_start_called = False
 
+        @override
         def on_train_batch_start(self, trainer, pl_module: LightningModule, batch: Any, batch_idx: int) -> None:
             deepspeed_engine = trainer.strategy.model
             assert trainer.global_step == deepspeed_engine.global_steps
@@ -939,14 +970,17 @@ def test_deepspeed_multigpu_partial_partition_parameters(tmp_path):
             super().__init__()
             self.layer_2 = torch.nn.Linear(32, 32)
 
+        @override
         def configure_model(self) -> None:
             if self.layer is None:
                 self.layer = torch.nn.Linear(32, 2)
 
+        @override
         def forward(self, x):
             x = self.layer_2(x)
             return self.layer(x)
 
+        @override
         def on_train_epoch_start(self) -> None:
             assert all(x.dtype == torch.float16 for x in self.parameters())
 
@@ -974,6 +1008,7 @@ def test_deepspeed_multigpu_test_rnn(tmp_path):
             super().__init__()
             self.rnn = torch.nn.GRU(32, 32)
 
+        @override
         def on_train_epoch_start(self) -> None:
             assert all(x.dtype == torch.float16 for x in self.parameters())
 
@@ -1065,6 +1100,7 @@ def test_deepspeed_multigpu_no_schedulers(tmp_path):
 @RunIf(min_cuda_gpus=1, standalone=True, deepspeed=True)
 def test_deepspeed_skip_backward_raises(tmp_path):
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             return None
 
@@ -1093,6 +1129,7 @@ def test_scheduler_step_count(mock_step, tmp_path, max_epoch, limit_train_batche
     step or epoch."""
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
             scheduler = torch.optim.lr_scheduler.StepLR(optimizer, 1, gamma=0.1)
@@ -1128,6 +1165,7 @@ def test_deepspeed_configure_gradient_clipping(tmp_path):
     of deepspeed."""
 
     class TestModel(BoringModel):
+        @override
         def configure_gradient_clipping(self, optimizer, gradient_clip_val, gradient_clip_algorithm):
             self.clip_gradients(optimizer, gradient_clip_val, gradient_clip_algorithm)
 
@@ -1168,6 +1206,7 @@ def test_deepspeed_multi_save_same_filepath(tmp_path):
     checkpoints."""
 
     class CustomModel(BoringModel):
+        @override
         def training_step(self, *args, **kwargs):
             self.log("grank", self.global_rank)
             return super().training_step(*args, **kwargs)
@@ -1241,6 +1280,7 @@ def test_deepspeed_configure_optimizer_device_set(tmp_path):
     estimated_stepping_batches works correctly as a result."""
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             assert self.trainer.estimated_stepping_batches == 1
             assert self.device.type == "cuda"

--- a/tests/tests_pytorch/strategies/test_deepspeed.py
+++ b/tests/tests_pytorch/strategies/test_deepspeed.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import contextlib
 import json
 import os
@@ -26,6 +25,7 @@ import torch.nn.functional as F
 from torch import Tensor, nn
 from torch.utils.data import DataLoader
 from torchmetrics import Accuracy
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.accelerators import CUDAAccelerator

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -1,4 +1,3 @@
-from typing_extensions import override
 import os
 from contextlib import nullcontext
 from copy import deepcopy
@@ -16,6 +15,7 @@ import torch.nn as nn
 from torch.distributed.fsdp.fully_sharded_data_parallel import CPUOffload, FullyShardedDataParallel, MixedPrecision
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy, always_wrap_policy, size_based_auto_wrap_policy, wrap
 from torchmetrics import Accuracy
+from typing_extensions import override
 
 from lightning.fabric.plugins.environments import LightningEnvironment
 from lightning.fabric.strategies.fsdp import _is_sharded_checkpoint

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import os
 from contextlib import nullcontext
 from copy import deepcopy
@@ -39,6 +40,7 @@ class TestFSDPModel(BoringModel):
     def _init_model(self) -> None:
         self.layer = torch.nn.Sequential(torch.nn.Linear(32, 32), torch.nn.ReLU(), torch.nn.Linear(32, 2))
 
+    @override
     def configure_model(self) -> None:
         if self.layer is None:
             self._init_model()
@@ -50,25 +52,31 @@ class TestFSDPModel(BoringModel):
                 self.layer[i] = wrap(layer)
         self.layer = wrap(self.layer)
 
+    @override
     def configure_optimizers(self):
         # There is some issue with SGD optimizer state in FSDP
         return torch.optim.AdamW(self.layer.parameters(), lr=0.1)
 
+    @override
     def on_train_batch_start(self, batch, batch_idx):
         assert batch.dtype == torch.float32
 
+    @override
     def on_train_batch_end(self, _, batch, batch_idx):
         assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
+    @override
     def on_test_batch_end(self, _, batch, batch_idx):
         assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
+    @override
     def on_validation_batch_end(self, _, batch, batch_idx):
         assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
+    @override
     def on_predict_batch_end(self, _, batch, batch_idx):
         assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
@@ -105,27 +113,33 @@ class TestBoringModel(BoringModel):
         self.layer = torch.nn.Sequential(torch.nn.Linear(32, 32), torch.nn.ReLU(), torch.nn.Linear(32, 2))
         self.should_be_wrapped = [wrap_min_params < (32 * 32 + 32), None, wrap_min_params < (32 * 2 + 2)]
 
+    @override
     def configure_optimizers(self):
         # SGD's FSDP optimizer, state is fixed in https://github.com/pytorch/pytorch/pull/99214
         return torch.optim.AdamW(self.parameters(), lr=0.1)
 
 
 class TestFSDPModelAutoWrapped(TestBoringModel):
+    @override
     def on_train_batch_start(self, batch, batch_idx):
         assert batch.dtype == torch.float32
 
+    @override
     def on_train_batch_end(self, _, batch, batch_idx):
         assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
+    @override
     def on_test_batch_end(self, _, batch, batch_idx):
         assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
+    @override
     def on_validation_batch_end(self, _, batch, batch_idx):
         assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
+    @override
     def on_predict_batch_end(self, _, batch, batch_idx):
         assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
@@ -237,9 +251,11 @@ def test_modules_without_parameters(tmp_path):
             self.metric = Accuracy("multiclass", num_classes=10)
             assert self.metric.device == self.metric.tp.device == torch.device("cpu")
 
+        @override
         def setup(self, stage) -> None:
             assert self.metric.device == self.metric.tp.device == torch.device("cpu")
 
+        @override
         def training_step(self, batch, batch_idx):
             loss = super().training_step(batch, batch_idx)
             assert self.metric.device == self.metric.tp.device == torch.device("cuda", 0)
@@ -377,6 +393,7 @@ def test_invalid_parameters_in_optimizer(use_orig_params):
     )
 
     class EmptyParametersModel(BoringModel):
+        @override
         def configure_optimizers(self):
             return torch.optim.Adam(self.parameters(), lr=1e-2)
 
@@ -384,6 +401,7 @@ def test_invalid_parameters_in_optimizer(use_orig_params):
     trainer.fit(model)
 
     class NoFlatParametersModel(BoringModel):
+        @override
         def configure_optimizers(self):
             layer = torch.nn.Linear(4, 5)
             return torch.optim.Adam(layer.parameters(), lr=1e-2)
@@ -695,6 +713,7 @@ def test_configure_model(precision, expected_dtype, tmp_path):
     )
 
     class MyModel(BoringModel):
+        @override
         def configure_model(self):
             self.layer = torch.nn.Linear(32, 2)
             # The model is on the CPU until after `.setup()``
@@ -703,10 +722,12 @@ def test_configure_model(precision, expected_dtype, tmp_path):
             assert self.layer.weight.device == expected_device
             assert self.layer.weight.dtype == expected_dtype
 
+        @override
         def configure_optimizers(self):
             # There is some issue with SGD optimizer state in FSDP
             return torch.optim.AdamW(self.layer.parameters(), lr=0.1)
 
+        @override
         def on_fit_start(self):
             # Parameters get sharded in `.setup()` and moved to the target device
             assert self.layer.weight.device == torch.device("cuda", self.local_rank)
@@ -802,10 +823,12 @@ class TestFSDPCheckpointModel(BoringModel):
         self.layer = torch.nn.Sequential(torch.nn.Linear(32, 32), torch.nn.ReLU(), torch.nn.Linear(32, 2))
         self.params_to_compare = params_to_compare
 
+    @override
     def configure_optimizers(self):
         # SGD's FSDP optimizer, state is fixed in https://github.com/pytorch/pytorch/pull/99214
         return torch.optim.AdamW(self.parameters(), lr=0.1)
 
+    @override
     def on_train_start(self):
         if self.params_to_compare is None:
             return
@@ -886,9 +909,11 @@ def test_module_init_context(precision, expected_dtype, tmp_path):
     """Test that the module under the init-context gets moved to the right device and dtype."""
 
     class Model(BoringModel):
+        @override
         def configure_optimizers(self):
             return torch.optim.Adam(self.parameters(), lr=1e-2)
 
+        @override
         def on_train_start(self):
             # Parameters get sharded in `FSDPStrategy.setup()` and moved to the target device
             assert self.layer.weight.device == torch.device("cuda", self.local_rank)
@@ -929,6 +954,7 @@ def test_save_sharded_and_consolidate_and_load(tmp_path):
     """Test the consolidation of a FSDP-sharded checkpoint into a single file."""
 
     class CustomModel(BoringModel):
+        @override
         def configure_optimizers(self):
             # Use Adam instead of SGD for this test because it has state
             # In PyTorch >= 2.4, saving an optimizer with empty state would result in a `KeyError: 'state'`

--- a/tests/tests_pytorch/strategies/test_model_parallel.py
+++ b/tests/tests_pytorch/strategies/test_model_parallel.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 from datetime import timedelta
 from re import escape
 from unittest import mock
@@ -21,6 +20,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 import torch.nn as nn
+from typing_extensions import override
 
 from lightning.fabric.strategies.model_parallel import _is_sharded_checkpoint
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_3

--- a/tests/tests_pytorch/strategies/test_model_parallel.py
+++ b/tests/tests_pytorch/strategies/test_model_parallel.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 from datetime import timedelta
 from re import escape
 from unittest import mock
@@ -76,6 +77,7 @@ def test_fsdp_v1_modules_unsupported():
     from torch.distributed.fsdp import FullyShardedDataParallel
 
     class Model(LightningModule):
+        @override
         def configure_model(self):
             pass
 
@@ -96,6 +98,7 @@ def test_configure_model_required():
         pass
 
     class Model2(LightningModule):
+        @override
         def configure_model(self):
             pass
 
@@ -231,6 +234,7 @@ def test_meta_device_materialization():
         def reset_parameters(self):
             self.buffer.fill_(1.0)
 
+        @override
         def configure_model(self) -> None:
             pass
 
@@ -263,6 +267,7 @@ def test_align_compiled_param_names_with_module():
             super().__init__()
             self.model = nn.Sequential(nn.Linear(32, 64), nn.ReLU(), nn.Linear(64, 32))
 
+        @override
         def forward(self, x):
             return self.model(x)
 
@@ -310,6 +315,7 @@ def test_align_compiled_param_names_no_compile():
             super().__init__()
             self.model = nn.Sequential(nn.Linear(32, 64), nn.Linear(64, 32))
 
+        @override
         def forward(self, x):
             return self.model(x)
 

--- a/tests/tests_pytorch/strategies/test_model_parallel_integration.py
+++ b/tests/tests_pytorch/strategies/test_model_parallel_integration.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from pathlib import Path
 
@@ -21,6 +20,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader, DistributedSampler
 from torchmetrics.classification import Accuracy
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer, seed_everything
 from lightning.pytorch.demos.boring_classes import BoringModel, RandomDataset

--- a/tests/tests_pytorch/strategies/test_model_parallel_integration.py
+++ b/tests/tests_pytorch/strategies/test_model_parallel_integration.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from pathlib import Path
 
@@ -34,6 +35,7 @@ class FeedForward(nn.Module):
         self.w2 = nn.Linear(32, 64)
         self.w3 = nn.Linear(64, 32)
 
+    @override
     def forward(self, x):
         return self.w3(F.silu(self.w1(x)) * self.w2(x))
 
@@ -98,20 +100,24 @@ class TemplateModel(LightningModule):
         self.model = FeedForward()
         self._compile = compile
 
+    @override
     def training_step(self, batch):
         output = self.model(batch)
         return output.sum()
 
+    @override
     def train_dataloader(self):
         dataset_size = 8
         dataset = RandomDataset(32, dataset_size)
         return DataLoader(dataset, batch_size=2)
 
+    @override
     def configure_optimizers(self):
         return torch.optim.AdamW(self.model.parameters())
 
 
 class FSDP2Model(TemplateModel):
+    @override
     def configure_model(self):
         parallelize = _parallelize_feed_forward_fsdp2_tp
         if self._compile:
@@ -120,6 +126,7 @@ class FSDP2Model(TemplateModel):
 
 
 class TensorParallelModel(TemplateModel):
+    @override
     def configure_model(self):
         parallelize = _parallelize_feed_forward_tp
         if self._compile:
@@ -128,6 +135,7 @@ class TensorParallelModel(TemplateModel):
 
 
 class FSDP2TensorParallelModel(TemplateModel):
+    @override
     def configure_model(self):
         parallelize = _parallelize_feed_forward_fsdp2_tp
         if self._compile:
@@ -141,14 +149,17 @@ class SimpleCompiledModule(LightningModule):
         self.model = nn.Sequential(nn.Linear(32, 64), nn.ReLU(), nn.Linear(64, 32))
         self._loss = nn.MSELoss()
 
+    @override
     def configure_model(self):
         self.model = torch.compile(self.model)
 
+    @override
     def training_step(self, batch, batch_idx):
         x, y = batch
         preds = self.model(x)
         return self._loss(preds, y)
 
+    @override
     def configure_optimizers(self):
         return torch.optim.AdamW(self.parameters(), lr=1e-3)
 
@@ -181,6 +192,7 @@ def test_setup_device_mesh(distributed):
         )
 
         class Model(BoringModel):
+            @override
             def configure_model(self):
                 device_mesh = self.device_mesh
                 assert isinstance(device_mesh, DeviceMesh)
@@ -209,6 +221,7 @@ def test_setup_device_mesh(distributed):
     )
 
     class Model(BoringModel):
+        @override
         def configure_model(self):
             device_mesh = self.device_mesh
             assert device_mesh.mesh_dim_names == ("data_parallel", "tensor_parallel")
@@ -228,6 +241,7 @@ def test_tensor_parallel(distributed, compile):
     from torch.distributed._tensor import DTensor
 
     class Model(TensorParallelModel):
+        @override
         def on_train_start(self):
             device_mesh = self.device_mesh
             optimizer = self.optimizers()
@@ -242,6 +256,7 @@ def test_tensor_parallel(distributed, compile):
             assert len(dataloader) == 8 // dataloader.batch_size
             assert isinstance(dataloader.sampler, DistributedSampler)
 
+        @override
         def training_step(self, batch):
             # All batches must be identical across TP group
             batches = self.all_gather(batch)
@@ -311,6 +326,7 @@ def test_fsdp2_tensor_parallel(distributed, compile):
     from torch.distributed._tensor import DTensor
 
     class Model(FSDP2TensorParallelModel):
+        @override
         def on_train_start(self):
             optimizer = self.optimizers()
             assert all(isinstance(weight, DTensor) for weight in self.model.parameters())
@@ -329,6 +345,7 @@ def test_fsdp2_tensor_parallel(distributed, compile):
             assert len(dataloader) == 8 // dataloader.batch_size // dp_mesh.size()
             assert isinstance(dataloader.sampler, DistributedSampler)
 
+        @override
         def training_step(self, batch):
             batches = self.all_gather(batch)
             dp_mesh = self.device_mesh["data_parallel"]
@@ -373,9 +390,11 @@ def test_modules_without_parameters(distributed, tmp_path):
             self.metric = Accuracy("multiclass", num_classes=10)
             assert self.metric.device == self.metric.tp.device == torch.device("cpu")
 
+        @override
         def setup(self, stage) -> None:
             assert self.metric.device == self.metric.tp.device == torch.device("cpu")
 
+        @override
         def training_step(self, batch):
             assert self.metric.device.type == self.metric.tp.device.type == "cuda"
             self.metric(torch.rand(2, 10, device=self.device), torch.randint(0, 10, size=(2,), device=self.device))
@@ -411,6 +430,7 @@ def test_module_init_context(distributed, compile, precision, expected_dtype, tm
     """Test that the module under the init-context gets moved to the right device and dtype."""
 
     class Model(FSDP2Model):
+        @override
         def on_train_start(self):
             assert self.model.w1.weight.device == torch.device("cuda", self.local_rank)
             assert self.model.w1.weight.dtype == expected_dtype
@@ -570,6 +590,7 @@ def test_save_load_sharded_state_dict(distributed, tmp_path):
             super().__init__()
             self.params_to_compare = params_to_compare
 
+        @override
         def on_train_start(self):
             if self.params_to_compare is None:
                 return

--- a/tests/tests_pytorch/strategies/test_registry.py
+++ b/tests/tests_pytorch/strategies/test_registry.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from unittest import mock
 
 import pytest
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.plugins import CheckpointIO

--- a/tests/tests_pytorch/strategies/test_registry.py
+++ b/tests/tests_pytorch/strategies/test_registry.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from unittest import mock
 
 import pytest
@@ -129,12 +130,15 @@ def test_ddp_find_unused_parameters_strategy_registry(
 
 def test_custom_registered_strategy_to_strategy_flag():
     class CustomCheckpointIO(CheckpointIO):
+        @override
         def save_checkpoint(self, checkpoint, path):
             pass
 
+        @override
         def load_checkpoint(self, path):
             pass
 
+        @override
         def remove_checkpoint(self, path):
             pass
 

--- a/tests/tests_pytorch/strategies/test_single_device.py
+++ b/tests/tests_pytorch/strategies/test_single_device.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pickle
 from unittest.mock import MagicMock, Mock
 
 import pytest
 import torch
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.core.optimizer import LightningOptimizer

--- a/tests/tests_pytorch/strategies/test_single_device.py
+++ b/tests/tests_pytorch/strategies/test_single_device.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pickle
 from unittest.mock import MagicMock, Mock
 
@@ -34,6 +35,7 @@ def test_single_cpu():
 
 
 class BoringModelGPU(BoringModel):
+    @override
     def on_train_start(self) -> None:
         # make sure that the model is on GPU when training
         assert self.device == torch.device("cuda:0")
@@ -82,15 +84,19 @@ def test_strategy_pickle():
 
 
 class BoringModelNoDataloaders(BoringModel):
+    @override
     def train_dataloader(self):
         raise NotImplementedError
 
+    @override
     def val_dataloader(self):
         raise NotImplementedError
 
+    @override
     def test_dataloader(self):
         raise NotImplementedError
 
+    @override
     def predict_dataloader(self):
         raise NotImplementedError
 

--- a/tests/tests_pytorch/strategies/test_xla.py
+++ b/tests/tests_pytorch/strategies/test_xla.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from unittest import mock
 from unittest.mock import Mock
@@ -25,6 +26,7 @@ from tests_pytorch.helpers.runif import RunIf
 
 
 class BoringModelTPU(BoringModel):
+    @override
     def on_train_start(self) -> None:
         # assert strategy attributes for device setting
         assert self.device == torch.device("xla", index=0)

--- a/tests/tests_pytorch/strategies/test_xla.py
+++ b/tests/tests_pytorch/strategies/test_xla.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from unittest import mock
 from unittest.mock import Mock
 
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.accelerators import XLAAccelerator

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import glob
 import inspect
 import json
@@ -164,6 +165,7 @@ def test_lightning_cli_args_callbacks(cleandir):
     ]
 
     class TestModel(BoringModel):
+        @override
         def on_fit_start(self):
             callback = [c for c in self.trainer.callbacks if isinstance(c, LearningRateMonitor)]
             assert len(callback) == 1
@@ -193,6 +195,7 @@ def test_lightning_cli_single_arg_callback():
 @pytest.mark.parametrize("run", [False, True])
 def test_lightning_cli_configurable_callbacks(cleandir, run):
     class MyLightningCLI(LightningCLI):
+        @override
         def add_arguments_to_parser(self, parser):
             parser.add_lightning_class_args(LearningRateMonitor, "learning_rate_monitor")
 
@@ -214,6 +217,7 @@ def test_lightning_cli_args_cluster_environments(cleandir):
     plugins = [{"class_path": "lightning.fabric.plugins.environments.SLURMEnvironment"}]
 
     class TestModel(BoringModel):
+        @override
         def on_fit_start(self):
             # Ensure SLURMEnvironment is set, instead of default LightningEnvironment
             assert isinstance(self.trainer._accelerator_connector.cluster_environment, SLURMEnvironment)
@@ -353,6 +357,7 @@ def test_lightning_cli_logger_save_config(cleandir):
         def __init__(self, *args, **kwargs) -> None:
             super().__init__(*args, save_to_log_dir=False, **kwargs)
 
+        @override
         def save_config(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
             nonlocal config
             config = self.parser.dump(self.config)
@@ -495,6 +500,7 @@ class BoringCkptPathModel(BoringModel):
 
 def test_lightning_cli_ckpt_path_argument_hparams(cleandir):
     class CkptPathCLI(LightningCLI):
+        @override
         def add_arguments_to_parser(self, parser):
             parser.link_arguments("model.out_dim", "model.hidden_dim", compute_fn=lambda x: x * 2)
 
@@ -533,6 +539,7 @@ class BoringCkptPathSubclass(BoringCkptPathModel):
 
 def test_lightning_cli_ckpt_path_argument_hparams_subclass_mode(cleandir):
     class CkptPathCLI(LightningCLI):
+        @override
         def add_arguments_to_parser(self, parser):
             parser.link_arguments("model.init_args.out_dim", "model.init_args.hidden_dim", compute_fn=lambda x: x * 2)
 
@@ -637,6 +644,7 @@ class BoringDataModuleBatchSizeAndClasses(BoringDataModule):
 
 def test_lightning_cli_link_arguments(cleandir):
     class MyLightningCLI(LightningCLI):
+        @override
         def add_arguments_to_parser(self, parser):
             parser.link_arguments("data.batch_size", "model.batch_size")
             parser.link_arguments("data.num_classes", "model.num_classes", apply_on="instantiate")
@@ -658,6 +666,7 @@ def test_lightning_cli_link_arguments(cleandir):
     assert hparams == {"batch_size": 12, "num_classes": 5}
 
     class MyLightningCLI2(LightningCLI):
+        @override
         def add_arguments_to_parser(self, parser):
             parser.link_arguments("data.batch_size", "model.init_args.batch_size")
             parser.link_arguments("data.num_classes", "model.init_args.num_classes", apply_on="instantiate")
@@ -695,6 +704,7 @@ class DeepLinkTargetModel(BoringModel):
         self.save_hyperparameters()
         self.optimizer = optimizer
 
+    @override
     def configure_optimizers(self):
         optimizer = self.optimizer(self.parameters())
         return {"optimizer": optimizer}
@@ -702,6 +712,7 @@ class DeepLinkTargetModel(BoringModel):
 
 def test_lightning_cli_link_arguments_subcommands_nested_target(cleandir):
     class MyLightningCLI(LightningCLI):
+        @override
         def add_arguments_to_parser(self, parser):
             parser.link_arguments(
                 "data.num_classes",
@@ -734,6 +745,7 @@ def test_lightning_cli_link_arguments_subcommands_nested_target(cleandir):
 
 
 class EarlyExitTestModel(BoringModel):
+    @override
     def on_fit_start(self):
         raise MisconfigurationException("Error on fit start")
 
@@ -795,6 +807,7 @@ def test_cli_config_filename(tmp_path):
 @pytest.mark.parametrize("run", [False, True])
 def test_lightning_cli_optimizer(run):
     class MyLightningCLI(LightningCLI):
+        @override
         def add_arguments_to_parser(self, parser):
             parser.add_optimizer_args(torch.optim.Adam)
 
@@ -816,6 +829,7 @@ def test_lightning_cli_optimizer(run):
 
 def test_lightning_cli_optimizer_and_lr_scheduler():
     class MyLightningCLI(LightningCLI):
+        @override
         def add_arguments_to_parser(self, parser):
             parser.add_optimizer_args(torch.optim.Adam)
             parser.add_lr_scheduler_args(torch.optim.lr_scheduler.ExponentialLR)
@@ -839,8 +853,10 @@ def test_cli_no_need_configure_optimizers(cleandir):
             super().__init__()
             self.layer = torch.nn.Linear(32, 2)
 
+        @override
         def training_step(self, *_): ...
 
+        @override
         def train_dataloader(self): ...
 
         # did not define `configure_optimizers`
@@ -862,6 +878,7 @@ def test_cli_no_need_configure_optimizers(cleandir):
 
 def test_lightning_cli_optimizer_and_lr_scheduler_subclasses(cleandir):
     class MyLightningCLI(LightningCLI):
+        @override
         def add_arguments_to_parser(self, parser):
             parser.add_optimizer_args((torch.optim.SGD, torch.optim.Adam))
             parser.add_lr_scheduler_args((torch.optim.lr_scheduler.StepLR, torch.optim.lr_scheduler.ExponentialLR))
@@ -889,6 +906,7 @@ def test_lightning_cli_optimizer_and_lr_scheduler_subclasses(cleandir):
 @pytest.mark.parametrize("use_generic_base_class", [False, True])
 def test_lightning_cli_optimizers_and_lr_scheduler_with_link_to(use_generic_base_class):
     class MyLightningCLI(LightningCLI):
+        @override
         def add_arguments_to_parser(self, parser):
             parser.add_optimizer_args(
                 (torch.optim.Optimizer,) if use_generic_base_class else torch.optim.Adam,
@@ -946,6 +964,7 @@ def test_lightning_cli_optimizers_and_lr_scheduler_with_callable_type():
             self.optim2 = optim2
             self.scheduler = scheduler
 
+        @override
         def configure_optimizers(self):
             optim1 = self.optim1(self.parameters())
             optim2 = self.optim2(self.parameters())
@@ -996,6 +1015,7 @@ class TestModelSaveHparams(BoringModel):
         self.scheduler = scheduler
         self.activation = activation
 
+    @override
     def configure_optimizers(self):
         optimizer = self.optimizer(self.parameters())
         scheduler = self.scheduler(optimizer)
@@ -1226,6 +1246,7 @@ def test_lightning_cli_custom_subcommand():
 
     class TestCLI(LightningCLI):
         @staticmethod
+        @override
         def subcommands():
             subcommands = LightningCLI.subcommands()
             subcommands["foo"] = {"model"}
@@ -1430,6 +1451,7 @@ def test_optimizers_and_lr_schedulers_add_arguments_to_parser_implemented_reload
         def __init__(self, *args):
             super().__init__(*args, run=False)
 
+        @override
         def add_arguments_to_parser(self, parser):
             parser.add_optimizer_args(nested_key="opt1", link_to="model.opt1_config")
             parser.add_optimizer_args(
@@ -1706,6 +1728,7 @@ def test_cli_configureoptimizers_can_be_overridden():
             super().__init__(BoringModel, run=False)
 
         @staticmethod
+        @override
         def configure_optimizers(self, optimizer, lr_scheduler=None):
             assert isinstance(self, BoringModel)
             assert lr_scheduler is None

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import glob
 import inspect
 import json
@@ -33,6 +32,7 @@ from tensorboard.backend.event_processing import event_accumulator
 from tensorboard.plugins.hparams.plugin_data_pb2 import HParamsPluginData
 from torch.optim import SGD
 from torch.optim.lr_scheduler import ReduceLROnPlateau, StepLR
+from typing_extensions import override
 
 from lightning.fabric.plugins.environments import SLURMEnvironment
 from lightning.pytorch import Callback, LightningDataModule, LightningModule, Trainer, __version__, seed_everything

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from typing_extensions import override
 import inspect
 import os
 import sys
@@ -23,6 +22,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 import torch.distributed
+from typing_extensions import override
 
 import lightning.fabric
 import lightning.pytorch

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+from typing_extensions import override
 import inspect
 import os
 import sys
@@ -134,10 +135,12 @@ def test_custom_cluster_environment_in_slurm_environment(cuda_count_0, tmp_path)
     """Test that we choose the custom cluster even when SLURM or TE flags are around."""
 
     class CustomCluster(LightningEnvironment):
+        @override
         @property
         def main_address(self):
             return "asdf"
 
+        @override
         @property
         def creates_processes_externally(self) -> bool:
             return True
@@ -171,32 +174,40 @@ def test_custom_cluster_environment_in_slurm_environment(cuda_count_0, tmp_path)
 @mock.patch("lightning.pytorch.strategies.DDPStrategy.setup_distributed", autospec=True)
 def test_custom_accelerator(cuda_count_0):
     class Accel(Accelerator):
+        @override
         def setup_device(self, device: torch.device) -> None:
             pass
 
+        @override
         def get_device_stats(self, device: torch.device) -> dict[str, Any]:
             pass
 
+        @override
         def teardown(self) -> None:
             pass
 
         @staticmethod
+        @override
         def parse_devices(devices):
             return devices
 
         @staticmethod
+        @override
         def get_parallel_devices(devices):
             return [torch.device("cpu")] * devices
 
         @staticmethod
+        @override
         def auto_device_count() -> int:
             return 1
 
         @staticmethod
+        @override
         def is_available() -> bool:
             return True
 
         @staticmethod
+        @override
         def name() -> str:
             return "custom_acc_name"
 

--- a/tests/tests_pytorch/trainer/connectors/test_callback_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_callback_connector.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import contextlib
 import logging
 from unittest import mock
@@ -105,6 +106,7 @@ def test_checkpoint_callbacks_are_last(tmp_path):
 
 
 class StatefulCallbackContent0(Callback):
+    @override
     def state_dict(self):
         return {"content0": 0}
 
@@ -114,10 +116,12 @@ class StatefulCallbackContent1(Callback):
         self._unique = unique
         self._other = other
 
+    @override
     @property
     def state_key(self):
         return self._generate_state_key(unique=self._unique)
 
+    @override
     def state_dict(self):
         return {"content1": self._unique}
 
@@ -313,10 +317,12 @@ def test_validate_unique_callback_state_key():
     """Test that we raise an error if the state keys collide, leading to missing state in the checkpoint."""
 
     class MockCallback(Callback):
+        @override
         @property
         def state_key(self):
             return "same_key"
 
+        @override
         def state_dict(self):
             # pretend these callbacks are stateful by overriding the `state_dict` hook
             return {"state": 1}
@@ -327,25 +333,30 @@ def test_validate_unique_callback_state_key():
 
 # Test with single stateful callback
 class StatefulCallback(Callback):
+    @override
     def state_dict(self):
         return {"state": 1}
 
 
 # Test with multiple stateful callbacks with unique state keys
 class StatefulCallback1(Callback):
+    @override
     @property
     def state_key(self):
         return "unique_key_1"
 
+    @override
     def state_dict(self):
         return {"state": 1}
 
 
 class StatefulCallback2(Callback):
+    @override
     @property
     def state_key(self):
         return "unique_key_2"
 
+    @override
     def state_dict(self):
         return {"state": 2}
 
@@ -365,20 +376,24 @@ def test_validate_callbacks_list_function(callbacks: list):
 
 # Test with multiple stateful callbacks with same state key
 class ConflictingCallback(Callback):
+    @override
     @property
     def state_key(self):
         return "same_key"
 
+    @override
     def state_dict(self):
         return {"state": 1}
 
 
 # Test with different types of stateful callbacks that happen to have same state key
 class AnotherConflictingCallback(Callback):
+    @override
     @property
     def state_key(self):
         return "same_key"  # Same key as ConflictingCallback
 
+    @override
     def state_dict(self):
         return {"state": 3}
 

--- a/tests/tests_pytorch/trainer/connectors/test_callback_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_callback_connector.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import contextlib
 import logging
 from unittest import mock
@@ -19,6 +18,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _PYTHON_GREATER_EQUAL_3_10_0
 from lightning.pytorch import Callback, LightningModule, Trainer

--- a/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import errno
 import operator
 import os
@@ -22,6 +21,7 @@ from unittest.mock import ANY, Mock
 import pytest
 import torch
 from lightning_utilities.core.imports import compare_version
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import Callback, ModelCheckpoint

--- a/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import errno
 import operator
 import os
@@ -274,14 +275,17 @@ def test_restore_callbacks_in_non_fit_phases(tmp_path, trainer_fn):
         def __init__(self):
             self.restored = False
 
+        @override
         def on_load_checkpoint(self, trainer, pl_module, checkpoint):
             if "callbacks" in checkpoint:
                 callback_state = checkpoint["callbacks"][self.__class__.__name__]
                 self.restored = callback_state["restored"]
 
+        @override
         def state_dict(self):
             return {"restored": self.restored}
 
+        @override
         def on_save_checkpoint(self, trainer, pl_module, checkpoint):
             checkpoint["callbacks"] = checkpoint.get("callbacks", {})
             checkpoint["callbacks"][self.__class__.__name__] = self.state_dict()

--- a/tests/tests_pytorch/trainer/connectors/test_data_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_data_connector.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from collections.abc import Sized
 from re import escape
 from unittest import mock
@@ -44,6 +45,7 @@ from tests_pytorch.helpers.runif import RunIf, _xfail_gloo_windows
 @pytest.mark.parametrize("mode", [1, 2])
 def test_replace_distributed_sampler(tmp_path, mode):
     class IndexedRandomDataset(RandomDataset):
+        @override
         def __getitem__(self, index):
             return self.data[index]
 
@@ -62,9 +64,11 @@ def test_replace_distributed_sampler(tmp_path, mode):
             self._numbers_test_dataloaders = numbers_test_dataloaders
             self._mode = mode
 
+        @override
         def test_step(self, batch, batch_idx, dataloader_idx=0):
             return super().test_step(batch, batch_idx)
 
+        @override
         def on_test_start(self) -> None:
             dataloader = self.trainer.test_dataloaders[0]
             assert isinstance(dataloader, CustomDataLoader)
@@ -92,6 +96,7 @@ def test_replace_distributed_sampler(tmp_path, mode):
                 return CustomDataLoader(32, dataset, batch_size=2, drop_last=True)
             return None
 
+        @override
         def test_dataloader(self):
             return [self.create_dataset()] * self._numbers_test_dataloaders
 
@@ -112,12 +117,14 @@ class TestSpawnBoringModel(BoringModel):
         super().__init__()
         self.warning_expected = warning_expected
 
+    @override
     def on_fit_start(self):
         ctx = pytest.warns if self.warning_expected else no_warning_call
         self.ctx = ctx(UserWarning, match="Consider setting `persistent_workers=True`")
         if self.global_rank == 0:
             self.ctx.__enter__()
 
+    @override
     def on_train_end(self):
         if self.global_rank == 0:
             self.ctx.__exit__(None, None, None)
@@ -321,6 +328,7 @@ def test_dataloader_reinit_for_subclass():
         def __len__(self):
             return len(self.data_source)
 
+        @override
         def __iter__(self):
             return iter(range(len(self)))
 
@@ -335,18 +343,22 @@ def test_dataloader_reinit_for_subclass():
 
 
 class LoaderTestModel(BoringModel):
+    @override
     def training_step(self, batch, batch_idx):
         assert len(self.trainer.train_dataloader) == 10
         return super().training_step(batch, batch_idx)
 
+    @override
     def validation_step(self, batch, batch_idx):
         assert len(self.trainer.val_dataloaders) == 10
         return super().validation_step(batch, batch_idx)
 
+    @override
     def test_step(self, batch, batch_idx):
         assert len(self.trainer.test_dataloaders) == 10
         return super().test_step(batch, batch_idx)
 
+    @override
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
         assert len(self.trainer.predict_dataloaders) == 10
         return super().predict_step(batch, batch_idx, dataloader_idx=dataloader_idx)
@@ -588,6 +600,7 @@ def test_eval_shuffle_with_distributed_sampler_replacement(shuffle):
     """Test that shuffle is not changed if set to True."""
 
     class CustomModel(BoringModel):
+        @override
         def val_dataloader(self):
             return DataLoader(RandomDataset(32, 64), shuffle=shuffle)
 

--- a/tests/tests_pytorch/trainer/connectors/test_data_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_data_connector.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from collections.abc import Sized
 from re import escape
 from unittest import mock
@@ -21,6 +20,7 @@ import pytest
 from lightning_utilities.test.warning import no_warning_call
 from torch import Tensor
 from torch.utils.data import BatchSampler, DataLoader, DistributedSampler, Sampler, SequentialSampler
+from typing_extensions import override
 
 import lightning.fabric
 from lightning.fabric.utilities.distributed import DistributedSamplerWrapper

--- a/tests/tests_pytorch/trainer/connectors/test_rich_integration.py
+++ b/tests/tests_pytorch/trainer/connectors/test_rich_integration.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 from unittest.mock import patch
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import ModelSummary, ProgressBar, RichModelSummary, RichProgressBar, TQDMProgressBar

--- a/tests/tests_pytorch/trainer/connectors/test_rich_integration.py
+++ b/tests/tests_pytorch/trainer/connectors/test_rich_integration.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 from unittest.mock import patch
 
 import pytest
@@ -130,6 +131,7 @@ class TestRichIntegration:
         """Test that tensor metrics are converted to float for RichProgressBar."""
 
         class MyModel(BoringModel):
+            @override
             def training_step(self, batch, batch_idx):
                 self.log("my_tensor_metric", torch.tensor(1.23), prog_bar=True)
                 return super().training_step(batch, batch_idx)

--- a/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import concurrent.futures
 import os
 import signal
@@ -19,6 +18,7 @@ from unittest import mock
 from unittest.mock import Mock
 
 import pytest
+from typing_extensions import override
 
 from lightning.fabric.plugins.environments import SLURMEnvironment
 from lightning.fabric.utilities.imports import _IS_WINDOWS

--- a/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import concurrent.futures
 import os
 import signal
@@ -60,6 +61,7 @@ def test_sigterm_handler_can_be_added(tmp_path):
     signal.signal(signal.SIGTERM, handler)
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             os.kill(os.getpid(), signal.SIGTERM)
 

--- a/tests/tests_pytorch/trainer/dynamic_args/test_multiple_eval_dataloaders.py
+++ b/tests/tests_pytorch/trainer/dynamic_args/test_multiple_eval_dataloaders.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pytest
 import torch
 from torch.utils.data import Dataset
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/trainer/dynamic_args/test_multiple_eval_dataloaders.py
+++ b/tests/tests_pytorch/trainer/dynamic_args/test_multiple_eval_dataloaders.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pytest
 import torch
 from torch.utils.data import Dataset
@@ -24,6 +25,7 @@ class RandomDatasetA(Dataset):
         self.len = length
         self.data = torch.randn(length, size)
 
+    @override
     def __getitem__(self, index):
         return torch.zeros(1)
 
@@ -36,6 +38,7 @@ class RandomDatasetB(Dataset):
         self.len = length
         self.data = torch.randn(length, size)
 
+    @override
     def __getitem__(self, index):
         return torch.ones(1)
 
@@ -46,6 +49,7 @@ class RandomDatasetB(Dataset):
 @pytest.mark.parametrize("seq_type", [tuple, list])
 def test_multiple_eval_dataloaders_seq(tmp_path, seq_type):
     class TestModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx):
             if dataloader_idx == 0:
                 assert batch.sum() == 0
@@ -54,6 +58,7 @@ def test_multiple_eval_dataloaders_seq(tmp_path, seq_type):
             else:
                 raise Exception("should only have two dataloaders")
 
+        @override
         def val_dataloader(self):
             dl1 = torch.utils.data.DataLoader(RandomDatasetA(32, 64), batch_size=11)
             dl2 = torch.utils.data.DataLoader(RandomDatasetB(32, 64), batch_size=11)

--- a/tests/tests_pytorch/trainer/flags/test_check_val_every_n_epoch.py
+++ b/tests/tests_pytorch/trainer/flags/test_check_val_every_n_epoch.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pytest
 from torch.utils.data import DataLoader
 
@@ -27,9 +28,11 @@ def test_check_val_every_n_epoch(tmp_path, max_epochs, expected_val_loop_calls, 
         val_epoch_calls = 0
         val_batches = []
 
+        @override
         def on_train_epoch_end(self, *args, **kwargs):
             self.val_batches.append(self.trainer.progress_bar_callback.total_val_batches)
 
+        @override
         def on_validation_epoch_start(self) -> None:
             self.val_epoch_calls += 1
 
@@ -59,10 +62,12 @@ def test_check_val_every_n_epoch_with_max_steps(tmp_path):
             super().__init__()
             self.validation_called_at_step = set()
 
+        @override
         def validation_step(self, *args):
             self.validation_called_at_step.add(self.global_step)
             return super().validation_step(*args)
 
+        @override
         def train_dataloader(self):
             return DataLoader(RandomDataset(32, data_samples_train))
 

--- a/tests/tests_pytorch/trainer/flags/test_check_val_every_n_epoch.py
+++ b/tests/tests_pytorch/trainer/flags/test_check_val_every_n_epoch.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pytest
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.pytorch.demos.boring_classes import BoringModel, RandomDataset
 from lightning.pytorch.trainer.trainer import Trainer

--- a/tests/tests_pytorch/trainer/flags/test_fast_dev_run.py
+++ b/tests/tests_pytorch/trainer/flags/test_fast_dev_run.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import os
 from unittest.mock import Mock
 
@@ -44,22 +45,27 @@ def test_callbacks_and_logger_not_called_with_fastdevrun(tmp_path, fast_dev_run)
             self.on_validation_epoch_end_call_count = 0
             self.test_step_call_count = 0
 
+        @override
         def training_step(self, batch, batch_idx):
             self.log("some_metric", torch.tensor(7.0))
             self.logger.experiment.dummy_log("some_distribution", torch.randn(7) + batch_idx)
             self.training_step_call_count += 1
             return super().training_step(batch, batch_idx)
 
+        @override
         def on_train_epoch_end(self):
             self.on_train_epoch_end_call_count += 1
 
+        @override
         def validation_step(self, batch, batch_idx):
             self.validation_step_call_count += 1
             return super().validation_step(batch, batch_idx)
 
+        @override
         def on_validation_epoch_end(self):
             self.on_validation_epoch_end_call_count += 1
 
+        @override
         def test_step(self, batch, batch_idx):
             self.test_step_call_count += 1
             return super().test_step(batch, batch_idx)

--- a/tests/tests_pytorch/trainer/flags/test_fast_dev_run.py
+++ b/tests/tests_pytorch/trainer/flags/test_fast_dev_run.py
@@ -1,9 +1,9 @@
-from typing_extensions import override
 import os
 from unittest.mock import Mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint

--- a/tests/tests_pytorch/trainer/flags/test_min_max_epochs.py
+++ b/tests/tests_pytorch/trainer/flags/test_min_max_epochs.py
@@ -1,6 +1,6 @@
-from typing_extensions import override
 import pytest
 from lightning_utilities.test.warning import no_warning_call
+from typing_extensions import override
 
 from lightning.fabric.utilities.warnings import PossibleUserWarning
 from lightning.pytorch import Trainer

--- a/tests/tests_pytorch/trainer/flags/test_min_max_epochs.py
+++ b/tests/tests_pytorch/trainer/flags/test_min_max_epochs.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import pytest
 from lightning_utilities.test.warning import no_warning_call
 
@@ -41,6 +42,7 @@ def test_max_epochs_not_set_warning(tmp_path):
     """Test that a warning is only emitted when `max_epochs` was not set by the user."""
 
     class CustomModel(BoringModel):
+        @override
         def training_step(self, *args, **kwargs):
             self.trainer.should_stop = True
 

--- a/tests/tests_pytorch/trainer/flags/test_overfit_batches.py
+++ b/tests/tests_pytorch/trainer/flags/test_overfit_batches.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from unittest import mock
 
@@ -50,6 +51,7 @@ def test_overfit_batches_raises_warning_in_case_of_sequential_sampler(tmp_path):
         def __init__(self, data_source):
             self.data_source = data_source
 
+        @override
         def __iter__(self):
             return iter(range(len(self.data_source)))
 
@@ -57,11 +59,13 @@ def test_overfit_batches_raises_warning_in_case_of_sequential_sampler(tmp_path):
             return len(self.data_source)
 
     class TestModel(BoringModel):
+        @override
         def train_dataloader(self):
             dataset = RandomDataset(32, 64)
             sampler = NonSequentialSampler(dataset)
             return torch.utils.data.DataLoader(dataset, sampler=sampler)
 
+        @override
         def val_dataloader(self):
             dataset = RandomDataset(32, 64)
             sampler = NonSequentialSampler(dataset)
@@ -114,6 +118,7 @@ def test_overfit_batch_limits_eval(stage, mode, overfit_batches):
 @RunIf(sklearn=True)
 def test_overfit_batch_limits_train(overfit_batches):
     class CustomDataModule(ClassifDataModule):
+        @override
         def train_dataloader(self):
             return DataLoader(
                 SklearnDataset(self.x_train, self.y_train, self._x_type, self._y_type),
@@ -181,10 +186,12 @@ def test_overfit_batches_same_batch_for_train_and_val(tmp_path):
             self.train_batches = []
             self.val_batches = []
 
+        @override
         def training_step(self, batch, batch_idx):
             self.train_batches.append(batch)
             return super().training_step(batch, batch_idx)
 
+        @override
         def validation_step(self, batch, batch_idx):
             self.val_batches.append(batch)
             return super().validation_step(batch, batch_idx)

--- a/tests/tests_pytorch/trainer/flags/test_overfit_batches.py
+++ b/tests/tests_pytorch/trainer/flags/test_overfit_batches.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from unittest import mock
 
 import pytest
 import torch
 from torch.utils.data import DataLoader, DistributedSampler, RandomSampler, Sampler, SequentialSampler
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel, RandomDataset

--- a/tests/tests_pytorch/trainer/flags/test_val_check_interval.py
+++ b/tests/tests_pytorch/trainer/flags/test_val_check_interval.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import logging
 import re
 import time
@@ -20,6 +19,7 @@ from unittest.mock import patch
 
 import pytest
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.pytorch.demos.boring_classes import BoringModel, RandomDataset, RandomIterableDataset
 from lightning.pytorch.trainer.trainer import Trainer

--- a/tests/tests_pytorch/trainer/flags/test_val_check_interval.py
+++ b/tests/tests_pytorch/trainer/flags/test_val_check_interval.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import logging
 import re
 import time
@@ -34,9 +35,11 @@ def test_val_check_interval(tmp_path, max_epochs, denominator):
             self.train_epoch_calls = 0
             self.val_epoch_calls = 0
 
+        @override
         def on_train_epoch_start(self) -> None:
             self.train_epoch_calls += 1
 
+        @override
         def on_validation_epoch_start(self) -> None:
             if not self.trainer.sanity_checking:
                 self.val_epoch_calls += 1
@@ -84,10 +87,12 @@ def test_validation_check_interval_exceed_data_length_correct(tmp_path, use_infi
             super().__init__()
             self.validation_called_at_step = set()
 
+        @override
         def validation_step(self, *args):
             self.validation_called_at_step.add(self.trainer.fit_loop.total_batch_idx + 1)
             return super().validation_step(*args)
 
+        @override
         def train_dataloader(self):
             train_ds = (
                 RandomIterableDataset(32, count=max_steps + 100)
@@ -204,6 +209,7 @@ def test_time_and_epoch_gated_val_check(
         val_batches = []
         val_epoch_calls = 0
 
+        @override
         def on_train_batch_end(self, *args, **kwargs):
             if (
                 isinstance(self.trainer.check_val_every_n_epoch, int)
@@ -212,10 +218,12 @@ def test_time_and_epoch_gated_val_check(
             ):
                 time.monotonic()
 
+        @override
         def on_train_epoch_end(self, *args, **kwargs):
             print(trainer.fit_loop.epoch_loop.val_loop.batch_progress.current.completed)
             self.val_batches.append(trainer.fit_loop.epoch_loop.val_loop.batch_progress.total.completed)
 
+        @override
         def on_validation_epoch_start(self) -> None:
             self.val_epoch_calls += 1
 

--- a/tests/tests_pytorch/trainer/logging_/test_distributed_logging.py
+++ b/tests/tests_pytorch/trainer/logging_/test_distributed_logging.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from typing import Any, Optional, Union
 from unittest.mock import Mock
+
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.pytorch import Callback, Trainer

--- a/tests/tests_pytorch/trainer/logging_/test_distributed_logging.py
+++ b/tests/tests_pytorch/trainer/logging_/test_distributed_logging.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from typing import Any, Optional, Union
 from unittest.mock import Mock
@@ -37,15 +38,19 @@ class AllRankLogger(Logger):
     def experiment(self) -> Any:
         return self.exp
 
+    @override
     def log_metrics(self, metrics: dict[str, float], step: Optional[int] = None):
         self.logs.update(metrics)
 
+    @override
     def version(self) -> Union[int, str]:
         return 1
 
+    @override
     def name(self) -> str:
         return "AllRank"
 
+    @override
     def log_hyperparams(self, *args, **kwargs) -> None:
         pass
 
@@ -53,9 +58,11 @@ class AllRankLogger(Logger):
 class TestModel(BoringModel):
     log_name = "rank-{rank}"
 
+    @override
     def on_train_start(self):
         self.log(self.log_name.format(rank=self.local_rank), 0)
 
+    @override
     def on_train_end(self):
         assert self.log_name.format(rank=self.local_rank) in self.logger.logs, "Expected rank to be logged"
 
@@ -107,12 +114,14 @@ def test_first_logger_call_in_subprocess(tmp_path):
     """
 
     class LoggerCallsObserver(Callback):
+        @override
         def setup(self, trainer, pl_module, stage):
             # this hook is executed after Strategy has setup the environment
             # logger should not write any logs until this point
             assert not trainer.logger.method_calls
             assert not os.listdir(trainer.logger.save_dir)
 
+        @override
         def on_train_start(self, trainer, pl_module):
             assert trainer.logger.method_call
             trainer.logger.log_graph.assert_called_once()
@@ -143,9 +152,11 @@ def test_logger_after_fit_predict_test_calls(tmp_path):
             self.buffer = {}
             self.logs = {}
 
+        @override
         def log_metrics(self, metrics: dict[str, float], step: Optional[int] = None) -> None:
             self.buffer.update(metrics)
 
+        @override
         def finalize(self, status: str) -> None:
             self.logs.update(self.buffer)
             self.buffer = {}
@@ -154,27 +165,34 @@ def test_logger_after_fit_predict_test_calls(tmp_path):
         def experiment(self) -> Any:
             return None
 
+        @override
         @property
         def version(self) -> Union[int, str]:
             return 1
 
+        @override
         @property
         def name(self) -> str:
             return "BufferLogger"
 
+        @override
         def log_hyperparams(self, *args, **kwargs) -> None:
             return None
 
     class LoggerCallsObserver(Callback):
+        @override
         def on_fit_end(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
             trainer.logger.log_metrics({"fit": 1})
 
+        @override
         def on_validation_end(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
             trainer.logger.log_metrics({"validate": 1})
 
+        @override
         def on_predict_end(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
             trainer.logger.log_metrics({"predict": 1})
 
+        @override
         def on_test_end(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
             trainer.logger.log_metrics({"test": 1})
 

--- a/tests/tests_pytorch/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/tests_pytorch/trainer/logging_/test_eval_loop_logging.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Test logging in the evaluation loop."""
 
+from typing_extensions import override
 import collections
 import itertools
 import os
@@ -43,12 +44,14 @@ def test__validation_step__log(tmp_path):
     """Tests that validation_step can log."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             out = super().training_step(batch, batch_idx)
             self.log("a", out["loss"], on_step=True, on_epoch=True)
             self.log("a2", 2)
             return out
 
+        @override
         def validation_step(self, batch, batch_idx):
             out = super().validation_step(batch, batch_idx)
             self.log("b", out["x"], on_step=True, on_epoch=True)
@@ -79,18 +82,21 @@ def test__validation_step__epoch_end__log(tmp_path):
     """Tests that on_validation_epoch_end can log."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             out = super().training_step(batch, batch_idx)
             self.log("a", out["loss"])
             self.log("b", out["loss"], on_step=True, on_epoch=True)
             return out
 
+        @override
         def validation_step(self, batch, batch_idx):
             out = super().validation_step(batch, batch_idx)
             self.log("c", out["x"])
             self.log("d", out["x"], on_step=True, on_epoch=True)
             return out
 
+        @override
         def on_validation_epoch_end(self):
             self.log("g", torch.tensor(2, device=self.device), on_epoch=True)
 
@@ -121,6 +127,7 @@ def test__validation_step__epoch_end__log(tmp_path):
 @pytest.mark.parametrize(("batches", "log_interval", "max_epochs"), [(1, 1, 1), (64, 32, 2)])
 def test_eval_epoch_logging(tmp_path, batches, log_interval, max_epochs):
     class TestModel(BoringModel):
+        @override
         def on_validation_epoch_end(self):
             self.log("c", torch.tensor(2), on_epoch=True, prog_bar=True, logger=True)
             self.log("d/e/f", 2)
@@ -154,6 +161,7 @@ def test_eval_epoch_logging(tmp_path, batches, log_interval, max_epochs):
 
 def test_eval_float_logging(tmp_path):
     class TestModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.log("a", 12.0)
@@ -179,12 +187,14 @@ def test_eval_logging_auto_reduce(tmp_path):
         val_losses = []
         manual_epoch_end_mean = None
 
+        @override
         def validation_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.val_losses.append(loss)
             self.log("val_loss", loss, on_epoch=True, on_step=True, prog_bar=True)
             return {"x": loss}
 
+        @override
         def on_validation_epoch_end(self) -> None:
             self.manual_epoch_end_mean = torch.stack(self.val_losses).mean()
 
@@ -215,6 +225,7 @@ def test_eval_epoch_only_logging(tmp_path, batches, log_interval, max_epochs):
     """Tests that on_test_epoch_end can be used to log, and we return them in the results."""
 
     class TestModel(BoringModel):
+        @override
         def on_test_epoch_end(self):
             self.log("c", torch.tensor(2))
             self.log("d/e/f", 2)
@@ -236,11 +247,13 @@ def test_eval_epoch_only_logging(tmp_path, batches, log_interval, max_epochs):
 @pytest.mark.parametrize("suffix", [False, True])
 def test_multi_dataloaders_add_suffix_properly(suffix, tmp_path):
     class TestModel(BoringModel):
+        @override
         def test_step(self, batch, batch_idx, dataloader_idx=0):  # noqa: PT028
             out = super().test_step(batch, batch_idx)
             self.log("test_loss", out["y"], on_step=True, on_epoch=True)
             return out
 
+        @override
         def test_dataloader(self):
             if suffix:
                 return [
@@ -295,16 +308,19 @@ def test_log_works_in_val_callback(tmp_path):
                 self.logged_arguments[fx] = {"on_step": on_step, "on_epoch": on_epoch, "prog_bar": prog_bar}
                 self.count += 1
 
+        @override
         def on_validation_start(self, _, pl_module):
             self.make_logging(
                 pl_module, "on_validation_start", on_steps=[False], on_epochs=[True], prob_bars=self.choices
             )
 
+        @override
         def on_validation_epoch_start(self, _, pl_module):
             self.make_logging(
                 pl_module, "on_validation_epoch_start", on_steps=[False], on_epochs=[True], prob_bars=self.choices
             )
 
+        @override
         def on_validation_batch_end(self, _, pl_module, *__):
             self.make_logging(
                 pl_module,
@@ -314,12 +330,14 @@ def test_log_works_in_val_callback(tmp_path):
                 prob_bars=self.choices,
             )
 
+        @override
         def on_validation_epoch_end(self, _, pl_module):
             self.make_logging(
                 pl_module, "on_validation_epoch_end", on_steps=[False], on_epochs=[True], prob_bars=self.choices
             )
 
     class TestModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx):
             loss = super().validation_step(batch, batch_idx)["x"]
             self.log("val_loss", loss)
@@ -418,19 +436,23 @@ def test_log_works_in_test_callback(tmp_path):
                         "func_name": func_name,
                     }
 
+        @override
         def on_test_start(self, _, pl_module):
             self.make_logging(pl_module, "on_test_start", on_steps=[False], on_epochs=[True], prob_bars=self.choices)
 
+        @override
         def on_test_epoch_start(self, _, pl_module):
             self.make_logging(
                 pl_module, "on_test_epoch_start", on_steps=[False], on_epochs=[True], prob_bars=self.choices
             )
 
+        @override
         def on_test_batch_end(self, _, pl_module, *__):
             self.make_logging(
                 pl_module, "on_test_batch_end", on_steps=self.choices, on_epochs=self.choices, prob_bars=self.choices
             )
 
+        @override
         def on_test_epoch_end(self, _, pl_module):
             self.make_logging(
                 pl_module, "on_test_epoch_end", on_steps=[False], on_epochs=[True], prob_bars=self.choices
@@ -441,11 +463,13 @@ def test_log_works_in_test_callback(tmp_path):
     class TestModel(BoringModel):
         seen_losses = {i: [] for i in range(num_dataloaders)}
 
+        @override
         def test_step(self, batch, batch_idx, dataloader_idx=0):  # noqa: PT028
             loss = super().test_step(batch, batch_idx)["y"]
             self.log("test_loss", loss)
             self.seen_losses[dataloader_idx].append(loss)
 
+        @override
         def test_dataloader(self):
             return [torch.utils.data.DataLoader(RandomDataset(32, 64)) for _ in range(num_dataloaders)]
 
@@ -503,11 +527,13 @@ def test_validation_step_log_with_tensorboard(mock_log_metrics, tmp_path):
             super().__init__()
             self.save_hyperparameters()
 
+        @override
         def training_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.log("train_loss", loss)
             return {"loss": loss}
 
+        @override
         def validation_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.val_losses.append(loss)
@@ -516,6 +542,7 @@ def test_validation_step_log_with_tensorboard(mock_log_metrics, tmp_path):
             self.log("valid_loss_2", loss, on_step=True, on_epoch=False)
             return {"val_loss": loss}  # not added to callback_metrics
 
+        @override
         def test_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.log("test_loss", loss)
@@ -575,6 +602,7 @@ def test_multiple_dataloaders_reset(val_check_interval, tmp_path):
     class TestModel(BoringModel):
         val_outputs = [[], []]
 
+        @override
         def training_step(self, batch, batch_idx):
             out = super().training_step(batch, batch_idx)
             value = 1 + batch_idx
@@ -583,11 +611,13 @@ def test_multiple_dataloaders_reset(val_check_interval, tmp_path):
             self.log("batch_idx", value, on_step=True, on_epoch=True, prog_bar=True)
             return out
 
+        @override
         def on_train_epoch_end(self):
             metrics = self.trainer.progress_bar_metrics
             v = 15 if self.current_epoch == 0 else 150
             assert metrics["batch_idx_epoch"] == (v / 5.0)
 
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx):
             value = (1 + batch_idx) * (1 + dataloader_idx)
             if self.current_epoch != 0:
@@ -595,6 +625,7 @@ def test_multiple_dataloaders_reset(val_check_interval, tmp_path):
             self.val_outputs[dataloader_idx].append(value)
             self.log("val_loss", value, on_step=False, on_epoch=True, prog_bar=True, logger=True)
 
+        @override
         def on_validation_epoch_end(self):
             outputs = self.val_outputs
             self.val_outputs = [[], []]
@@ -614,6 +645,7 @@ def test_multiple_dataloaders_reset(val_check_interval, tmp_path):
             assert self.trainer._results["validation_step.val_loss.0"].cumulated_batch_size == 5
             assert self.trainer._results["validation_step.val_loss.1"].cumulated_batch_size == 5
 
+        @override
         def val_dataloader(self):
             return [super().val_dataloader(), super().val_dataloader()]
 
@@ -642,10 +674,12 @@ def test_metrics_and_outputs_device(tmp_path, accelerator):
     class TestModel(BoringModel):
         outputs = []
 
+        @override
         def on_before_backward(self, loss: Tensor) -> None:
             # the loss should be on the correct device before backward
             assert loss.device.type == accelerator
 
+        @override
         def validation_step(self, *args):
             x = torch.tensor(2.0, requires_grad=True, device=self.device)
             y = x * 2
@@ -655,6 +689,7 @@ def test_metrics_and_outputs_device(tmp_path, accelerator):
             self.outputs.append(y)
             return y
 
+        @override
         def on_validation_epoch_end(self):
             # the step outputs were not moved after returning them
             assert all(o.device == self.device for o in self.outputs)
@@ -676,6 +711,7 @@ def test_logging_results_with_no_dataloader_idx(tmp_path):
     log_key_dl1 = {"test_log_b_class": 456}
 
     class CustomBoringModel(BoringModel):
+        @override
         def test_step(self, batch, batch_idx, dataloader_idx):
             self.log_dict(log_common_same_val)
             self.log(log_common_diff_val, dataloader_idx + 1)
@@ -686,6 +722,7 @@ def test_logging_results_with_no_dataloader_idx(tmp_path):
             )
             self.log_dict(log_key_dl0 if dataloader_idx == 0 else log_key_dl1, add_dataloader_idx=False)
 
+        @override
         def test_dataloader(self):
             return [torch.utils.data.DataLoader(RandomDataset(32, 64)) for _ in range(num_dataloaders)]
 
@@ -713,15 +750,18 @@ def test_logging_multi_dataloader_on_epoch_end(mock_log_metrics, tmp_path):
     class CustomBoringModel(BoringModel):
         outputs = [[], []]
 
+        @override
         def test_step(self, batch, batch_idx, dataloader_idx):
             value = dataloader_idx + 1
             self.log("foo", value)
             self.outputs[dataloader_idx].append(value)
             return value
 
+        @override
         def on_test_epoch_end(self):
             self.log("foobar", sum(sum(o) for o in self.outputs))
 
+        @override
         def test_dataloader(self):
             return [super().test_dataloader(), super().test_dataloader()]
 
@@ -934,15 +974,19 @@ def test_eval_step_logging(mock_log_metrics, tmp_path, num_dataloaders):
     """Test that eval step during fit/validate/test is updated correctly."""
 
     class CustomBoringModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx=None):
             self.log(f"val_log_{self.trainer.state.fn.value}", batch_idx, on_step=True, on_epoch=False)
 
+        @override
         def test_step(self, batch, batch_idx, dataloader_idx=None):
             self.log("test_log", batch_idx, on_step=True, on_epoch=False)
 
+        @override
         def val_dataloader(self):
             return [super().val_dataloader()] * num_dataloaders
 
+        @override
         def test_dataloader(self):
             return [super().test_dataloader()] * num_dataloaders
 

--- a/tests/tests_pytorch/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/tests_pytorch/trainer/logging_/test_eval_loop_logging.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Test logging in the evaluation loop."""
 
-from typing_extensions import override
 import collections
 import itertools
 import os
@@ -26,6 +25,7 @@ import numpy as np
 import pytest
 import torch
 from torch import Tensor
+from typing_extensions import override
 
 from lightning.pytorch import Trainer, callbacks
 from lightning.pytorch.demos.boring_classes import BoringModel, RandomDataset

--- a/tests/tests_pytorch/trainer/logging_/test_logger_connector.py
+++ b/tests/tests_pytorch/trainer/logging_/test_logger_connector.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import operator
 from functools import partial
 from unittest import mock
@@ -23,6 +22,7 @@ from lightning_utilities.core.imports import compare_version
 from torch.utils.data import DataLoader
 from torchmetrics import Accuracy, MeanAbsoluteError, MeanSquaredError, MetricCollection
 from torchmetrics import AveragePrecision as AvgPre
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule
 from lightning.pytorch.callbacks.callback import Callback

--- a/tests/tests_pytorch/trainer/logging_/test_logger_connector.py
+++ b/tests/tests_pytorch/trainer/logging_/test_logger_connector.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import operator
 from functools import partial
 from unittest import mock
@@ -266,10 +267,12 @@ def test_auto_add_dataloader_idx(tmp_path, add_dataloader_idx):
     """Test that auto_add_dataloader_idx argument works."""
 
     class TestModel(BoringModel):
+        @override
         def val_dataloader(self):
             dl = super().val_dataloader()
             return [dl, dl]
 
+        @override
         def validation_step(self, *args, **kwargs):
             output = super().validation_step(*args[:-1], **kwargs)
             name = "val_loss" if add_dataloader_idx else f"val_loss_custom_naming_{args[-1]}"
@@ -307,6 +310,7 @@ def test_metrics_reset(tmp_path):
             ap.reset = mock.Mock(side_effect=ap.reset)
             return acc, ap
 
+        @override
         def setup(self, stage):
             fn = stage.value
             if fn == "fit":
@@ -320,6 +324,7 @@ def test_metrics_reset(tmp_path):
                 self.add_module(f"acc_{fn}_{stage}", acc)
                 self.add_module(f"ap_{fn}_{stage}", ap)
 
+        @override
         def forward(self, x):
             return self.layer(x)
 
@@ -347,28 +352,35 @@ def test_metrics_reset(tmp_path):
 
             return loss
 
+        @override
         def training_step(self, batch, batch_idx, *args, **kwargs):
             return self._step(batch)
 
+        @override
         def validation_step(self, batch, batch_idx, *args, **kwargs):
             if self.trainer.sanity_checking:
                 return None
             return self._step(batch)
 
+        @override
         def test_step(self, batch, batch_idx, *args, **kwargs):
             return self._step(batch)
 
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
             return [optimizer], [lr_scheduler]
 
+        @override
         def train_dataloader(self):
             return DataLoader(RandomDataset(32, 64))
 
+        @override
         def val_dataloader(self):
             return DataLoader(RandomDataset(32, 64))
 
+        @override
         def test_dataloader(self):
             return DataLoader(RandomDataset(32, 64))
 
@@ -442,6 +454,7 @@ def test_metriccollection_compute_groups(tmp_path, compute_groups):
             )
             self.layer = torch.nn.Linear(32, 10)
 
+        @override
         def training_step(self, batch):
             self.metrics(torch.rand(10, 10).softmax(-1), torch.randint(0, 10, (10,)))
             self.metrics._is_currently_logging = True
@@ -449,12 +462,15 @@ def test_metriccollection_compute_groups(tmp_path, compute_groups):
             self.metrics._is_currently_logging = False
             return self.layer(batch).sum()
 
+        @override
         def train_dataloader(self):
             return DataLoader(RandomDataset(32, 64))
 
+        @override
         def configure_optimizers(self):
             return torch.optim.SGD(self.parameters(), lr=0.1)
 
+        @override
         def on_train_epoch_end(self) -> None:
             self.metrics.wrapped_assertion_calls.call_count == 2
             self.metrics.wrapped_assertion_calls.reset_mock()
@@ -572,6 +588,7 @@ def test_result_collection_on_tensor_with_mean_reduction():
 @pytest.mark.parametrize("logger", [False, True])
 def test_logged_metrics_has_logged_epoch_value(tmp_path, logger):
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             self.log("epoch", -batch_idx, logger=True)
             return super().training_step(batch, batch_idx)

--- a/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
+++ b/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Test logging in the training loop."""
 
+from typing_extensions import override
 import collections
 import itertools
 from re import escape
@@ -42,6 +43,7 @@ def test__training_step__log(tmp_path):
     """Tests that only training_step can be used."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             out = super().training_step(batch, batch_idx)
             loss = out["loss"]
@@ -105,6 +107,7 @@ def test__training_step__log(tmp_path):
 
 def test__training_step__epoch_end__log(tmp_path):
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             out = super().training_step(batch, batch_idx)
             loss = out["loss"]
@@ -112,6 +115,7 @@ def test__training_step__epoch_end__log(tmp_path):
             self.log_dict({"a1": loss, "a2": loss})
             return out
 
+        @override
         def on_train_epoch_end(self):
             self.log("b1", torch.tensor(1.0))
             self.log("b", torch.tensor(2.0), on_epoch=True, prog_bar=True, logger=True)
@@ -148,11 +152,13 @@ def test__training_step__log_max_reduce_fx(tmp_path, batches, fx, result):
     """Tests that log works correctly with different tensor types."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             acc = self.step(batch[0])
             self.log("foo", torch.tensor(batch_idx, dtype=torch.long), on_step=False, on_epoch=True, reduce_fx=fx)
             return acc
 
+        @override
         def validation_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.log("bar", torch.tensor(batch_idx).float(), on_step=False, on_epoch=True, reduce_fx=fx)
@@ -175,6 +181,7 @@ def test__training_step__log_max_reduce_fx(tmp_path, batches, fx, result):
 
 def test_different_batch_types_for_sizing(tmp_path):
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             assert isinstance(batch, dict)
             a = batch["a"]
@@ -182,15 +189,18 @@ def test_different_batch_types_for_sizing(tmp_path):
             self.log("a", 2, on_step=True, on_epoch=True)
             return acc
 
+        @override
         def validation_step(self, batch, batch_idx):
             assert isinstance(batch, dict)
             loss = self.step(batch["a"])
             self.log("n", 3, on_step=True, on_epoch=True)
             return {"x": loss}
 
+        @override
         def train_dataloader(self):
             return torch.utils.data.DataLoader(RandomDictDataset(32, 64), batch_size=32)
 
+        @override
         def val_dataloader(self):
             return torch.utils.data.DataLoader(RandomDictDataset(32, 64), batch_size=32)
 
@@ -234,24 +244,29 @@ def test_log_works_in_train_callback(tmp_path):
                 self.logged_arguments[fx] = {"on_step": on_step, "on_epoch": on_epoch, "prog_bar": prog_bar}
                 self.count += 1
 
+        @override
         def on_train_start(self, _, pl_module):
             self.make_logging(pl_module, "on_train_start", on_steps=[False], on_epochs=[True], prob_bars=self.choices)
 
+        @override
         def on_train_epoch_start(self, _, pl_module):
             self.make_logging(
                 pl_module, "on_train_epoch_start", on_steps=[False], on_epochs=[True], prob_bars=self.choices
             )
 
+        @override
         def on_train_batch_start(self, _, pl_module, *__):
             self.make_logging(
                 pl_module, "on_train_batch_start", on_steps=self.choices, on_epochs=self.choices, prob_bars=self.choices
             )
 
+        @override
         def on_train_batch_end(self, _, pl_module, *__):
             self.make_logging(
                 pl_module, "on_train_batch_end", on_steps=self.choices, on_epochs=self.choices, prob_bars=self.choices
             )
 
+        @override
         def on_train_epoch_end(self, _, pl_module):
             self.make_logging(
                 pl_module, "on_train_epoch_end", on_steps=[False], on_epochs=[True], prob_bars=self.choices
@@ -260,6 +275,7 @@ def test_log_works_in_train_callback(tmp_path):
     class TestModel(BoringModel):
         seen_losses = []
 
+        @override
         def training_step(self, batch, batch_idx):
             loss = super().training_step(batch, batch_idx)["loss"]
             self.seen_losses.append(loss)
@@ -319,6 +335,7 @@ class LoggingSyncDistModel(BoringModel):
     def rank(self) -> int:
         return self.trainer.global_rank
 
+    @override
     def training_step(self, batch, batch_idx):
         value = self.fake_result + self.rank
         self.log("foo", value, on_step=True, on_epoch=False, sync_dist=True, reduce_fx="sum")
@@ -335,6 +352,7 @@ class LoggingSyncDistModel(BoringModel):
         self.log("foo_11", batch_idx + self.rank, on_step=True, on_epoch=True, sync_dist=True, reduce_fx="mean")
         return super().training_step(batch, batch_idx)
 
+    @override
     def validation_step(self, batch, batch_idx):
         self.log("bar", self.fake_result, on_step=False, on_epoch=True, sync_dist=True, reduce_fx="sum")
         self.log("bar_2", self.fake_result, on_step=False, on_epoch=True, sync_dist=True, reduce_fx="mean")
@@ -392,12 +410,14 @@ def test_logging_sync_dist_true_ddp(tmp_path):
     """Tests to ensure that the sync_dist flag works with ddp."""
 
     class TestLoggingSyncDistModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             acc = self.step(batch[0])
             self.log("foo", 1, on_step=False, on_epoch=True, sync_dist=True, reduce_fx="SUM")
             self.log("cho", acc, on_step=False, on_epoch=True)
             return acc
 
+        @override
         def validation_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.log("bar", 2, on_step=False, on_epoch=True, sync_dist=True, reduce_fx="AVG")
@@ -424,10 +444,12 @@ def test_logging_sync_dist_true_ddp(tmp_path):
 
 def test_progress_bar_metrics_contains_values_on_train_epoch_end(tmp_path: str):
     class TestModel(BoringModel):
+        @override
         def training_step(self, *args):
             self.log("foo", torch.tensor(self.current_epoch), on_step=False, on_epoch=True, prog_bar=True)
             return super().training_step(*args)
 
+        @override
         def on_train_epoch_end(self, *_):
             self.log(
                 "foo_2", torch.tensor(self.current_epoch), prog_bar=True, on_epoch=True, sync_dist=True, reduce_fx="sum"
@@ -435,11 +457,13 @@ def test_progress_bar_metrics_contains_values_on_train_epoch_end(tmp_path: str):
             self.on_train_epoch_end_called = True
 
     class TestProgressBar(TQDMProgressBar):
+        @override
         def get_metrics(self, trainer: Trainer, model: LightningModule):
             items = super().get_metrics(trainer, model)
             items.pop("v_num", None)
             return items
 
+        @override
         def on_train_end(self, trainer: Trainer, model: LightningModule):
             metrics = self.get_metrics(trainer, model)
             assert metrics["foo"] == self.trainer.current_epoch - 1
@@ -467,15 +491,19 @@ def test_logging_in_callbacks_with_log_function(tmp_path):
     """Tests ensure self.log can be used directly in callbacks."""
 
     class LoggingCallback(callbacks.Callback):
+        @override
         def on_train_start(self, trainer, pl_module):
             self.log("on_train_start", 1)
 
+        @override
         def on_train_epoch_start(self, trainer, pl_module):
             self.log("on_train_epoch_start", 2)
 
+        @override
         def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
             self.log("on_train_batch_end", 3)
 
+        @override
         def on_train_epoch_end(self, trainer, pl_module):
             self.log("on_train_epoch_end", 5)
 
@@ -513,11 +541,13 @@ def test_metric_are_properly_reduced(tmp_path, accelerator):
             super().__init__()
             self.val_acc = Accuracy(task="multiclass", num_classes=2) if _TM_GE_0_11 else Accuracy()
 
+        @override
         def training_step(self, batch, batch_idx):
             output = super().training_step(batch, batch_idx)
             self.log("train_loss", output["loss"])
             return output
 
+        @override
         def validation_step(self, batch, batch_idx):
             preds = torch.tensor([[0.9, 0.1]], device=self.device)
             targets = torch.tensor([1], device=self.device)
@@ -552,6 +582,7 @@ def test_metric_are_properly_reduced(tmp_path, accelerator):
 )
 def test_log_invalid_raises(tmp_path, value):
     class TestModel(BoringModel):
+        @override
         def training_step(self, *args):
             self.log("foo", value)
 
@@ -566,6 +597,7 @@ def test_log_tensor_and_clone_no_torch_warning(tmp_path):
     """Regression test for issue https://github.com/Lightning-AI/pytorch-lightning/issues/14594."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, *args):
             self.log("foo", torch.tensor(1))
             return super().training_step(*args)
@@ -579,6 +611,7 @@ def test_log_tensor_and_clone_no_torch_warning(tmp_path):
 
 def test_logging_raises(tmp_path):
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             self.log("foo/dataloader_idx_0", -1)
 
@@ -597,6 +630,7 @@ def test_logging_raises(tmp_path):
         trainer.fit(model)
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             self.log("foo", Accuracy(task="multiclass", num_classes=2) if _TM_GE_0_11 else Accuracy())
 
@@ -609,6 +643,7 @@ def test_logging_raises(tmp_path):
             super().__init__()
             self.bar = Accuracy(task="multiclass", num_classes=2) if _TM_GE_0_11 else Accuracy()
 
+        @override
         def training_step(self, batch, batch_idx):
             self.log("foo", Accuracy(task="multiclass", num_classes=2) if _TM_GE_0_11 else Accuracy())
 
@@ -620,6 +655,7 @@ def test_logging_raises(tmp_path):
         trainer.fit(model)
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, *args):
             self.log("foo", -1, prog_bar=False)
             self.log("foo", -1, prog_bar=True)
@@ -630,6 +666,7 @@ def test_logging_raises(tmp_path):
         trainer.fit(model)
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, *args):
             self.log("foo", -1, reduce_fx=torch.argmax)
             return super().training_step(*args)
@@ -639,6 +676,7 @@ def test_logging_raises(tmp_path):
         trainer.fit(model)
 
     class TestModel(BoringModel):
+        @override
         def on_train_start(self):
             self.log("foo", torch.tensor([1.0, 2.0]))
 
@@ -649,12 +687,14 @@ def test_logging_raises(tmp_path):
 
 def test_sanity_metrics_are_reset(tmp_path):
     class TestModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx):
             output = super().validation_step(batch, batch_idx)
             if self.trainer.sanity_checking:
                 self.log("val_loss", output["x"], prog_bar=True, logger=True)
             return output
 
+        @override
         def training_step(self, batch, batch_idx):
             loss = super().training_step(batch, batch_idx)["loss"]
             if batch_idx == 0:
@@ -674,25 +714,31 @@ def test_sanity_metrics_are_reset(tmp_path):
 
 def test_on_epoch_logging_with_sum_and_on_batch_start(tmp_path):
     class TestModel(BoringModel):
+        @override
         def on_train_epoch_end(self):
             self.log("on_train_epoch_end", 3.0, reduce_fx="mean")
             assert self.trainer._results["on_train_epoch_end.on_train_epoch_end"].value == 3.0
             assert all(v == 3 for v in self.trainer.callback_metrics.values())
 
+        @override
         def on_validation_epoch_end(self):
             self.log("on_validation_epoch_end", 3.0, reduce_fx="mean")
             assert self.trainer._results["on_validation_epoch_end.on_validation_epoch_end"].value == 3.0
             assert all(v == 3 for v in self.trainer.callback_metrics.values())
 
+        @override
         def on_train_batch_start(self, *_):
             self.log("on_train_batch_start", 1.0, on_step=False, on_epoch=True, reduce_fx="sum")
 
+        @override
         def on_train_batch_end(self, *_):
             self.log("on_train_batch_end", 1.0, on_step=False, on_epoch=True, reduce_fx="sum")
 
+        @override
         def on_validation_batch_start(self, *_):
             self.log("on_validation_batch_start", 1.0, reduce_fx="sum")
 
+        @override
         def on_validation_batch_end(self, *_):
             self.log("on_validation_batch_end", 1.0, reduce_fx="sum")
 
@@ -715,6 +761,7 @@ def test_log_metrics_epoch_step_values(mock_log_metrics, tmp_path):
     """Tests the default epoch and step values logged."""
 
     class MyModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             self.log("foo", 0.0, on_step=True, on_epoch=True)
             return super().training_step(batch, batch_idx)
@@ -748,6 +795,7 @@ def test_log_on_train_start(mock_log_metrics, tmp_path):
     """Tests that logged metrics on_train_start get reset after the first epoch."""
 
     class MyModel(BoringModel):
+        @override
         def on_train_start(self):
             self.log("foo", 123)
 

--- a/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
+++ b/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Test logging in the training loop."""
 
-from typing_extensions import override
 import collections
 import itertools
 from re import escape
@@ -27,6 +26,7 @@ from lightning_utilities.test.warning import no_warning_call
 from torch import Tensor
 from torch.utils.data import DataLoader
 from torchmetrics import Accuracy
+from typing_extensions import override
 
 from lightning.pytorch import Trainer, callbacks
 from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint, TQDMProgressBar

--- a/tests/tests_pytorch/trainer/optimization/test_backward_calls.py
+++ b/tests/tests_pytorch/trainer/optimization/test_backward_calls.py
@@ -1,8 +1,8 @@
-from typing_extensions import override
 from unittest.mock import patch
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/trainer/optimization/test_backward_calls.py
+++ b/tests/tests_pytorch/trainer/optimization/test_backward_calls.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 from unittest.mock import patch
 
 import pytest
@@ -44,6 +45,7 @@ def test_backward_count_with_closure(torch_backward, tmp_path):
     """Using a closure (e.g. with LBFGS) should lead to no extra backward calls."""
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             return torch.optim.LBFGS(self.parameters(), lr=0.1)
 

--- a/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
+++ b/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import collections
 import contextlib
 from copy import deepcopy
@@ -38,6 +39,7 @@ class ManualOptModel(BoringModel):
         super().__init__()
         self.automatic_optimization = False
 
+    @override
     def training_step(self, batch, batch_idx):
         opt_a, opt_b = self.optimizers()
 
@@ -62,6 +64,7 @@ class ManualOptModel(BoringModel):
 
         return loss_2
 
+    @override
     def configure_optimizers(self):
         optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
         optimizer_2 = torch.optim.SGD(self.layer.parameters(), lr=0.1)
@@ -104,6 +107,7 @@ def test_multiple_optimizers_manual_call_counts(tmp_path, kwargs):
 
 def test_multiple_optimizers_manual_log(tmp_path):
     class TestModel(ManualOptModel):
+        @override
         def training_step(self, batch, batch_idx):
             loss_2 = super().training_step(batch, batch_idx)
             self.log("a", loss_2, on_epoch=True)
@@ -162,10 +166,12 @@ class ManualOptimizationExtendedModel(BoringModel):
     def should_update(self):
         return self.count % 2 == 0
 
+    @override
     def on_train_batch_start(self, batch, batch_idx):
         self.called["on_train_batch_start"] += 1
         self.weight_before = self.layer.weight.clone()
 
+    @override
     def training_step(self, batch, batch_idx):
         self.called["training_step"] += 1
         opt = self.optimizers()
@@ -180,6 +186,7 @@ class ManualOptimizationExtendedModel(BoringModel):
 
         return loss.detach() if self.detach else loss
 
+    @override
     def on_train_batch_end(self, *_):
         self.called["on_train_batch_end"] += 1
         after_before = self.layer.weight.clone()
@@ -198,6 +205,7 @@ class ManualOptimizationExtendedModel(BoringModel):
         assert_emtpy_grad(self.layer.weight.grad)
         self.count += 1
 
+    @override
     def on_train_end(self):
         assert self.called["training_step"] == 10
         assert self.called["on_train_batch_start"] == 10
@@ -251,10 +259,12 @@ def test_manual_optimization_and_accumulated_gradient(tmp_path):
         def has_gradient(self):
             return self.layer.weight.grad is not None
 
+        @override
         def on_train_batch_start(self, batch, batch_idx):
             self.called["on_train_batch_start"] += 1
             self.weight_before = self.layer.weight.clone()
 
+        @override
         def training_step(self, batch, batch_idx):
             self.called["training_step"] += 1
             opt = self.optimizers()
@@ -270,6 +280,7 @@ def test_manual_optimization_and_accumulated_gradient(tmp_path):
 
             return loss.detach() if self.detach else loss
 
+        @override
         def on_train_batch_end(self, *_):
             self.called["on_train_batch_end"] += 1
             after_before = self.layer.weight.clone()
@@ -285,6 +296,7 @@ def test_manual_optimization_and_accumulated_gradient(tmp_path):
                         assert torch.sum(self.layer.weight.grad) != 0
             self.count += 1
 
+        @override
         def on_train_epoch_end(self, *_, **__):
             assert self.called["training_step"] == 20
             assert self.called["on_train_batch_start"] == 20
@@ -310,15 +322,19 @@ class CustomMapping(collections.abc.Mapping):
     def __init__(self, *args, **kwargs):
         self._store = dict(*args, **kwargs)
 
+    @override
     def __getitem__(self, key):
         return self._store[key]
 
+    @override
     def __iter__(self):
         return iter(self._store)
 
+    @override
     def __len__(self):
         return len(self._store)
 
+    @override
     def __repr__(self):
         return f"{self.__class__.__name__}({self._store})"
 
@@ -336,6 +352,7 @@ def test_multiple_optimizers_step(tmp_path, dicttype):
     """Tests that `step` works with several optimizers."""
 
     class TestModel(ManualOptModel):
+        @override
         def training_step(self, batch, batch_idx):
             opt_a, opt_b = self.optimizers()
             x = batch[0]
@@ -365,6 +382,7 @@ def test_multiple_optimizers_step(tmp_path, dicttype):
             return dicttype(loss1=loss_1.detach(), loss2=loss_2.detach())
 
         # sister test: tests/plugins/test_amp_plugins.py::test_amp_gradient_unscale
+        @override
         def on_after_backward(self) -> None:
             # check grads are scaled
             scale = self.trainer.precision_plugin.scaler.get_scale()
@@ -384,6 +402,7 @@ def test_multiple_optimizers_step(tmp_path, dicttype):
             for actual, expected in zip(grads, self.original_grads):
                 torch.testing.assert_close(actual, expected)
 
+        @override
         def on_before_optimizer_step(self, optimizer, *_):
             self.check_grads_unscaled(optimizer)
 
@@ -419,6 +438,7 @@ def test_step_with_optimizer_closure(tmp_path):
             super().__init__()
             self.automatic_optimization = False
 
+        @override
         def training_step(self, batch, batch_idx):
             # make sure there are no grads
             assert_emtpy_grad(self.layer.weight.grad)
@@ -479,6 +499,7 @@ def test_step_with_optimizer_closure_2(tmp_path):
             super().__init__()
             self.automatic_optimization = False
 
+        @override
         def training_step(self, batch, batch_idx):
             opt = self.optimizers()
             x = batch[0]
@@ -520,10 +541,12 @@ def test_step_with_optimizer_closure_with_different_frequencies(mock_sgd_step, m
             super().__init__()
             self.automatic_optimization = False
 
+        @override
         def on_train_start(self) -> None:
             mock_sgd_step.reset_mock()
             mock_adam_step.reset_mock()
 
+        @override
         def training_step(self, batch, batch_idx):
             # emulate gans training
             opt_gen, opt_dis = self.optimizers()
@@ -561,6 +584,7 @@ def test_step_with_optimizer_closure_with_different_frequencies(mock_sgd_step, m
                 opt_dis.step(closure=dis_closure)
                 opt_dis.zero_grad()
 
+        @override
         def configure_optimizers(self):
             optimizer_gen = torch.optim.SGD(self.layer.parameters(), lr=0.1)
             optimizer_dis = torch.optim.Adam(self.layer.parameters(), lr=0.001)
@@ -601,6 +625,7 @@ class TesManualOptimizationDDPModel(BoringModel):
         torch_distrib.all_reduce(self.layer.weight.grad.data, async_op=False)
         return True
 
+    @override
     def training_step(self, batch, batch_idx):
         # emulate gans training
         opt_gen, opt_dis = self.optimizers()
@@ -651,11 +676,13 @@ class TesManualOptimizationDDPModel(BoringModel):
         if make_dis_optimizer_step:
             opt_dis.step(closure=dis_closure)
 
+    @override
     def configure_optimizers(self):
         optimizer_gen = torch.optim.SGD(self.layer.parameters(), lr=0.1)
         optimizer_dis = torch.optim.Adam(self.layer.parameters(), lr=0.001)
         return [optimizer_gen, optimizer_dis]
 
+    @override
     def on_train_start(self):
         # this is done here instead of in the calling function due to `spawn`
         sgd, adam = self.optimizers()
@@ -664,6 +691,7 @@ class TesManualOptimizationDDPModel(BoringModel):
         self.adam_step_patch = patch.object(adam, "step", wraps=adam.step)
         self.adam_step_mock = self.adam_step_patch.start()
 
+    @override
     def on_train_end(self):
         self.sgd_step_patch.stop()
         assert self.sgd_step_mock.call_count == 4
@@ -710,6 +738,7 @@ def test_step_with_optimizer_closure_with_different_frequencies_ddp_spawn(tmp_pa
 
 
 class TestManualOptimizationDDPModelToggleModel(TesManualOptimizationDDPModel):
+    @override
     def training_step(self, batch, batch_idx):
         # emulate gans training
         opt_gen, opt_dis = self.optimizers()
@@ -777,11 +806,13 @@ def test_lr_schedulers(tmp_path):
             super().__init__()
             self.automatic_optimization = False
 
+        @override
         def training_step(self, batch, batch_idx):
             scheduler_1, scheduler_2 = self.lr_schedulers()
             assert scheduler_1 is self.scheduler_1
             assert scheduler_2 is self.scheduler_2
 
+        @override
         def configure_optimizers(self):
             optimizer_1 = torch.optim.SGD(self.parameters(), lr=0.1)
             optimizer_2 = torch.optim.SGD(self.parameters(), lr=0.1)
@@ -806,10 +837,12 @@ def test_lr_schedulers_reduce_lr_on_plateau(tmp_path, scheduler_as_dict):
             self.scheduler_as_dict = scheduler_as_dict
             self.automatic_optimization = False
 
+        @override
         def on_train_epoch_end(self):
             scheduler = self.lr_schedulers()
             scheduler.step(torch.tensor(0.0))
 
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD(self.parameters(), lr=0.1)
 
@@ -862,6 +895,7 @@ def test_multiple_optimizers_logging(precision, tmp_path):
             super().__init__()
             self.automatic_optimization = False
 
+        @override
         def training_step(self, batch, batch_idx):
             optimizer1, optimizer2 = self.optimizers()
             # Discriminator.
@@ -886,6 +920,7 @@ def test_multiple_optimizers_logging(precision, tmp_path):
             optimizer2.step()
             self.untoggle_optimizer(optimizer2)
 
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
             optimizer_2 = torch.optim.SGD(self.layer.parameters(), lr=0.1)
@@ -931,6 +966,7 @@ def test_manual_optimization_with_non_pytorch_scheduler(automatic_optimization):
             super().__init__()
             self.automatic_optimization = automatic_optimization
 
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
             scheduler = IncompatibleScheduler(optimizer)

--- a/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
+++ b/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import collections
 import contextlib
 from copy import deepcopy
@@ -22,6 +21,7 @@ import pytest
 import torch
 import torch.distributed as torch_distrib
 import torch.nn.functional as F
+from typing_extensions import override
 
 from lightning.fabric.utilities.exceptions import MisconfigurationException
 from lightning.pytorch import Trainer, seed_everything

--- a/tests/tests_pytorch/trainer/optimization/test_multiple_optimizers.py
+++ b/tests/tests_pytorch/trainer/optimization/test_multiple_optimizers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests to ensure that the behaviours related to multiple optimizers works."""
 
+from typing_extensions import override
 import pytest
 import torch
 
@@ -21,6 +22,7 @@ from lightning.pytorch.demos.boring_classes import BoringModel
 
 
 class MultiOptModel(BoringModel):
+    @override
     def configure_optimizers(self):
         opt_a = torch.optim.SGD(self.layer.parameters(), lr=0.001)
         opt_b = torch.optim.SGD(self.layer.parameters(), lr=0.001)
@@ -31,6 +33,7 @@ def test_multiple_optimizers_automatic_optimization_raises():
     """Test that multiple optimizers in automatic optimization is not allowed."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx, optimizer_idx):
             return super().training_step(batch, batch_idx)
 
@@ -42,6 +45,7 @@ def test_multiple_optimizers_automatic_optimization_raises():
         trainer.fit(model)
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             return torch.optim.Adam(self.parameters()), torch.optim.Adam(self.parameters())
 
@@ -59,6 +63,7 @@ def test_multiple_optimizers_manual(tmp_path):
             super().__init__()
             self.automatic_optimization = False
 
+        @override
         def training_step(self, batch, batch_idx):
             self.training_step_called = True
 

--- a/tests/tests_pytorch/trainer/optimization/test_multiple_optimizers.py
+++ b/tests/tests_pytorch/trainer/optimization/test_multiple_optimizers.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Tests to ensure that the behaviours related to multiple optimizers works."""
 
-from typing_extensions import override
 import pytest
 import torch
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/trainer/optimization/test_optimizers.py
+++ b/tests/tests_pytorch/trainer/optimization/test_optimizers.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from unittest import mock
 from unittest.mock import call
 
@@ -53,6 +54,7 @@ def test_multi_optimizer_with_scheduling(tmp_path):
     class Model(BoringModel):
         init_lr = 5e-4
 
+        @override
         def training_step(self, batch, batch_idx):
             opt1, opt2 = self.optimizers()
             loss = self.loss(self.step(batch))
@@ -62,11 +64,13 @@ def test_multi_optimizer_with_scheduling(tmp_path):
             opt1.step()
             opt2.step()
 
+        @override
         def on_train_epoch_end(self):
             scheduler1, scheduler2 = self.lr_schedulers()
             scheduler1.step()
             scheduler2.step()
 
+        @override
         def configure_optimizers(self):
             optimizer1 = optim.Adam(self.parameters(), lr=self.init_lr)
             optimizer2 = optim.Adam(self.parameters(), lr=self.init_lr)
@@ -137,10 +141,12 @@ def test_scheduler_initialized_with_custom_reduceonplateau():
 
 def test_reducelronplateau_scheduling(tmp_path):
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             self.log("foo", batch_idx)
             return super().training_step(batch, batch_idx)
 
+        @override
         def configure_optimizers(self):
             optimizer = optim.Adam(self.parameters())
             return {
@@ -255,6 +261,7 @@ def test_configure_optimizer_from_dict(tmp_path):
     """Tests if `configure_optimizer` method could return a dictionary with `optimizer` field only."""
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             return {"optimizer": optim.SGD(params=self.parameters(), lr=1e-03)}
 
@@ -268,6 +275,7 @@ def test_init_optimizers_during_evaluation_and_prediction(tmp_path, fn):
     """Test that optimizers is an empty list during evaluation and prediction."""
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             optimizer1 = optim.Adam(self.parameters(), lr=0.1)
             optimizer2 = optim.Adam(self.parameters(), lr=0.1)
@@ -402,6 +410,7 @@ def test_invalid_optimizer_in_scheduler(tmp_path):
     """Test exception when optimizer attached to lr_schedulers wasn't returned."""
 
     class InvalidOptimizerModel(BoringModel):
+        @override
         def configure_optimizers(self):
             opt1 = optim.SGD(self.layer.parameters(), lr=0.1)
             opt2 = optim.SGD(self.layer.parameters(), lr=0.1)
@@ -418,6 +427,7 @@ def test_invalid_optimizer_dict_raises(tmp_path):
     """Test exception when lr_scheduler dict has no scheduler."""
 
     class DummyModel(BoringModel):
+        @override
         def configure_optimizers(self):
             return [{"optimizer": optim.Adam(self.parameters())}, optim.Adam(self.parameters())]
 
@@ -432,10 +442,12 @@ def test_optimizer_state_on_device(tmp_path):
     """Test that optimizers that create state initially at instantiation still end up with the state on the GPU."""
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             # Adagrad creates state tensors immediately, model is not yet on GPU.
             return optim.Adagrad(self.parameters())
 
+        @override
         def on_train_start(self, *args, **kwargs):
             opt = self.optimizers()
             _, state = next(iter(opt.state.items()))
@@ -488,6 +500,7 @@ def test_lr_scheduler_state_updated_before_saving(tmp_path, every_n_train_steps,
     )
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD(self.parameters(), lr=lr)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=gamma)
@@ -496,6 +509,7 @@ def test_lr_scheduler_state_updated_before_saving(tmp_path, every_n_train_steps,
                 lr_scheduler_config["interval"] = "step"
             return [optimizer], [lr_scheduler_config]
 
+        @override
         def on_save_checkpoint(self, checkpoint):
             lr_scheduler_config = checkpoint["lr_schedulers"][0]
             # 2 batches ran. since the lr_scheduler_config interval is `step`, the step count should be 2
@@ -524,10 +538,12 @@ def test_plateau_scheduler_lr_step_interval_updated_after_saving(tmp_path, save_
     )
 
     class Model(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             self.log("foo", batch_idx)
             return super().training_step(batch, batch_idx)
 
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.Adam(self.parameters())
 
@@ -538,6 +554,7 @@ def test_plateau_scheduler_lr_step_interval_updated_after_saving(tmp_path, save_
             lr_scheduler_config_2 = {"scheduler": lr_scheduler2, "interval": "step"}
             return [optimizer], [lr_scheduler_config_1, lr_scheduler_config_2]
 
+        @override
         def on_save_checkpoint(self, checkpoint):
             lr_scheduler_config_1 = checkpoint["lr_schedulers"][0]
             last_epoch = lr_scheduler_config_1["last_epoch"]
@@ -567,6 +584,7 @@ def test_lr_scheduler_step_hook(tmp_path):
         def load_state_dict(self, state_dict): ...
 
     class CustomBoringModel(BoringModel):
+        @override
         def lr_scheduler_step(self, scheduler: int, metric):
             # step-level
             if isinstance(scheduler, torch.optim.lr_scheduler.StepLR):
@@ -575,6 +593,7 @@ def test_lr_scheduler_step_hook(tmp_path):
             elif isinstance(scheduler, CustomEpochScheduler):
                 scheduler.step(epoch=self.current_epoch)
 
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD(self.layer.parameters(), lr=1e-2)
             lr_scheduler1 = {"scheduler": torch.optim.lr_scheduler.StepLR(optimizer, step_size=1), "interval": "step"}
@@ -613,6 +632,7 @@ def test_invalid_scheduler_missing_state_dict():
         def step(self): ...
 
     class CustomBoringModel(BoringModel):
+        @override
         def configure_optimizers(self):
             opt = torch.optim.SGD(self.parameters(), lr=1e-2)
             lr_scheduler = CustomScheduler(opt)
@@ -640,6 +660,7 @@ def test_invalid_lr_scheduler_with_custom_step_method(override):
         def load_state_dict(self, state_dict): ...
 
     class CustomBoringModel(BoringModel):
+        @override
         def configure_optimizers(self):
             opt = torch.optim.SGD(self.parameters(), lr=1e-2)
             lr_scheduler = CustomScheduler(opt)

--- a/tests/tests_pytorch/trainer/optimization/test_optimizers.py
+++ b/tests/tests_pytorch/trainer/optimization/test_optimizers.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from unittest import mock
 from unittest.mock import call
 
 import pytest
 import torch
 from torch import optim
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint

--- a/tests/tests_pytorch/trainer/properties/test_estimated_stepping_batches.py
+++ b/tests/tests_pytorch/trainer/properties/test_estimated_stepping_batches.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import logging
 import os
 from unittest import mock
@@ -20,6 +19,7 @@ from unittest import mock
 import pytest
 import torch
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel, RandomIterableDataset

--- a/tests/tests_pytorch/trainer/properties/test_estimated_stepping_batches.py
+++ b/tests/tests_pytorch/trainer/properties/test_estimated_stepping_batches.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import logging
 import os
 from unittest import mock
@@ -144,6 +145,7 @@ def test_num_stepping_batches_with_tpu_single():
 
 
 class MultiprocessModel(BoringModel):
+    @override
     def on_train_start(self):
         assert self.trainer.estimated_stepping_batches == len(self.train_dataloader()) // self.trainer.world_size
 

--- a/tests/tests_pytorch/trainer/properties/test_get_model.py
+++ b/tests/tests_pytorch/trainer/properties/test_get_model.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import pytest
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/trainer/properties/test_get_model.py
+++ b/tests/tests_pytorch/trainer/properties/test_get_model.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import pytest
 
 from lightning.pytorch import Trainer
@@ -20,9 +21,11 @@ from tests_pytorch.helpers.runif import RunIf
 
 
 class TrainerGetModel(BoringModel):
+    @override
     def on_fit_start(self):
         assert self == self.trainer.lightning_module
 
+    @override
     def on_fit_end(self):
         assert self == self.trainer.lightning_module
 

--- a/tests/tests_pytorch/trainer/properties/test_log_dir.py
+++ b/tests/tests_pytorch/trainer/properties/test_log_dir.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import pytest
 
 from lightning.pytorch import Trainer
@@ -25,6 +26,7 @@ class TestModel(BoringModel):
         super().__init__()
         self.expected_log_dir = expected_log_dir
 
+    @override
     def training_step(self, *args, **kwargs):
         assert self.trainer.log_dir == self.expected_log_dir
         return super().training_step(*args, **kwargs)

--- a/tests/tests_pytorch/trainer/properties/test_log_dir.py
+++ b/tests/tests_pytorch/trainer/properties/test_log_dir.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import pytest
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint

--- a/tests/tests_pytorch/trainer/test_config_validator.py
+++ b/tests/tests_pytorch/trainer/test_config_validator.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from unittest.mock import Mock
 
 import pytest
@@ -97,6 +98,7 @@ def test_trainer_predict_verify_config(tmp_path, datamodule):
             super().__init__()
             self.layer = torch.nn.Linear(32, 2)
 
+        @override
         def forward(self, x):
             return self.layer(x)
 
@@ -105,9 +107,11 @@ def test_trainer_predict_verify_config(tmp_path, datamodule):
             super().__init__()
             self._dataloaders = dataloaders
 
+        @override
         def test_dataloader(self):
             return self._dataloaders
 
+        @override
         def predict_dataloader(self):
             return self._dataloaders
 

--- a/tests/tests_pytorch/trainer/test_config_validator.py
+++ b/tests/tests_pytorch/trainer/test_config_validator.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from unittest.mock import Mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel, RandomDataset

--- a/tests/tests_pytorch/trainer/test_dataloaders.py
+++ b/tests/tests_pytorch/trainer/test_dataloaders.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 from unittest.mock import Mock, call, patch
 
@@ -24,6 +23,7 @@ from torch.utils.data.dataloader import DataLoader
 from torch.utils.data.dataset import Dataset, IterableDataset
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import SequentialSampler
+from typing_extensions import override
 
 import lightning.pytorch
 from lightning.fabric.utilities.data import _auto_add_worker_init_fn, has_iterable_dataset

--- a/tests/tests_pytorch/trainer/test_dataloaders.py
+++ b/tests/tests_pytorch/trainer/test_dataloaders.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 from unittest.mock import Mock, call, patch
 
@@ -45,17 +46,21 @@ from tests_pytorch.helpers.runif import RunIf
 
 
 class MultiValDataLoaderBoringModel(BoringModel):
+    @override
     def val_dataloader(self):
         return [DataLoader(RandomDataset(32, 64)), DataLoader(RandomDataset(32, 64), batch_size=8)]
 
+    @override
     def validation_step(self, batch, batch_idx, dataloader_idx):
         return super().validation_step(batch, batch_idx)
 
 
 class MultiTestDataLoaderBoringModel(BoringModel):
+    @override
     def test_dataloader(self):
         return [DataLoader(RandomDataset(32, 64)), DataLoader(RandomDataset(32, 64), batch_size=8)]
 
+    @override
     def test_step(self, batch, batch_idx, dataloader_idx):
         return super().test_step(batch, batch_idx)
 
@@ -198,10 +203,12 @@ def test_dataloaders_passed_to_fn(tmp_path, ckpt_path, n):
 
 
 class DummyModel(BoringModel):
+    @override
     def training_step(self, batch, batch_idx):
         self.log("loss", self.global_step)
         return super().training_step(batch, batch_idx)
 
+    @override
     def on_validation_epoch_end(self):
         self.log("val_log", self.current_epoch)
 
@@ -216,21 +223,27 @@ class Counter(Callback):
         self.val_batches_seen = 0
         self.test_batches_seen = 0
 
+    @override
     def on_train_batch_start(self, *_):
         self.train_batches_seen += 1
 
+    @override
     def on_train_epoch_start(self, *_):
         self.train_epoch_count += 1
 
+    @override
     def on_validation_batch_start(self, *_):
         self.val_batches_seen += 1
 
+    @override
     def on_test_batch_start(self, *_):
         self.test_batches_seen += 1
 
+    @override
     def on_validation_epoch_start(self, *_):
         self.val_epoch_count += 1
 
+    @override
     def on_test_epoch_start(self, *_):
         self.test_epoch_count += 1
 
@@ -564,6 +577,7 @@ def test_warning_with_few_workers_multi_loader(_, tmp_path, ckpt_path, stage):
     """Test that a warning is emitted if the dataloader only has a few workers."""
 
     class CustomModel(MultiEvalDataLoaderModel):
+        @override
         def training_step(self, batch, batch_idx):
             return super().training_step(batch["a_b"][0], batch_idx)
 
@@ -596,6 +610,7 @@ class NumpyRandomDataset(Dataset):
     # this dataset uses numpy instead of torch to produce random numbers
     size = 16
 
+    @override
     def __getitem__(self, index):
         return numpy.random.randint(0, 100, 3)
 
@@ -639,11 +654,13 @@ class MultiProcessModel(BoringModel):
         super().__init__()
         self.batches_seen = []
 
+    @override
     def training_step(self, batch, batch_idx):
         self.batches_seen.append(batch)
         # the actual training step is not needed for the assertions below
         return super().training_step(torch.rand(1, 32, device=self.device), batch_idx)
 
+    @override
     def on_train_epoch_end(self):
         world_size = 2
         num_samples = NumpyRandomDataset.size
@@ -707,6 +724,7 @@ def test_warning_with_iterable_dataset_and_len(tmp_path):
     original_dataset = model.train_dataloader().dataset
 
     class IterableWithoutLen(IterableDataset):
+        @override
         def __iter__(self):
             return iter(original_dataset)
 
@@ -747,6 +765,7 @@ def test_iterable_dataset_stop_iteration_at_epoch_beginning(yield_at_all, tmp_pa
         def __init__(self, gen):
             self.gen = gen
 
+        @override
         def __iter__(self):
             return iter(self.gen())
 
@@ -777,18 +796,21 @@ class DistribSamplerCallback(Callback):
     def __init__(self, expected_seeds=(0, 0, 0)):
         self.expected_seed = expected_seeds
 
+    @override
     def on_train_start(self, trainer, pl_module):
         train_sampler = trainer.train_dataloader.sampler
         assert isinstance(train_sampler, DistributedSampler)
         assert train_sampler.shuffle
         assert train_sampler.seed == self.expected_seed[0]
 
+    @override
     def on_validation_start(self, trainer, pl_module):
         val_sampler = trainer.val_dataloaders.sampler
         assert isinstance(val_sampler, DistributedSampler)
         assert not val_sampler.shuffle
         assert val_sampler.seed == self.expected_seed[1]
 
+    @override
     def on_test_start(self, trainer, pl_module):
         test_sampler = trainer.test_dataloaders.sampler
         assert isinstance(test_sampler, DistributedSampler)
@@ -819,11 +841,13 @@ class TestModelUniqueDDPSampling(BoringModel):
         super().__init__()
         self.seen_samples = []
 
+    @override
     def training_step(self, batch, batch_idx):
         self.seen_samples.extend(batch.tolist())
         # the actual training step is not needed for the test
         return super().training_step(torch.rand(1, 32, device=self.device), batch_idx)
 
+    @override
     def on_train_end(self):
         seen_samples = self.all_gather(self.seen_samples)
         # The samples should be unique across all processes
@@ -851,6 +875,7 @@ def test_distributed_sampler_without_global_seed(tmp_path):
 
 
 class ModelWithDataLoaderDistributedSampler(BoringModel):
+    @override
     def train_dataloader(self):
         dataloader = super().train_dataloader()
         dist_sampler = DistributedSampler(dataloader.dataset, shuffle=True, seed=11)
@@ -884,6 +909,7 @@ def test_fit_multiple_train_loaders(tmp_path, mode, num_training_batches):
     """Integration test for multiple train iterables."""
 
     class CustomBoringModel(BoringModel):
+        @override
         def train_dataloader(self):
             loaders_a_b = [DataLoader(RandomDataset(32, 64)), DataLoader(RandomDataset(32, 16))]
             loaders_c_d_e = [
@@ -895,6 +921,7 @@ def test_fit_multiple_train_loaders(tmp_path, mode, num_training_batches):
             loaders = {"a_b": loaders_a_b, "c_d_e": loaders_c_d_e}
             return CombinedLoader(loaders, mode)
 
+        @override
         def training_step(self, batch, batch_idx):
             assert len(batch) == 2
             assert len(batch["a_b"]) == 2
@@ -920,9 +947,11 @@ def test_train_dataloader_not_implemented_error(tmp_path, check_interval, datalo
     """Test not_implemented_error train data loader (e.g. IterableDataset)"""
 
     class CustomBoringModel(BoringModel):
+        @override
         def train_dataloader(self):
             return dataloader_wrapper(DataLoader(RandomDataset(32, 64)))
 
+        @override
         def val_dataloader(self):
             return dataloader_wrapper(DataLoader(RandomDataset(32, 64)))
 
@@ -1043,10 +1072,12 @@ def test_dataloaders_load_every_n_epochs_infrequent_val(
     sanity_val_step_epochs, val_step_epochs = [], []
 
     class TestModel(BoringModel):
+        @override
         def train_dataloader(self):
             train_reload_epochs.append(self.current_epoch)
             return super().train_dataloader()
 
+        @override
         def val_dataloader(self):
             if self.trainer.sanity_checking:
                 sanity_val_check_epochs.append(self.current_epoch)
@@ -1054,6 +1085,7 @@ def test_dataloaders_load_every_n_epochs_infrequent_val(
                 val_reload_epochs.append(self.current_epoch)
             return super().val_dataloader()
 
+        @override
         def validation_step(self, *args, **kwargs):
             if self.trainer.sanity_checking:
                 sanity_val_step_epochs.append(self.current_epoch)
@@ -1088,14 +1120,17 @@ def test_dataloaders_load_every_n_epochs_frequent_val(tmp_path):
     train_reload_epochs, val_reload_epochs, val_check_epochs = [], [], []
 
     class TestModel(BoringModel):
+        @override
         def train_dataloader(self):
             train_reload_epochs.append(self.current_epoch)
             return super().train_dataloader()
 
+        @override
         def val_dataloader(self):
             val_reload_epochs.append(self.current_epoch)
             return super().val_dataloader()
 
+        @override
         def on_validation_epoch_end(self):
             val_check_epochs.append(self.current_epoch)
 
@@ -1132,6 +1167,7 @@ def test_dataloaders_load_every_n_epochs_exception(tmp_path, n):
 
 def test_dataloaders_load_every_epoch_no_sanity_check(tmp_path):
     class TestModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx):
             self.log("dummy_val", 5.0)
             return super().validation_step(batch, batch_idx)
@@ -1285,10 +1321,12 @@ def test_correct_dataloader_idx_in_hooks(tmp_path, mode):
             elif self.trainer.testing:
                 assert dataloader_idx == (0 if self.test_call_count <= 5 else 1)
 
+        @override
         def transfer_batch_to_device(self, batch, device, dataloader_idx):
             self.assert_dataloader_idx_hook(dataloader_idx)
             return super().transfer_batch_to_device(batch, device, dataloader_idx)
 
+        @override
         def on_before_batch_transfer(self, batch, dataloader_idx):
             # incrementing here since this is the first hook called at each step
             if self.trainer.validating:
@@ -1299,13 +1337,16 @@ def test_correct_dataloader_idx_in_hooks(tmp_path, mode):
             self.assert_dataloader_idx_hook(dataloader_idx)
             return super().on_before_batch_transfer(batch, dataloader_idx)
 
+        @override
         def on_after_batch_transfer(self, batch, dataloader_idx):
             self.assert_dataloader_idx_hook(dataloader_idx)
             return super().on_after_batch_transfer(batch, dataloader_idx)
 
+        @override
         def training_step(self, batch, batch_idx):
             return super().training_step(batch["a"], batch_idx)
 
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx):
             self.assert_dataloader_idx_hook(dataloader_idx)
             out = super().validation_step(batch, batch_idx)
@@ -1313,6 +1354,7 @@ def test_correct_dataloader_idx_in_hooks(tmp_path, mode):
             out[f"val_loss_{dataloader_idx}"] = loss
             return out
 
+        @override
         def test_step(self, batch, batch_idx, dataloader_idx):
             self.assert_dataloader_idx_hook(dataloader_idx)
             out = super().test_step(batch, batch_idx)
@@ -1324,17 +1366,21 @@ def test_correct_dataloader_idx_in_hooks(tmp_path, mode):
             self.assert_dataloader_idx_hook(dataloader_idx)
             return super().predict(batch, batch_idx, dataloader_idx)
 
+        @override
         def train_dataloader(self):
             return CombinedLoader(
                 {"a": DataLoader(RandomDataset(32, 64)), "b": DataLoader(RandomDataset(32, 64))}, mode=mode
             )
 
+        @override
         def val_dataloader(self):
             return [DataLoader(RandomDataset(32, 64)), DataLoader(RandomDataset(32, 64))]
 
+        @override
         def test_dataloader(self):
             return [DataLoader(RandomDataset(32, 64)), DataLoader(RandomDataset(32, 64))]
 
+        @override
         def predict_dataloader(self):
             return [DataLoader(RandomDataset(32, 64)), DataLoader(RandomDataset(32, 64))]
 
@@ -1370,18 +1416,22 @@ def test_request_dataloader(tmp_path):
             self.on_train_batch_start_called = False
             self.on_val_batch_start_called = False
 
+        @override
         def train_dataloader(self):
             loader = super().train_dataloader()
             return DataLoaderWrapper(loader)
 
+        @override
         def on_train_batch_start(self, batch, batch_idx: int) -> None:
             assert isinstance(self.trainer.train_dataloader, DataLoaderWrapper)
             self.on_train_batch_start_called = True
 
+        @override
         def val_dataloader(self):
             loader = super().val_dataloader()
             return DataLoaderWrapper(loader)
 
+        @override
         def on_validation_batch_start(self, *_):
             assert isinstance(self.trainer.val_dataloaders, DataLoaderWrapper)
             self.on_val_batch_start_called = True
@@ -1399,6 +1449,7 @@ def test_request_dataloader(tmp_path):
 @pytest.mark.parametrize("num_loaders", [1, 2])
 def test_multiple_dataloaders_with_random_sampler_overfit_batches(num_loaders, tmp_path):
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             assert all(isinstance(dl.sampler, SequentialSampler) for dl in self.trainer.train_dataloader)
             return super().training_step(batch[0], batch_idx)
@@ -1407,6 +1458,7 @@ def test_multiple_dataloaders_with_random_sampler_overfit_batches(num_loaders, t
             ds = RandomDataset(32, 64)
             return DataLoader(ds, sampler=RandomSampler(ds))
 
+        @override
         def train_dataloader(self):
             return [self._create_dataloader() for _ in range(num_loaders)]
 

--- a/tests/tests_pytorch/trainer/test_ddp_sigterm_handling.py
+++ b/tests/tests_pytorch/trainer/test_ddp_sigterm_handling.py
@@ -1,4 +1,3 @@
-from typing_extensions import override
 import os
 import signal
 import time
@@ -6,6 +5,7 @@ import time
 import pytest
 import torch
 import torch.multiprocessing as mp
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer, seed_everything
 from lightning.pytorch.demos.boring_classes import BoringDataModule

--- a/tests/tests_pytorch/trainer/test_ddp_sigterm_handling.py
+++ b/tests/tests_pytorch/trainer/test_ddp_sigterm_handling.py
@@ -1,3 +1,4 @@
+from typing_extensions import override
 import os
 import signal
 import time
@@ -20,6 +21,7 @@ pytestmark = pytest.mark.skipif(
 
 
 class DummyModel(LightningModule):
+    @override
     def training_step(self, batch, batch_idx):
         # Simulate SIGTERM in rank 0 at batch 2
         if self.trainer.global_rank == 0 and batch_idx == 2:

--- a/tests/tests_pytorch/trainer/test_states.py
+++ b/tests/tests_pytorch/trainer/test_states.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pytest
+from typing_extensions import override
 
 from lightning.pytorch import Callback, Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/trainer/test_states.py
+++ b/tests/tests_pytorch/trainer/test_states.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pytest
 
 from lightning.pytorch import Callback, Trainer
@@ -36,6 +37,7 @@ def test_trainer_fn_while_running(tmp_path, extra_params):
             self.expected_stage = expected_stage
             self.lr = 0.1
 
+        @override
         def on_train_batch_start(self, *_):
             assert self.trainer.state.status == TrainerStatus.RUNNING
             assert self.trainer.state.fn == self.expected_fn
@@ -46,11 +48,13 @@ def test_trainer_fn_while_running(tmp_path, extra_params):
             assert self.trainer.state.fn == self.expected_fn
             assert self.trainer.sanity_checking
 
+        @override
         def on_validation_batch_start(self, *_):
             assert self.trainer.state.status == TrainerStatus.RUNNING
             assert self.trainer.state.fn == self.expected_fn
             assert self.trainer.validating or self.trainer.sanity_checking
 
+        @override
         def on_test_batch_start(self, *_):
             assert self.trainer.state.status == TrainerStatus.RUNNING
             assert self.trainer.state.fn == self.expected_fn
@@ -80,6 +84,7 @@ def test_interrupt_state_on_keyboard_interrupt(tmp_path, extra_params):
     model = BoringModel()
 
     class InterruptCallback(Callback):
+        @override
         def on_train_batch_start(self, trainer, pl_module, batch, batch_idx):
             raise KeyboardInterrupt
 

--- a/tests/tests_pytorch/trainer/test_trainer.py
+++ b/tests/tests_pytorch/trainer/test_trainer.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import gc
 import logging
 import math
@@ -184,6 +185,7 @@ def test_gradient_accumulation_scheduling_last_batch(tmp_path, accumulate_grad_b
     """Verify optimizer.step() applied to last batch while grad accumulation."""
 
     class TestModel(BoringModel):
+        @override
         def state_dict(self, *args, **kwargs):
             return deepcopy(super().state_dict(*args, **kwargs))
 
@@ -192,6 +194,7 @@ def test_gradient_accumulation_scheduling_last_batch(tmp_path, accumulate_grad_b
             values = [torch.equal(d1[k], d2[k]) for k in keys]
             return all(values) if equal else not any(values)
 
+        @override
         def backward(self, *args, **kwargs) -> None:
             pre_bwd_state_dict = self.state_dict()
             assert self.check(self.start_state_dict, pre_bwd_state_dict)
@@ -203,6 +206,7 @@ def test_gradient_accumulation_scheduling_last_batch(tmp_path, accumulate_grad_b
 
             return out
 
+        @override
         def optimizer_step(self, *args, **kwargs):
             pre_opt_step_state_dict = self.state_dict()
             assert self.check(self.start_state_dict, pre_opt_step_state_dict)
@@ -216,10 +220,12 @@ def test_gradient_accumulation_scheduling_last_batch(tmp_path, accumulate_grad_b
             self.opt_step_called = True
             return out
 
+        @override
         def on_train_batch_start(self, *_):
             self.start_state_dict = self.state_dict()
             self.opt_step_called = False
 
+        @override
         def on_train_batch_end(self, outputs, batch, batch_idx):
             end_state_dict = self.state_dict()
             is_last_batch = (batch_idx + 1) == self.trainer.num_training_batches
@@ -412,12 +418,15 @@ def test_fit_ckpt_path_epoch_restored(monkeypatch, tmp_path, tmpdir_server, url_
         num_batches_seen = 0
         num_on_load_checkpoint_called = 0
 
+        @override
         def on_train_epoch_end(self):
             self.num_epochs_end_seen += 1
 
+        @override
         def on_train_batch_start(self, *_):
             self.num_batches_seen += 1
 
+        @override
         def on_load_checkpoint(self, _):
             self.num_on_load_checkpoint_called += 1
 
@@ -545,6 +554,7 @@ def test_trainer_min_steps_and_epochs(tmp_path):
     num_train_samples = math.floor(len(BoringModel().train_dataloader()) * 0.5)
 
     class CustomModel(BoringModel):
+        @override
         def training_step(self, *args, **kwargs):
             # try to force stop right after first step
             if self.global_step > 0:
@@ -589,6 +599,7 @@ def test_trainer_min_steps_and_min_epochs_not_reached(tmp_path, caplog):
     class TestModel(BoringModel):
         training_step_invoked = 0
 
+        @override
         def training_step(self, batch, batch_idx):
             output = super().training_step(batch, batch_idx)
             output["loss"] = output["loss"] * 0.0  # force minimal loss to trigger early stopping
@@ -755,13 +766,16 @@ def test_checkpoint_find_last(tmp_path):
 @pytest.mark.parametrize("fn", ["validate", "test", "predict"])
 def test_checkpoint_path_input(tmp_path, ckpt_path, save_top_k, fn):
     class TestModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx):
             self.log("foo", -batch_idx)
             return super().validation_step(batch, batch_idx)
 
+        @override
         def test_step(self, *args):
             return self.validation_step(*args)
 
+        @override
         def predict_step(self, batch, *_):
             return self(batch)
 
@@ -825,13 +839,16 @@ def test_checkpoint_path_input(tmp_path, ckpt_path, save_top_k, fn):
 @pytest.mark.parametrize("fn", ["validate", "test", "predict"])
 def test_tested_checkpoint_path_best(tmp_path, enable_checkpointing, fn):
     class TestModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx):
             self.log("foo", -batch_idx)
             return super().validation_step(batch, batch_idx)
 
+        @override
         def test_step(self, *args):
             return self.validation_step(*args)
 
+        @override
         def predict_step(self, batch, *_):
             return self(batch)
 
@@ -886,6 +903,7 @@ def test_disabled_training(tmp_path):
     class CurrentModel(BoringModel):
         training_step_invoked = False
 
+        @override
         def training_step(self, *args, **kwargs):
             self.training_step_invoked = True
             return super().training_step(*args, **kwargs)
@@ -940,6 +958,7 @@ def test_disabled_validation(tmp_path):
     class CurrentModel(BoringModel):
         validation_step_invoked = False
 
+        @override
         def validation_step(self, *args, **kwargs):
             self.validation_step_invoked = True
             return super().validation_step(*args, **kwargs)
@@ -982,9 +1001,11 @@ def test_on_exception_hook(tmp_path):
         def __init__(self):
             super().__init__()
 
+        @override
         def on_train_batch_start(self, trainer, pl_module, batch, batch_idx):
             raise KeyboardInterrupt
 
+        @override
         def on_test_start(self, trainer, pl_module):
             raise MisconfigurationException
 
@@ -993,6 +1014,7 @@ def test_on_exception_hook(tmp_path):
             super().__init__()
             self.exception = None
 
+        @override
         def on_exception(self, trainer, pl_module, exception):
             self.exception = exception
 
@@ -1025,6 +1047,7 @@ def test_keyboard_interrupt(tmp_path):
         def __init__(self):
             super().__init__()
 
+        @override
         def on_train_batch_start(self, trainer, pl_module, batch, batch_idx):
             raise KeyboardInterrupt
 
@@ -1060,6 +1083,7 @@ def test_gradient_clipping_by_norm(tmp_path, precision):
     )
 
     class TestModel(ClassificationModel):
+        @override
         def configure_gradient_clipping(self, *args, **kwargs):
             super().configure_gradient_clipping(*args, **kwargs)
             # test that gradient is clipped correctly
@@ -1088,6 +1112,7 @@ def test_gradient_clipping_by_value(tmp_path, precision):
     )
 
     class TestModel(BoringModel):
+        @override
         def configure_gradient_clipping(self, *args, **kwargs):
             super().configure_gradient_clipping(*args, **kwargs)
             # test that gradient is clipped correctly
@@ -1125,9 +1150,11 @@ def test_num_sanity_val_steps(tmp_path, limit_val_batches):
     assert trainer.num_sanity_val_steps == num_sanity_val_steps
 
     class CustomModelMixedVal(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx):
             return super().validation_step(batch, batch_idx)
 
+        @override
         def val_dataloader(self):
             return [DataLoader(RandomDataset(32, 64), batch_size=8), DataLoader(RandomDataset(32, 64))]
 
@@ -1148,9 +1175,11 @@ def test_num_sanity_val_steps_neg_one(tmp_path, limit_val_batches):
     `limit_val_batches` Trainer argument."""
 
     class CustomModel(BoringModel):
+        @override
         def validation_step(self, batch, batch_idx, dataloader_idx):
             return super().validation_step(batch, batch_idx)
 
+        @override
         def val_dataloader(self):
             return [DataLoader(RandomDataset(32, 64)), DataLoader(RandomDataset(32, 64))]
 
@@ -1228,10 +1257,12 @@ def test_trainer_setup_call(tmp_path, stage):
     """Test setup call gets the correct stage."""
 
     class CurrentModel(BoringModel):
+        @override
         def setup(self, stage):
             self.stage = stage
 
     class CurrentCallback(Callback):
+        @override
         def setup(self, trainer, model, stage):
             assert model is not None
             self.stage = stage
@@ -1255,6 +1286,7 @@ def test_trainer_setup_call(tmp_path, stage):
 @patch("lightning.pytorch.loggers.tensorboard.TensorBoardLogger.log_metrics")
 def test_log_every_n_steps(log_metrics_mock, tmp_path, train_batches, max_steps, log_interval):
     class TestModel(BoringModel):
+        @override
         def training_step(self, *args, **kwargs):
             self.log("foo", -1)
             return super().training_step(*args, **kwargs)
@@ -1278,9 +1310,11 @@ class TestLightningDataModule(LightningDataModule):
         super().__init__()
         self._dataloaders = dataloaders
 
+    @override
     def test_dataloader(self):
         return self._dataloaders
 
+    @override
     def predict_dataloader(self):
         return self._dataloaders
 
@@ -1293,11 +1327,13 @@ class CustomPredictionWriter(BasePredictionWriter):
         super().__init__(*args, **kwargs)
         self.output_dir = output_dir
 
+    @override
     def write_on_batch_end(self, trainer, pl_module, prediction, batch_indices, *_):
         assert prediction.shape == torch.Size([1, 2])
         assert len(batch_indices) == 1
         self.write_on_batch_end_called = True
 
+    @override
     def write_on_epoch_end(self, trainer, pl_module, predictions, batch_indices):
         expected = 1 if trainer._accelerator_connector.is_distributed else 2
         assert len(predictions) == 2
@@ -1306,6 +1342,7 @@ class CustomPredictionWriter(BasePredictionWriter):
         assert len(batch_indices[0]) == expected
         self.write_on_epoch_end_called = True
 
+    @override
     def on_predict_epoch_end(self, trainer, pl_module):
         if trainer._accelerator_connector.is_distributed:
             for idx in range(2):
@@ -1369,6 +1406,7 @@ def test_trainer_predict_no_return(tmp_path):
     """Test trainer.predict warns when nothing is returned."""
 
     class CustomBoringModel(BoringModel):
+        @override
         def predict_step(self, batch, batch_idx, dataloader_idx=0):
             if (batch_idx + 1) % 2 == 0:
                 return None
@@ -1381,6 +1419,7 @@ def test_trainer_predict_no_return(tmp_path):
 
 def test_trainer_predict_grad(tmp_path):
     class CustomBoringModel(BoringModel):
+        @override
         def predict_step(self, batch, batch_idx, dataloader_idx=0):
             assert batch.expand_as(batch).grad_fn is None
             return super().predict_step(batch, batch_idx, dataloader_idx)
@@ -1436,6 +1475,7 @@ def test_index_batch_sampler_wrapper_with_iterable_dataset(dataset_cls, tmp_path
             super().__init__(*args, **kwargs)
             self.output_dir = output_dir
 
+        @override
         def write_on_batch_end(self, trainer, pl_module, prediction, batch_indices, *_):
             assert not batch_indices if is_iterable_dataset else batch_indices
 
@@ -1492,6 +1532,7 @@ def test_trainer_access_in_configure_optimizers(tmp_path):
     """Verify that the configure optimizer function can reference the trainer."""
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             assert self.trainer is not None, "Expect to have access to the trainer within `configure_optimizers`"
 
@@ -1514,6 +1555,7 @@ def test_setup_hook_device_and_layers(tmp_path, accelerator):
     expected_device = torch.device(accelerator, 0)
 
     class TestModel(BoringModel):
+        @override
         def setup(self, stage: str) -> None:
             # The `self.device` attribute already points to what device the model will land on
             assert self.device == expected_device
@@ -1523,6 +1565,7 @@ def test_setup_hook_device_and_layers(tmp_path, accelerator):
             self.new_layer = torch.nn.Linear(2, 2)
             assert self.new_layer.weight.device == torch.device("cpu")
 
+        @override
         def training_step(self, batch, batch_idx):
             output = self.layer(batch)
             # will crash if not moved to correct device
@@ -1563,22 +1606,27 @@ def test_train_loop_system(tmp_path):
     }
 
     class TestOptimizer(SGD):
+        @override
         def step(self, *args, **kwargs):
             called_methods.append("step")
             return super().step(*args, **kwargs)
 
+        @override
         def zero_grad(self, *args, **kwargs):
             called_methods.append("zero_grad")
             return super().zero_grad(*args, **kwargs)
 
     class TestModel(BoringModel):
+        @override
         def configure_optimizers(self):
             return TestOptimizer(self.parameters(), lr=0.1)
 
+        @override
         def training_step(self, *args, **kwargs):
             called_methods.append("training_step")
             return super().training_step(*args, **kwargs)
 
+        @override
         def backward(self, *args, **kwargs):
             called_methods.append("backward")
             return super().backward(*args, **kwargs)
@@ -1637,18 +1685,22 @@ def test_exception_when_testing_or_validating_with_fast_dev_run():
 
 
 class TrainerStagesModel(BoringModel):
+    @override
     def on_train_start(self) -> None:
         assert self.trainer.model.training
         assert self.training
 
+    @override
     def on_validation_start(self) -> None:
         assert not self.trainer.model.training
         assert not self.training
 
+    @override
     def on_test_start(self) -> None:
         assert not self.trainer.model.training
         assert not self.training
 
+    @override
     def on_predict_start(self) -> None:
         assert not self.trainer.model.training
         assert not self.training
@@ -1669,6 +1721,7 @@ def test_model_in_correct_mode_during_stages(tmp_path, strategy, devices):
 
 
 class TestDummyModelForCheckpoint(BoringModel):
+    @override
     def validation_step(self, batch, batch_idx):
         loss = self.step(batch)
         self.log("x", loss)
@@ -1693,6 +1746,7 @@ def test_fit_test_synchronization(tmp_path):
 
 
 class CustomCallbackOnLoadCheckpoint(Callback):
+    @override
     def state_dict(self) -> dict:
         return {"a": None}
 
@@ -1742,15 +1796,18 @@ def test_multiple_trainer_constant_memory_allocated(tmp_path):
     """This tests ensures calling the trainer several times reset the memory back to 0."""
 
     class TestModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             loss = super().training_step(batch, batch_idx)
             self.log("train_loss", loss["loss"])
             return loss
 
+        @override
         def configure_optimizers(self):
             return torch.optim.Adam(self.layer.parameters(), lr=0.1)
 
     class Check(Callback):
+        @override
         def on_train_epoch_start(self, trainer, *_):
             assert isinstance(trainer.strategy.model, DistributedDataParallel)
 
@@ -1790,15 +1847,19 @@ def test_multiple_trainer_constant_memory_allocated(tmp_path):
 
 
 class TrainerStagesErrorsModel(BoringModel):
+    @override
     def on_train_start(self) -> None:
         raise Exception("Error during train")
 
+    @override
     def on_validation_start(self) -> None:
         raise Exception("Error during validation")
 
+    @override
     def on_test_start(self) -> None:
         raise Exception("Error during test")
 
+    @override
     def on_predict_start(self) -> None:
         raise Exception("Error during predict")
 
@@ -1806,6 +1867,7 @@ class TrainerStagesErrorsModel(BoringModel):
 class ExceptionCounter(Callback):
     exceptions = 0
 
+    @override
     def on_exception(self, *_):
         self.exceptions += 1
 
@@ -1849,16 +1911,20 @@ def test_trainer_metrics_reset_before_each_task(tmp_path):
             assert trainer.progress_bar_metrics == {}
             assert trainer.logged_metrics == {}
 
+        @override
         def on_train_start(self, trainer, *args, **kwargs):
             self._make_assertions(trainer)
 
+        @override
         def on_validation_start(self, trainer, *args, **kwargs):
             if trainer.state.fn == TrainerFn.VALIDATING:
                 self._make_assertions(trainer)
 
+        @override
         def on_test_start(self, trainer, *args, **kwargs):
             self._make_assertions(trainer)
 
+        @override
         def on_predict_start(self, trainer, *args, **kwargs):
             self._make_assertions(trainer)
 
@@ -1866,14 +1932,17 @@ def test_trainer_metrics_reset_before_each_task(tmp_path):
         def __init__(self):
             super().__init__()
 
+        @override
         def training_step(self, *args, **kwargs):
             self.log("train/metric", 7.0)
             return super().training_step(*args, **kwargs)
 
+        @override
         def validation_step(self, *args, **kwargs):
             self.log("val/metric", 14.0)
             return super().validation_step(*args, **kwargs)
 
+        @override
         def test_step(self, *args, **kwargs):
             self.log("test/metric", 21.0)
             return super().test_step(*args, **kwargs)
@@ -1888,6 +1957,7 @@ def test_trainer_metrics_reset_before_each_task(tmp_path):
 
 def test_detect_anomaly_nan(tmp_path):
     class NanModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             output = super().training_step(batch, batch_idx)
             output["loss"] = output["loss"] * torch.tensor(float("nan"))
@@ -2051,6 +2121,7 @@ def test_trainer_save_checkpoint_no_model_attached():
 
 def test_trainer_calls_logger_finalize_on_exception(tmp_path):
     class CustomModel(BoringModel):
+        @override
         def on_fit_start(self):
             super().on_fit_start()
             raise Exception("logger-finalize")
@@ -2072,6 +2143,7 @@ def test_trainer_calls_strategy_on_exception(exception_type, tmp_path):
     exception = exception_type("Test exception")
 
     class ExceptionModel(BoringModel):
+        @override
         def on_fit_start(self):
             raise exception
 
@@ -2090,6 +2162,7 @@ def test_trainer_calls_datamodule_on_exception(exception_type, tmp_path):
     exception = exception_type("Test exception")
 
     class ExceptionModel(BoringModel):
+        @override
         def on_fit_start(self):
             raise exception
 

--- a/tests/tests_pytorch/trainer/test_trainer.py
+++ b/tests/tests_pytorch/trainer/test_trainer.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import gc
 import logging
 import math
@@ -32,6 +31,7 @@ from torch.multiprocessing import ProcessRaisedException
 from torch.nn.parallel.distributed import DistributedDataParallel
 from torch.optim import SGD
 from torch.utils.data import DataLoader, IterableDataset
+from typing_extensions import override
 
 import tests_pytorch.helpers.utils as tutils
 from lightning.fabric.utilities.cloud_io import _load as pl_load

--- a/tests/tests_pytorch/tuner/test_lr_finder.py
+++ b/tests/tests_pytorch/tuner/test_lr_finder.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import glob
 import logging
 import math
@@ -23,6 +22,7 @@ from unittest import mock
 import pytest
 import torch
 from lightning_utilities.test.warning import no_warning_call
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer, seed_everything
 from lightning.pytorch.callbacks import EarlyStopping

--- a/tests/tests_pytorch/tuner/test_lr_finder.py
+++ b/tests/tests_pytorch/tuner/test_lr_finder.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import glob
 import logging
 import math
@@ -47,6 +48,7 @@ def test_error_with_multiple_optimizers(tmp_path):
             self.save_hyperparameters()
             self.automatic_optimization = False
 
+        @override
         def configure_optimizers(self):
             optimizer1 = torch.optim.SGD(self.parameters(), lr=self.hparams.lr)
             optimizer2 = torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
@@ -125,6 +127,7 @@ def test_tuner_lr_find(tmp_path, use_hparams):
             self.save_hyperparameters()
             self.lr = lr
 
+        @override
         def configure_optimizers(self):
             return torch.optim.SGD(self.parameters(), lr=self.hparams.lr if use_hparams else self.lr)
 
@@ -151,6 +154,7 @@ def test_trainer_arg_str(tmp_path, use_hparams):
             self.save_hyperparameters()
             self.my_fancy_lr = my_fancy_lr
 
+        @override
         def configure_optimizers(self):
             return torch.optim.SGD(self.parameters(), lr=self.hparams.my_fancy_lr if use_hparams else self.my_fancy_lr)
 
@@ -175,6 +179,7 @@ def test_call_to_trainer_method(tmp_path, opt):
             super().__init__()
             self.save_hyperparameters()
 
+        @override
         def configure_optimizers(self):
             return (
                 torch.optim.Adagrad(self.parameters(), lr=self.hparams.lr)
@@ -247,6 +252,7 @@ def test_suggestion_parameters_work(tmp_path):
             super().__init__()
             self.lr = lr
 
+        @override
         def configure_optimizers(self):
             return torch.optim.SGD(self.parameters(), lr=self.lr)
 
@@ -272,6 +278,7 @@ def test_suggestion_with_non_finite_values(tmp_path):
             super().__init__()
             self.lr = lr
 
+        @override
         def configure_optimizers(self):
             return torch.optim.SGD(self.parameters(), lr=self.lr)
 
@@ -325,6 +332,7 @@ def test_lr_finder_ends_before_num_training(tmp_path):
             super().__init__()
             self.save_hyperparameters()
 
+        @override
         def on_before_optimizer_step(self, optimizer):
             assert self.global_step < num_training
 
@@ -422,16 +430,19 @@ def test_lr_finder_callback_restarting(tmp_path):
             super().__init__()
             self.learning_rate = 0.123
 
+        @override
         def on_train_batch_start(self, batch, batch_idx):
             if getattr(self, "_expected_max_steps", None) is not None:
                 assert self.trainer.fit_loop.max_steps == self._expected_max_steps
 
+        @override
         def configure_optimizers(self):
             return torch.optim.SGD(self.parameters(), lr=self.learning_rate)
 
     class CustomLearningRateFinder(LearningRateFinder):
         milestones = (1,)
 
+        @override
         def lr_find(self, trainer, pl_module) -> None:
             pl_module._expected_max_steps = trainer.global_step + self._num_training_steps
             super().lr_find(trainer, pl_module)
@@ -439,6 +450,7 @@ def test_lr_finder_callback_restarting(tmp_path):
             assert not trainer.fit_loop.restarting
             assert not trainer.fit_loop.epoch_loop.restarting
 
+        @override
         def on_train_epoch_start(self, trainer, pl_module):
             if trainer.current_epoch in self.milestones or trainer.current_epoch == 0:
                 self.lr_find(trainer, pl_module)
@@ -493,6 +505,7 @@ def test_lr_finder_callback_val_batches(tmp_path):
             super().__init__()
             self.lr = lr
 
+        @override
         def configure_optimizers(self):
             return torch.optim.SGD(self.parameters(), lr=self.lr)
 
@@ -520,6 +533,7 @@ def test_lr_finder_training_step_none_output(tmp_path):
             super().__init__()
             self.lr = 0.123
 
+        @override
         def training_step(self, batch: Any, batch_idx: int) -> STEP_OUTPUT:
             if self.trainer.global_step in none_steps:
                 return None
@@ -549,12 +563,14 @@ def test_lr_finder_with_early_stopping(tmp_path):
             super().__init__()
             self.learning_rate = 0.1
 
+        @override
         def validation_step(self, batch, batch_idx):
             output = self.step(batch)
             # Log validation loss that EarlyStopping will monitor
             self.log("val_loss", output, on_epoch=True)
             return output
 
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.Adam(self.parameters(), lr=self.learning_rate)
 
@@ -639,6 +655,7 @@ def test_lr_finder_callback_applies_lr_after_restore(tmp_path):
         def __len__(self) -> int:
             return len(self.x)
 
+        @override
         def __getitem__(self, idx):
             return self.x[idx], self.y[idx]
 
@@ -649,12 +666,14 @@ def test_lr_finder_callback_applies_lr_after_restore(tmp_path):
             self.encoder = nn.Sequential(nn.Linear(28 * 28, 128), nn.ReLU(), nn.Linear(128, 3))
             self.decoder = nn.Sequential(nn.Linear(3, 128), nn.ReLU(), nn.Linear(128, 28 * 28))
 
+        @override
         def training_step(self, batch: Any, batch_idx: int) -> STEP_OUTPUT:
             x, y = batch
             z = self.encoder(x)
             x_hat = self.decoder(z)
             return F.mse_loss(x_hat, y)
 
+        @override
         def configure_optimizers(self):
             return torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
 
@@ -763,12 +782,14 @@ def test_lr_finder_checkpoint_cleanup_on_error(tmp_path):
             self.current_step = 0
             self.learning_rate = 1e-3
 
+        @override
         def training_step(self, batch, batch_idx):
             self.current_step += 1
             if self.current_step >= self.fail_on_step:
                 raise RuntimeError("Intentional failure for testing cleanup")
             return super().training_step(batch, batch_idx)
 
+        @override
         def configure_optimizers(self):
             optimizer = torch.optim.SGD(self.parameters(), lr=self.learning_rate)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
@@ -813,10 +834,12 @@ def test_lr_finder_with_backbone_finetuning_callback(tmp_path):
             self.head = torch.nn.Linear(8, 2)
             self.learning_rate = 1e-3
 
+        @override
         def forward(self, x):
             backbone_features = self.backbone(x)
             return self.head(backbone_features)
 
+        @override
         def configure_optimizers(self):
             return torch.optim.Adam(filter(lambda p: p.requires_grad, self.parameters()), lr=self.learning_rate)
 
@@ -855,6 +878,7 @@ def test_lr_finder_respects_weights_only(tmp_path):
             super().__init__()
             self.net = torch.nn.Linear(in_features, out_features)
 
+        @override
         def forward(self, x):
             return self.net(x)
 
@@ -867,11 +891,13 @@ def test_lr_finder_respects_weights_only(tmp_path):
             self.loss = loss
             self.lr = lr
 
+        @override
         def training_step(self, batch, batch_idx):
             x, y = batch
             y_hat = self.layer(x)
             return self.loss(y_hat, y)
 
+        @override
         def configure_optimizers(self):
             return torch.optim.Adam(self.parameters(), lr=self.lr)
 

--- a/tests/tests_pytorch/tuner/test_scale_batch_size.py
+++ b/tests/tests_pytorch/tuner/test_scale_batch_size.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import glob
 import logging
 import math
@@ -37,6 +38,7 @@ class BatchSizeDataModule(BoringDataModule):
         if batch_size is not None:
             self.batch_size = batch_size
 
+    @override
     def train_dataloader(self):
         return DataLoader(self.random_train, batch_size=getattr(self, "batch_size", 1))
 
@@ -47,15 +49,19 @@ class BatchSizeModel(BoringModel):
         if batch_size is not None:
             self.batch_size = batch_size
 
+    @override
     def train_dataloader(self):
         return DataLoader(RandomDataset(32, 64), batch_size=getattr(self, "batch_size", 1))
 
+    @override
     def val_dataloader(self):
         return DataLoader(RandomDataset(32, 64), batch_size=getattr(self, "batch_size", 1))
 
+    @override
     def test_dataloader(self):
         return DataLoader(RandomDataset(32, 64), batch_size=getattr(self, "batch_size", 1))
 
+    @override
     def predict_dataloader(self):
         return DataLoader(RandomDataset(32, 64), batch_size=getattr(self, "batch_size", 1))
 
@@ -149,9 +155,11 @@ def test_auto_scale_batch_size_set_model_attribute(tmp_path, use_hparams):
             super().__init__()
             self.save_hyperparameters()
 
+        @override
         def train_dataloader(self):
             return DataLoader(RandomDataset(32, 64), batch_size=self.hparams.batch_size)
 
+        @override
         def val_dataloader(self):
             return DataLoader(RandomDataset(32, 64), batch_size=self.hparams.batch_size)
 
@@ -177,9 +185,11 @@ def test_auto_scale_batch_size_set_datamodule_attribute(tmp_path, use_hparams):
             super().__init__()
             self.save_hyperparameters()
 
+        @override
         def train_dataloader(self):
             return DataLoader(self.random_train, batch_size=self.hparams.batch_size)
 
+        @override
         def val_dataloader(self):
             return DataLoader(RandomDataset(32, 64), batch_size=self.hparams.batch_size)
 
@@ -446,6 +456,7 @@ def test_batch_size_finder_with_multiple_eval_dataloaders(tmp_path):
     """Test that an error is raised with batch size finder is called with multiple eval dataloaders."""
 
     class CustomModel(BoringModel):
+        @override
         def val_dataloader(self):
             return [super().val_dataloader(), super().val_dataloader()]
 
@@ -463,10 +474,12 @@ def test_batch_size_finder_with_multiple_eval_dataloaders(tmp_path):
 @patch("lightning.pytorch.tuner.batch_size_scaling.is_oom_error", return_value=True)
 def test_dataloader_batch_size_updated_on_failure(_, tmp_path, scale_method, expected_batch_size):
     class CustomBatchSizeModel(BatchSizeModel):
+        @override
         def training_step(self, *_, **__):
             if self.batch_size > 100:
                 raise RuntimeError
 
+        @override
         def train_dataloader(self):
             return DataLoader(RandomDataset(32, 1000), batch_size=self.batch_size)
 
@@ -554,12 +567,14 @@ def test_scale_batch_size_checkpoint_cleanup_on_error(tmp_path):
             self.current_step = 0
             self.batch_size = 2
 
+        @override
         def training_step(self, batch, batch_idx):
             self.current_step += 1
             if self.current_step >= self.fail_on_step:
                 raise RuntimeError("Intentional failure for testing cleanup")
             return super().training_step(batch, batch_idx)
 
+        @override
         def train_dataloader(self):
             return DataLoader(RandomDataset(32, 64), batch_size=self.batch_size)
 
@@ -606,6 +621,7 @@ class FailsAtBatchSizeBoringModel(BoringModel):
         self.batch_size = batch_size
         self.fail_at = fail_at
 
+    @override
     def training_step(self, batch, batch_idx):
         # Simulate OOM error when batch size is too large
         if self.batch_size >= self.fail_at:

--- a/tests/tests_pytorch/tuner/test_scale_batch_size.py
+++ b/tests/tests_pytorch/tuner/test_scale_batch_size.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import glob
 import logging
 import math
@@ -23,6 +22,7 @@ import pytest
 import torch
 from lightning_utilities.test.warning import no_warning_call
 from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks.batch_size_finder import BatchSizeFinder

--- a/tests/tests_pytorch/utilities/test_all_gather_grad.py
+++ b/tests/tests_pytorch/utilities/test_all_gather_grad.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 import numpy as np
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/utilities/test_all_gather_grad.py
+++ b/tests/tests_pytorch/utilities/test_all_gather_grad.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 import numpy as np
 import pytest
 import torch
@@ -56,6 +57,7 @@ def test_all_gather_collection(tmp_path):
     class TestModel(BoringModel):
         on_train_epoch_end_called = False
 
+        @override
         def on_train_epoch_end(self):
             losses = torch.rand(2, 2).t()
             gathered_loss = self.all_gather({
@@ -109,6 +111,7 @@ def test_all_gather_sync_grads(tmp_path):
     class TestModel(BoringModel):
         training_step_called = False
 
+        @override
         def training_step(self, batch, batch_idx):
             self.training_step_called = True
             tensor = torch.rand(2, 2, requires_grad=True, device=self.device)

--- a/tests/tests_pytorch/utilities/test_auto_restart.py
+++ b/tests/tests_pytorch/utilities/test_auto_restart.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import inspect
 
 import pytest
 from torch.utils.data.dataloader import DataLoader
+from typing_extensions import override
 
 from lightning.fabric.utilities.seed import seed_everything
 from lightning.pytorch import Callback, Trainer

--- a/tests/tests_pytorch/utilities/test_auto_restart.py
+++ b/tests/tests_pytorch/utilities/test_auto_restart.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import inspect
 
 import pytest
@@ -38,6 +39,7 @@ class TestAutoRestartModelUnderSignal(BoringModel):
             # simulate `os.kill(os.getpid(), signal.SIGTERM)`
             self.trainer._signal_connector.received_sigterm = True
 
+    @override
     def training_step(self, batch, batch_idx):
         self.seen_train_batches.append(batch)
         should_signal = self.trainer.fit_loop.epoch_loop._is_training_done if self.on_last_batch else batch_idx == 2
@@ -45,6 +47,7 @@ class TestAutoRestartModelUnderSignal(BoringModel):
             self._signal()
         return super().training_step(batch, batch_idx)
 
+    @override
     def validation_step(self, batch, batch_idx):
         should_signal = (
             self.trainer.fit_loop.epoch_loop.val_loop.batch_progress.is_last_batch
@@ -55,17 +58,21 @@ class TestAutoRestartModelUnderSignal(BoringModel):
             self._signal()
         return super().validation_step(batch, batch_idx)
 
+    @override
     def on_train_epoch_end(self):
         if not self.failure_on_step and self.failure_on_training:
             self._signal()
 
+    @override
     def on_validation_epoch_end(self):
         if not self.failure_on_step and not self.failure_on_training:
             self._signal()
 
+    @override
     def train_dataloader(self):
         return DataLoader(RandomDataset(32, 4))
 
+    @override
     def val_dataloader(self):
         return DataLoader(RandomDataset(32, 4))
 
@@ -79,6 +86,7 @@ def _fit_model(
     class MyTestCallback(Callback):
         raising_function = None
 
+        @override
         def on_exception(self, trainer, pl_module, exception):
             if isinstance(exception, SIGTERMException):
                 caller = inspect.trace()[-1]

--- a/tests/tests_pytorch/utilities/test_combined_loader.py
+++ b/tests/tests_pytorch/utilities/test_combined_loader.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import math
 import pickle
 from collections.abc import Sequence
@@ -26,6 +25,7 @@ from torch.utils.data import DataLoader, TensorDataset
 from torch.utils.data.dataset import Dataset, IterableDataset
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import RandomSampler, SequentialSampler
+from typing_extensions import override
 
 from lightning.fabric.utilities.types import _Stateful
 from lightning.pytorch import Trainer

--- a/tests/tests_pytorch/utilities/test_combined_loader.py
+++ b/tests/tests_pytorch/utilities/test_combined_loader.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import math
 import pickle
 from collections.abc import Sequence
@@ -284,6 +285,7 @@ class TestIterableDataset(IterableDataset):
     def __init__(self, size: int = 10):
         self.size = size
 
+    @override
     def __iter__(self):
         self.sampler = SequentialSampler(range(self.size))
         self.sampler_iter = iter(self.sampler)
@@ -335,6 +337,7 @@ def test_combined_loader_simultaneous_workers(mode):
             super().__init__(*args, **kwargs)
             self.workers_active = False
 
+        @override
         def _get_iterator(self):
             self.workers_active = True
             return super()._get_iterator()
@@ -398,6 +401,7 @@ def test_combined_loader_sequence_with_map_and_iterable(lengths):
         def __init__(self, size: int = 10):
             self.size = size
 
+        @override
         def __iter__(self):
             self.sampler = SequentialSampler(range(self.size))
             self.iter_sampler = iter(self.sampler)
@@ -410,6 +414,7 @@ def test_combined_loader_sequence_with_map_and_iterable(lengths):
         def __init__(self, size: int = 10):
             self.size = size
 
+        @override
         def __getitem__(self, index):
             return index
 
@@ -434,6 +439,7 @@ def test_combined_data_loader_validation_test(use_distributed_sampler):
         def __len__(self):
             return len(self.data)
 
+        @override
         def __getitem__(self, index):
             return self.data[index]
 
@@ -521,6 +527,7 @@ def test_combined_data_loader_with_max_size_cycle_and_ddp(monkeypatch, accelerat
                 assert last_batch == {"a": torch.tensor([8]), "b": torch.tensor([0])}
 
     class InfiniteDataset(IterableDataset):
+        @override
         def __iter__(self):
             while True:
                 yield 1

--- a/tests/tests_pytorch/utilities/test_compile.py
+++ b/tests/tests_pytorch/utilities/test_compile.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import os
 import sys
 from unittest import mock
 
 import pytest
 import torch
+from typing_extensions import override
 
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_2
 from lightning.pytorch import LightningModule, Trainer

--- a/tests/tests_pytorch/utilities/test_compile.py
+++ b/tests/tests_pytorch/utilities/test_compile.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import os
 import sys
 from unittest import mock
@@ -165,6 +166,7 @@ def test_compile_uncompile():
 @mock.patch.dict(os.environ, {})
 def test_trainer_compiled_model_that_logs(tmp_path):
     class MyModel(BoringModel):
+        @override
         def training_step(self, batch, batch_idx):
             loss = self.step(batch)
             self.log("loss", loss)

--- a/tests/tests_pytorch/utilities/test_deepspeed_model_summary.py
+++ b/tests/tests_pytorch/utilities/test_deepspeed_model_summary.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing_extensions import override
 from unittest import mock
 
 import torch
@@ -33,6 +34,7 @@ def test_deepspeed_summary(tmp_path):
     total_parameters = sum(x.numel() for x in model.parameters())
 
     class TestCallback(Callback):
+        @override
         def on_fit_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
             model_summary = DeepSpeedSummary(pl_module, max_depth=1)
             assert model_summary.total_parameters == total_parameters

--- a/tests/tests_pytorch/utilities/test_deepspeed_model_summary.py
+++ b/tests/tests_pytorch/utilities/test_deepspeed_model_summary.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing_extensions import override
 from unittest import mock
 
 import torch
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.pytorch import Callback, Trainer

--- a/tests/tests_pytorch/utilities/test_dtype_device_mixin.py
+++ b/tests/tests_pytorch/utilities/test_dtype_device_mixin.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import torch.nn as nn
 
 from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
@@ -36,6 +37,7 @@ class TopModule(BoringModel):
 
 
 class DeviceAssertCallback(Callback):
+    @override
     def on_train_batch_start(self, trainer, model, batch, batch_idx):
         rank = trainer.local_rank
         assert isinstance(model, TopModule)

--- a/tests/tests_pytorch/utilities/test_dtype_device_mixin.py
+++ b/tests/tests_pytorch/utilities/test_dtype_device_mixin.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import torch.nn as nn
+from typing_extensions import override
 
 from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
 from lightning.pytorch import Callback, Trainer

--- a/tests/tests_pytorch/utilities/test_model_summary.py
+++ b/tests/tests_pytorch/utilities/test_model_summary.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 from collections import OrderedDict
 from typing import Any
 from unittest import mock
@@ -20,6 +19,7 @@ import pytest
 import torch
 import torch.nn as nn
 from lightning_utilities.test.warning import no_warning_call
+from typing_extensions import override
 
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel

--- a/tests/tests_pytorch/utilities/test_model_summary.py
+++ b/tests/tests_pytorch/utilities/test_model_summary.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 from collections import OrderedDict
 from typing import Any
 from unittest import mock
@@ -41,6 +42,7 @@ class EmptyModule(LightningModule):
         self.parameter = torch.rand(3, 3, requires_grad=True)
         self.example_input_array = torch.zeros(1, 2, 3, 4, 5)
 
+    @override
     def forward(self, *args, **kwargs):
         return {"loss": self.parameter.sum()}
 
@@ -57,6 +59,7 @@ class PreCalculatedModel(BoringModel):
         # calculate model size based on precision.
         self.pre_calculated_model_size = 1.0 / (32 / precision)
 
+    @override
     def forward(self, x):
         x = self.layer(x)
         return self.layer1(x)
@@ -77,6 +80,7 @@ class UnorderedModel(LightningModule):
 
         self.example_input_array = (torch.rand(2, 3), torch.rand(2, 10))
 
+    @override
     def forward(self, x, y):
         out1 = self.layer1(x)
         out2 = self.layer2(y)
@@ -93,6 +97,7 @@ class MixedDtypeModel(LightningModule):
         self.reduce = nn.Linear(20, 1)  # dtype: float
         self.example_input_array = torch.tensor([[0, 2, 1], [3, 5, 3]])  # dtype: long
 
+    @override
     def forward(self, x):
         return self.reduce(self.embed(x))
 
@@ -106,6 +111,7 @@ class PartialScriptModel(LightningModule):
         self.layer2 = nn.Linear(3, 2)
         self.example_input_array = torch.rand(2, 5)
 
+    @override
     def forward(self, x):
         return self.layer2(self.layer1(x))
 
@@ -118,6 +124,7 @@ class LazyModel(LightningModule):
         self.layer1 = nn.LazyLinear(5)
         self.layer2 = nn.LazyLinear(2)
 
+    @override
     def forward(self, inp):
         return self.layer2(self.layer1(inp))
 
@@ -141,6 +148,7 @@ class DeepNestedModel(LightningModule):
         self.head = UnorderedModel()
         self.example_input_array = torch.rand(2, 5)
 
+    @override
     def forward(self, inp):
         return self.head(self.branch1(inp), self.branch2(inp))
 
@@ -153,6 +161,7 @@ class NonLayerParamsModel(LightningModule):
         self.param = torch.nn.Parameter(torch.ones(2, 2))
         self.layer = torch.nn.Linear(2, 2)
 
+    @override
     def forward(self, inp):
         self.layer(self.param @ inp)
 
@@ -283,6 +292,7 @@ def test_example_input_array_types(example_input, expected_size, max_depth):
     """Test the types of example inputs supported for display in the summary."""
 
     class DummyModule(nn.Module):
+        @override
         def forward(self, *args, **kwargs):
             return None
 
@@ -292,6 +302,7 @@ def test_example_input_array_types(example_input, expected_size, max_depth):
             self.layer = DummyModule()
 
         # this LightningModule and submodule accept any type of input
+        @override
         def forward(self, *args, **kwargs):
             return self.layer(*args, **kwargs)
 
@@ -398,6 +409,7 @@ def test_summary_data_output(example_input):
     """Ensure all items are converted to strings when getting summary data."""
 
     class TestModel(BoringModel):
+        @override
         @property
         def example_input_array(self) -> Any:
             return example_input
@@ -440,6 +452,7 @@ def test_summary_restores_module_mode():
             self.layer2 = torch.nn.Linear(2, 2)
             self.example_input_array = torch.rand(2, 2)
 
+        @override
         def forward(self, x):
             assert not self.training
             assert not self.layer1.training

--- a/tests/tests_pytorch/utilities/test_parameter_tying.py
+++ b/tests/tests_pytorch/utilities/test_parameter_tying.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing_extensions import override
 import pytest
 import torch
 from torch import nn
@@ -27,6 +28,7 @@ class ParameterSharingModule(BoringModel):
         self.layer_3 = nn.Linear(32, 10, bias=False)
         self.layer_3.weight = self.layer_1.weight
 
+    @override
     def forward(self, x):
         x = self.layer_1(x)
         x = self.layer_2(x)
@@ -52,6 +54,7 @@ def test_set_shared_parameters():
             super().__init__()
             self.layer = layer
 
+        @override
         def forward(self, x):
             return self.layer(x)
 
@@ -63,6 +66,7 @@ def test_set_shared_parameters():
             self.layer_2 = nn.Linear(10, 32, bias=False)
             self.net_b = SubModule(self.layer)
 
+        @override
         def forward(self, x):
             x = self.net_a(x)
             x = self.layer_2(x)

--- a/tests/tests_pytorch/utilities/test_parameter_tying.py
+++ b/tests/tests_pytorch/utilities/test_parameter_tying.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing_extensions import override
 import pytest
 import torch
 from torch import nn
+from typing_extensions import override
 
 from lightning.pytorch.demos.boring_classes import BoringModel
 from lightning.pytorch.utilities import find_shared_parameters, set_shared_parameters


### PR DESCRIPTION
This PR adds the `@override` decorator to methods that override parent methods across the codebase as requested in #18695.