### PR TITLE
Remove dead jsonargparse<4.39 skip guards

### DIFF
--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -14,7 +14,6 @@
 import glob
 import inspect
 import json
-import operator
 import os
 from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdout
 from io import StringIO
@@ -26,7 +25,6 @@ from unittest.mock import ANY
 import pytest
 import torch
 import yaml
-from lightning_utilities import compare_version
 from lightning_utilities.test.warning import no_warning_call
 from tensorboard.backend.event_processing import event_accumulator
 from tensorboard.plugins.hparams.plugin_data_pb2 import HParamsPluginData
@@ -258,9 +256,6 @@ def test_lightning_cli_args(cleandir):
     assert loaded_config["trainer"] == cli_config["trainer"]
 
 
-@pytest.mark.skipif(
-    compare_version("jsonargparse", operator.lt, "4.39"), reason="incompatibilities with older jsonargparse"
-)
 def test_lightning_env_parse(cleandir):
     out = StringIO()
     with mock.patch("sys.argv", ["", "fit", "--help"]), redirect_stdout(out), pytest.raises(SystemExit):
@@ -427,9 +422,6 @@ def any_model_any_data_cli():
     LightningCLI(LightningModule, LightningDataModule, subclass_mode_model=True, subclass_mode_data=True)
 
 
-@pytest.mark.skipif(
-    compare_version("jsonargparse", operator.lt, "4.39"), reason="incompatibilities with older jsonargparse"
-)
 def test_lightning_cli_help():
     cli_args = ["any.py", "fit", "--help"]
     out = StringIO()
@@ -1209,9 +1201,6 @@ def test_lightning_cli_subcommands():
             assert e in parameters
 
 
-@pytest.mark.skipif(
-    compare_version("jsonargparse", operator.lt, "4.39"), reason="incompatibilities with older jsonargparse"
-)
 def test_lightning_cli_custom_subcommand():
     class TestTrainer(Trainer):
         def foo(self, model: LightningModule, x: int, y: float = 1.0):


### PR DESCRIPTION
## What does this PR do?

Removes `@pytest.mark.skipif(compare_version("jsonargparse", operator.lt, "4.39"), ...)` guards in `test_cli.py` — the jsonargparse floor is pinned to `>=4.39.0` in [`requirements/pytorch/extra.txt`](https://github.com/Lightning-AI/pytorch-lightning/blob/master/requirements/pytorch/extra.txt#L8), so these were always false. Also drops the now-unused `operator` and `compare_version` imports.