### PR TITLE
Remove unreachable torchvision<0.14 fallback in get_torchvision_model

### DIFF
--- a/src/lightning/pytorch/utilities/model_helpers.py
+++ b/src/lightning/pytorch/utilities/model_helpers.py
@@ -17,7 +17,6 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, TypeVar
 
-from lightning_utilities.core.imports import RequirementCache
 from torch import nn
 from typing_extensions import Concatenate, ParamSpec, override
 
@@ -54,11 +53,7 @@ def get_torchvision_model(model_name: str, **kwargs: Any) -> nn.Module:
 
     from torchvision import models
 
-    torchvision_greater_equal_0_14 = RequirementCache("torchvision>=0.14.0")
-    # TODO: deprecate this function when 0.14 is the minimum supported torchvision
-    if torchvision_greater_equal_0_14:
-        return models.get_model(model_name, **kwargs)
-    return getattr(models, model_name)(**kwargs)
+    return models.get_model(model_name, **kwargs)
 
 
 class _ModuleMode:


### PR DESCRIPTION
## What does this PR do?

Collapses the version branch in `get_torchvision_model` ([`model_helpers.py`](https://github.com/Lightning-AI/pytorch-lightning/blob/master/src/lightning/pytorch/utilities/model_helpers.py#L49)). 

The torchvision floor is pinned to `>=0.16.0` in [`requirements/pytorch/examples.txt`](https://github.com/Lightning-AI/pytorch-lightning/blob/master/requirements/pytorch/examples.txt#L5), so the `RequirementCache("torchvision>=0.14.0")` check was always `True` and the `getattr(models, model_name)(...)` fallback was unreachable. 


## PR review

Anyone in the community is free to review the PR once the tests have passed.