### PR TITLE
[experiment] Instrument parity benchmark per-run timing

### DIFF
--- a/tests/parity_pytorch/measure.py
+++ b/tests/parity_pytorch/measure.py
@@ -28,8 +28,13 @@ def measure_loops(cls_model, kind: str, loop: Callable, num_runs: int = 10, num_
 
         time_end = time.perf_counter()
 
+        # TEMP(experiment): stream per-run timing so the benchmark log shows where wall time goes.
+        print(f"[timing] {kind} / {cls_model.__name__} run {i}: {time_end - time_start:.1f}s", flush=True)
+
         hist_losses.append(final_loss)
         hist_durations.append(time_end - time_start)
         hist_memory.append(used_memory)
 
+    # TEMP(experiment): total time for this loop kind.
+    print(f"[timing] {kind} / {cls_model.__name__} TOTAL: {sum(hist_durations):.1f}s", flush=True)
     return {"losses": hist_losses, "durations": hist_durations, "memory": hist_memory}


### PR DESCRIPTION
## What does this PR do?

**Draft / experiment — not for merge.** Adds lightweight, streaming timing output to `measure_loops` so the benchmark job's log reveals where wall time is actually spent.

### Motivation

Comparing two runs of the same `benchmark.yml` job on adjacent commits (both on identical 2× NVIDIA L4 hardware):

- Run A: **~16.5 min** total
- Run B: **~78 min** total

The entire difference is a single test — `test_pytorch_parity[ParityModuleCIFAR-...]` — which took **12.7 min** in A vs **74 min** in B (5.8×). Because the trainer runs with `enable_progress_bar=False`, the test emits **zero output for the whole 74 minutes**, so there's no way to see whether the time is in the Lightning loop vs the vanilla loop, the warm-up run vs the full run, or data download vs compute.

### Change

Two `print(..., flush=True)` lines in `measure_loops`:
- per-run duration (`run 0`, `run 1`, …)
- per-loop total

This turns the silent 74-minute black box into a timeline we can read straight from the CI log. Once we know the breakdown, a follow-up can shrink/fix the CIFAR workload (subset the data, bump `num_workers`, avoid per-step `.item()` sync, add a timeout).

### Notes

- Purely additive; no behavior/assertion changes.
- Lines are marked `TEMP(experiment)` and will be removed or refined before any real PR.