### PR TITLE
fix(tests): flaky model summary precision test on CPU

### DIFF
--- a/tests/tests_pytorch/utilities/test_model_summary.py
+++ b/tests/tests_pytorch/utilities/test_model_summary.py
@@ -347,7 +347,8 @@ def test_model_size_warning_on_unsupported_precision(tmp_path):
 
     # supported precision by lightning but not by the model summary
     trainer = Trainer(max_epochs=1, precision="16-mixed", default_root_dir=tmp_path)
-    trainer.fit(model)
+    # avoid `fit`: "16-mixed" autocasts to bfloat16 on CPU, which not every CI machine supports
+    model.trainer = trainer
 
     with pytest.warns(UserWarning, match="Precision .* is not supported by the model summary.*"):
         summary = summarize(model)


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky test that has been failing CI on `master`.

Ref actions:
- https://github.com/Lightning-AI/pytorch-lightning/actions/runs/29517652411/job/87686600628
- https://github.com/Lightning-AI/pytorch-lightning/actions/runs/29517652411/job/87686600655


`test_model_size_warning_on_unsupported_precision` calls `trainer.fit()` with `precision="16-mixed"`, which autocasts to **bfloat16 on CPU**. The GitHub runner pool is CPU-heterogeneous, so on machines without bf16 support the forward pass fails with `RuntimeError: could not create a primitive` (or crashes with SIGILL, exit code 132). This is why the failing job moves between OS/PyTorch versions from run to run.

The test only needs the trainer's `precision` to be attached — the model summary reads `trainer.precision` and never runs a forward for this model (`example_input_array` is `None`). So attach the trainer directly instead of running a step.
