### PR TITLE
Test: Add unit test for sized_len utilitytest, add unit test for sized_len utility

### DIFF
--- a/tests/tests_fabric/utilities/test_data.py
+++ b/tests/tests_fabric/utilities/test_data.py
@@ -22,6 +22,7 @@ from lightning.fabric.utilities.data import (
     _WrapAttrTag,
     has_iterable_dataset,
     has_len,
+    sized_len,
     suggested_max_num_workers,
 )
 from lightning.fabric.utilities.exceptions import MisconfigurationException
@@ -48,6 +49,22 @@ def test_has_len():
         assert has_len(DataLoader(RandomDataset(0, 0)))
 
     assert not has_len(DataLoader(RandomIterableDataset(1, 1)))
+
+
+def test_sized_len():
+    # a sized object returns its length
+    assert sized_len(DataLoader(RandomDataset(1, 5))) == 5
+    # a zero-length sized object returns 0, not None
+    assert sized_len(DataLoader(RandomDataset(0, 0))) == 0
+    # an object without __len__ returns None (len() raises TypeError)
+    assert sized_len(DataLoader(RandomIterableDataset(1, 1))) is None
+
+    # an object whose __len__ raises NotImplementedError also returns None
+    class _NoLen:
+        def __len__(self):
+            raise NotImplementedError
+
+    assert sized_len(_NoLen()) is None
 
 
 def test_replace_dunder_methods_multiple_loaders_without_init():


### PR DESCRIPTION
## What does this PR do?

Adds a unit test for `sized_len` in `lightning/fabric/utilities/data.py`,
which previously had no direct test coverage.

The test covers all three code paths of the function:
- an object with a length returns that length,
- a zero-length sized object returns `0` (not `None`), a distinction
  `has_len` relies on to emit its zero-length warning,
- an object without `__len__`, or whose `__len__` raises
  `NotImplementedError`, returns `None`.

This is a test-only change; no source code or behavior is modified. No
issue was opened since this is a small coverage addition, I'm happy to open
one if the maintainers would prefer.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? N/A — test-only coverage addition
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? N/A
- Did you write any **new necessary tests**? Yes — this PR is the test
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request? None
- Did you **update the CHANGELOG**? N/A — test updates are exempt per the template
</details>

## PR review

Anyone in the community is can review.

## Did you have fun?

Yes!!