### PR TITLE
Fix EarlyStopping latching should_stop before min_epochs is reached

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -48,6 +48,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed arbitrary code execution in `load_from_checkpoint` by restricting the `_instantiator` hyperparameter to an allowlist of trusted instantiators ([#21832](https://github.com/Lightning-AI/pytorch-lightning/pull/21832))
 
+- Fixed `EarlyStopping` latching `trainer.should_stop` while `min_epochs` had not been reached, which stopped training the instant `min_epochs` was met even if the monitored metric had recovered during the grace window ([#19966](https://github.com/Lightning-AI/pytorch-lightning/issues/19966))
+
 ---
 
 ## [2.6.4] - 2026-05-20

--- a/src/lightning/pytorch/callbacks/early_stopping.py
+++ b/src/lightning/pytorch/callbacks/early_stopping.py
@@ -236,6 +236,20 @@ class EarlyStopping(Callback):
 
         # stop every ddp process if any world process decides to stop
         should_stop = trainer.strategy.reduce_boolean_decision(should_stop, all=False)
+
+        if should_stop and not trainer.fit_loop._met_min_epochs:
+            # `min_epochs` has not been met yet, so the trainer would ignore the request anyway. Do not latch it
+            # onto `trainer.should_stop`: the metric may still recover within the grace window, and a stale
+            # decision must not fire the instant `min_epochs` is reached. See issue #19966.
+            # NOTE: `min_steps` is deliberately not covered here, as the training epoch loop honors it at batch
+            # granularity, which this callback (evaluated once per epoch/validation) cannot reproduce.
+            should_stop = False
+            self.stopping_reason = EarlyStoppingReason.NOT_STOPPED
+            reason = (
+                f"{reason} However, `min_epochs={trainer.fit_loop.min_epochs}` has not been reached yet,"
+                " so the decision is deferred and will be re-evaluated on the next check."
+            )
+
         trainer.should_stop = trainer.should_stop or should_stop
         if should_stop:
             self.stopped_epoch = trainer.current_epoch

--- a/src/lightning/pytorch/loops/fit_loop.py
+++ b/src/lightning/pytorch/loops/fit_loop.py
@@ -158,10 +158,16 @@ class _FitLoop(_Loop):
         raise RuntimeError("`FitLoop._results` property isn't defined. Accessed outside of scope")
 
     @property
+    def _met_min_epochs(self) -> bool:
+        return self.epoch_progress.current.processed >= self.min_epochs if self.min_epochs else True
+
+    @property
+    def _met_min_steps(self) -> bool:
+        return self.epoch_loop.global_step >= self.min_steps if self.min_steps else True
+
+    @property
     def _can_stop_early(self) -> bool:
-        met_min_epochs = self.epoch_progress.current.processed >= self.min_epochs if self.min_epochs else True
-        met_min_steps = self.epoch_loop.global_step >= self.min_steps if self.min_steps else True
-        return met_min_epochs and met_min_steps
+        return self._met_min_epochs and self._met_min_steps
 
     @property
     def _should_reload_train_dl(self) -> bool:

--- a/tests/tests_pytorch/callbacks/test_early_stopping.py
+++ b/tests/tests_pytorch/callbacks/test_early_stopping.py
@@ -328,6 +328,47 @@ def test_min_epochs_min_steps_global_step(tmp_path, limit_train_batches, min_epo
     assert trainer.global_step == stop_step
 
 
+class _ScriptedScoreModel(BoringModel):
+    """Logs a predetermined ``val_loss`` per epoch."""
+
+    def __init__(self, scores):
+        super().__init__()
+        self.scores = scores
+
+    def on_validation_epoch_end(self):
+        self.log("val_loss", self.scores[min(self.current_epoch, len(self.scores) - 1)])
+
+
+def test_early_stopping_recovers_from_improvement_during_min_epochs(tmp_path):
+    """Patience is exhausted before `min_epochs`, but the metric improves again within the grace window.
+
+    Training must not stop the instant `min_epochs` is reached. See issue #19966.
+
+    """
+    #         epoch:  0     1     2     3    4    5    6    7
+    scores = [10.0, 11.0, 12.0, 1.0, 0.9, 0.8, 0.7, 0.6]
+    model = _ScriptedScoreModel(scores)
+    early_stopping = EarlyStopping(monitor="val_loss", mode="min", patience=2)
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        min_epochs=6,
+        max_epochs=8,
+        callbacks=[early_stopping],
+        limit_train_batches=2,
+        limit_val_batches=2,
+        num_sanity_val_steps=0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
+    trainer.fit(model)
+
+    # the metric improved on epochs 3, 4 and 5, so the stale patience decision from epoch 2 must be revoked
+    assert early_stopping.wait_count == 0
+    assert trainer.current_epoch == 8
+
+
 def test_early_stopping_mode_options():
     with pytest.raises(MisconfigurationException, match="`mode` can be .* got unknown_option"):
         EarlyStopping(monitor="foo", mode="unknown_option")


### PR DESCRIPTION
## What does this PR do?

Fixes #19966.

When `EarlyStopping` decides to stop, it latches that decision:

```python
trainer.should_stop = trainer.should_stop or should_stop
```

`trainer.should_stop` is monotonic — nothing ever clears it. So if patience is exhausted *before* `min_epochs` is reached, the decision is frozen even though `_FitLoop._can_stop_early` correctly refuses to act on it yet. The callback keeps evaluating and may well flip its own verdict back to "don't stop" when the metric recovers, but the trainer never hears about it, and training dies the instant `min_epochs` is met.

Note this is **not** a stale `wait_count` problem, which is the intuitive reading of the issue: `_evaluate_stopping_criteria` does reset `wait_count = 0` on improvement, including inside the grace window. The added test asserts `wait_count == 0` at the moment training incorrectly stops.

### Fix

Don't latch a stop decision the trainer would ignore anyway. While under `min_epochs`, the verdict is re-derived on the next check instead of frozen at first trip. If the metric never recovers, `wait_count` is still `>= patience` when `min_epochs` is reached and training stops there exactly as before.

### An existing resume inconsistency this removes

`trainer.should_stop` is never checkpointed — it resets to `False` on every `fit()`. So on current master the same run gives different results depending on whether it was interrupted:

| | uninterrupted | crash at epoch 3 + resume |
|---|---|---|
| before | stops at epoch **6** | runs to epoch **8** |
| after | epoch **8** | epoch **8** |

Resuming already produced the behavior this PR makes unconditional.

### Checkpoint compatibility

State schema is unchanged, and the two load-bearing fields are byte-identical: `wait_count` and `best_score` are unaffected, so resumed patience arithmetic is identical. For a checkpoint taken *during* the grace window, three advisory fields differ — `stopped_epoch` (`2` → `0`), `stopping_reason` (`PATIENCE_EXHAUSTED` → `NOT_STOPPED`) and `stopping_reason_message`. These previously reported that the run had stopped at an epoch where it demonstrably had not, so the new values are more accurate, but it is technically a behavior change for anyone parsing them.

### Open question for maintainers (why this is a draft)

**`min_steps` still has the identical bug** and is deliberately left untouched. With `min_steps=1000` and 10 batches/epoch there is a 100-epoch grace window where a recovered metric is still killed at step 1000.

I excluded it because extending the fix to `min_steps` breaks `test_min_epochs_min_steps_global_step`: `training_epoch_loop` honors `min_steps` at *batch* granularity and stops mid-epoch exactly at the step boundary, which a once-per-validation callback cannot reproduce — deferring pushes the stop to the end of the epoch (step 12 instead of 10). That test encodes the current behavior, and I didn't want to unilaterally rewrite a passing test to make the patch fit. Is that batch-granular stop a guarantee worth keeping, or an artifact worth trading for consistency?

Secondary: should `divergence_threshold` / non-finite trips bypass the grace window as hard stops? They are currently deferred uniformly.

### Tests

Adds `test_early_stopping_recovers_from_improvement_during_min_epochs`, which fails on master (`assert 6 == 8`) and passes here.

```
tests/tests_pytorch/callbacks/test_early_stopping.py    54 passed
tests/tests_pytorch/callbacks                          363 passed, 37 skipped, 1 xfailed
tests/tests_pytorch/loops/test_training_loop.py + test_loops.py    72 passed
tests/tests_pytorch/loops/test_training_epoch_loop.py + trainer/flags/test_min_max_epochs.py    22 passed
```

<!-- ci-skip -->
