### PR TITLE
Fixes mypy issues with `bitsandbytes > 0.48`

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -28,6 +28,7 @@ jobs:
   mypy:
     runs-on: ubuntu-22.04
     env:
+      UV_TORCH_BACKEND: "cpu"
       # Supply-chain guard: skip PyPI releases newer than this. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
       UV_EXCLUDE_NEWER: "2 days"
     steps:

--- a/requirements/fabric/strategies.txt
+++ b/requirements/fabric/strategies.txt
@@ -6,4 +6,4 @@
 # note: is a bug around 0.10 with `MPS_Accelerator must implement all abstract methods`
 #  shall be resolved by https://github.com/microsoft/DeepSpeed/issues/4372
 deepspeed >=0.15.0,<0.17.0; platform_system != "Windows" and platform_system != "Darwin"  # strict
-bitsandbytes >=0.45.2,<0.47.0; platform_system != "Darwin"
+bitsandbytes >=0.45.2,<0.50.0; platform_system != "Darwin"

--- a/requirements/pytorch/extra.txt
+++ b/requirements/pytorch/extra.txt
@@ -8,4 +8,4 @@ hydra-core >=1.2.0, <1.4.0
 jsonargparse[signatures,jsonnet] >=4.39.0, <4.48.0
 rich >=12.3.0, <14.4.0
 tensorboardX >=2.2, <2.7.0  # min version is set by torch.onnx missing attribute
-bitsandbytes >=0.45.2,<0.47.0; platform_system != "Darwin"
+bitsandbytes >=0.45.2,<0.50.0; platform_system != "Darwin"

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed type checking for the `BitsandbytesPrecision` plugin with bitsandbytes 0.48+ ([#21858](https://github.com/Lightning-AI/pytorch-lightning/pull/21858))
+
 - Fixed DeepSpeed checkpoint path validation rejecting remote filesystem URIs (S3, GCS, HDFS) ([#21636](https://github.com/Lightning-AI/pytorch-lightning/pull/21636))
 
 - Fixed `FSDPStrategy` raising `RuntimeError` under PyTorch 2.5+ when `root_device` is CPU, by passing an explicit `torch.device("cpu")` instead of `device_id=None` (relevant only when the GPU-accelerator guard is bypassed) ([#21774](https://github.com/Lightning-AI/pytorch-lightning/pull/21774))

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed type checking for the `BitsandbytesPrecision` plugin with bitsandbytes 0.48+ ([#21858](https://github.com/Lightning-AI/pytorch-lightning/pull/21858))
+- Fixed type checking for the `BitsandbytesPrecision` plugin and raised the supported `bitsandbytes` ceiling to `<0.50` (compatible with 0.48/0.49) ([#21858](https://github.com/Lightning-AI/pytorch-lightning/pull/21858))
 
 - Fixed DeepSpeed checkpoint path validation rejecting remote filesystem URIs (S3, GCS, HDFS) ([#21636](https://github.com/Lightning-AI/pytorch-lightning/pull/21636))
 

--- a/src/lightning/fabric/plugins/precision/bitsandbytes.py
+++ b/src/lightning/fabric/plugins/precision/bitsandbytes.py
@@ -175,9 +175,7 @@ def _ignore_missing_weights_hook(module: torch.nn.Module, incompatible_keys: _In
             incompatible_keys.missing_keys.remove(key)
 
 
-def _replace_param(
-    param: torch.nn.Parameter, data: torch.Tensor, quant_state: Optional[tuple] = None
-) -> torch.nn.Parameter:
+def _replace_param(param: torch.Tensor, data: torch.Tensor, quant_state: Any = None) -> torch.nn.Parameter:
     bnb = _import_bitsandbytes()
 
     # doing `param.data = weight` raises a RuntimeError if param.data was on meta-device, so
@@ -199,7 +197,7 @@ def _replace_param(
     param.data = data
     if isinstance(param, bnb.nn.Params4bit):
         param.quant_state = quant_state
-    return param
+    return cast(torch.nn.Parameter, param)
 
 
 @functools.lru_cache(maxsize=1)
@@ -224,9 +222,9 @@ def _import_bitsandbytes() -> ModuleType:
         the state dict."""
 
         def __init__(self, *args: Any, device: Optional[_DEVICE] = None, threshold: float = 6.0, **kwargs: Any) -> None:
-            super().__init__(*args, device=device, threshold=threshold, **kwargs)
-            self.weight = cast(bnb.nn.Int8Params, self.weight)  # type: ignore[has-type]
-            self.bias: Optional[torch.nn.Parameter] = self.bias
+            kwargs.update(device=device, threshold=threshold)
+            super().__init__(*args, **kwargs)
+            self.weight = cast(bnb.nn.Int8Params, self.weight)
             # if the device is CUDA or we are under a CUDA context manager, quantize the weight here, so we don't end up
             # filling the device memory with float32 weights which could lead to OOM
             if torch.tensor(0, device=device).device.type == "cuda":
@@ -267,7 +265,8 @@ def _import_bitsandbytes() -> ModuleType:
                 setattr(int8params, "SCB", SCB)
             return int8params
 
-        def to_empty(self, *, device: _DEVICE, recurse: bool = True) -> Self:
+        def to_empty(self, *, device: Optional[_DEVICE], recurse: bool = True) -> Self:
+            assert device is not None
             if self.weight.device.type == "meta":
                 # need custom logic if int8params is on meta device
                 raise NotImplementedError
@@ -311,9 +310,9 @@ def _import_bitsandbytes() -> ModuleType:
         state dict, meta-device initialization, and materialization."""
 
         def __init__(self, *args: Any, device: Optional[_DEVICE] = None, **kwargs: Any) -> None:
-            super().__init__(*args, device=device, **kwargs)
-            self.weight = cast(bnb.nn.Params4bit, self.weight)  # type: ignore[has-type]
-            self.bias: Optional[torch.nn.Parameter] = self.bias
+            kwargs.update(device=device)
+            super().__init__(*args, **kwargs)
+            self.weight = cast(bnb.nn.Params4bit, self.weight)
             # if the device is CUDA or we are under a CUDA context manager, quantize the weight here, so we don't end up
             # filling the device memory with float32 weights which could lead to OOM
             if torch.tensor(0, device=device).device.type == "cuda":
@@ -348,9 +347,10 @@ def _import_bitsandbytes() -> ModuleType:
                 quant_type=params4bit.quant_type,
                 quant_storage=params4bit.quant_storage,
             )
-            return _replace_param(params4bit, w_4bit, quant_state)
+            return cast(bnb.nn.Params4bit, _replace_param(params4bit, w_4bit, quant_state))
 
-        def to_empty(self, *, device: _DEVICE, recurse: bool = True) -> Self:
+        def to_empty(self, *, device: Optional[_DEVICE], recurse: bool = True) -> Self:
+            assert device is not None
             if self.weight.dtype == torch.uint8:  # was quantized
                 # cannot init the quantized params directly
                 weight = torch.empty(self.weight.quant_state.shape, device=device, dtype=torch.half)


### PR DESCRIPTION
## What does this PR do?

Fixes mypy issues with bitsandbytes 0.48+

Follows up on #21851 by moving the bitsandbytes compatibility change into this PR.

> CUDA 13.0 CI began pulling a newer bitsandbytes (0.49.x), which changed the `Linear8bitLt` / `Linear4bit` constructor signatures and stubs and broke the `mypy` type check with **15 errors** (multiple-values-for-keyword, unused `type: ignore`, `bias` reassignment, `to_empty` Liskov violations, `_replace_param` arg/return types). Failing job: [code-checks / mypy on #21851](https://github.com/Lightning-AI/pytorch-lightning/actions/runs/30009935250/job/89215119509).

<img width="1508" height="573" alt="image" src="https://github.com/user-attachments/assets/06d72d7a-c890-4b53-9db8-13bbb9751188" />


This PR:

- Raises the test dependency ceiling from `<0.47.0` to `<0.50.0` so CUDA 13.0 CI can resolve a compatible bitsandbytes binary.
- Updates the Fabric bitsandbytes precision wrapper annotations for bitsandbytes 0.48+ without changing runtime behavior.
- Sets `UV_TORCH_BACKEND: "cpu"` on the `mypy` job so it resolves the CPU torch build.

