### PR TITLE
Fabric: validate named barriers across ranks

### DIFF
--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -633,6 +633,8 @@ class Fabric:
         will cause your program to slow down. This method needs to be called on all processes. Failing to do so will
         cause your program to stall forever.
 
+        The optional ``name`` must agree on every process. Different names fail before entering the barrier.
+
         """
         self._validate_launched()
         self._strategy.barrier(name=name)
@@ -864,7 +866,7 @@ class Fabric:
                 if not callable(v):
                     raise TypeError(f"Expected `fabric.save(filter=...)` for key {k!r} to be a callable, given {v!r}")
         self._strategy.save_checkpoint(path=path, state=_unwrap_objects(state), filter=filter)
-        self.barrier()
+        self.barrier("lightning.fabric.save")
 
     def load(
         self,

--- a/src/lightning/fabric/strategies/ddp.py
+++ b/src/lightning/fabric/strategies/ddp.py
@@ -39,6 +39,7 @@ from lightning.fabric.utilities.distributed import (
     _get_default_process_group_backend_for_device,
     _init_dist_connection,
     _sync_ddp_if_available,
+    _validate_same_barrier_name,
 )
 from lightning.fabric.utilities.distributed import group as _group
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_3
@@ -169,6 +170,7 @@ class DDPStrategy(ParallelStrategy):
     def barrier(self, *args: Any, **kwargs: Any) -> None:
         if not _distributed_is_initialized():
             return
+        _validate_same_barrier_name(kwargs.get("name", args[0] if args else None), device=self.root_device)
         if torch.distributed.get_backend() == "nccl":
             torch.distributed.barrier(device_ids=self._determine_ddp_device_ids())
         else:

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -67,6 +67,7 @@ from lightning.fabric.utilities.distributed import (
     _get_default_process_group_backend_for_device,
     _init_dist_connection,
     _sync_ddp_if_available,
+    _validate_same_barrier_name,
 )
 from lightning.fabric.utilities.distributed import group as _group
 from lightning.fabric.utilities.imports import (
@@ -393,6 +394,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
     def barrier(self, *args: Any, **kwargs: Any) -> None:
         if not _distributed_is_initialized():
             return
+        _validate_same_barrier_name(kwargs.get("name", args[0] if args else None), device=self.root_device)
         if torch.distributed.get_backend() == "nccl":
             torch.distributed.barrier(device_ids=[self.root_device.index])
         else:

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -57,6 +57,7 @@ from lightning.fabric.utilities.distributed import (
     _get_default_process_group_backend_for_device,
     _init_dist_connection,
     _sync_ddp_if_available,
+    _validate_same_barrier_name,
 )
 from lightning.fabric.utilities.distributed import group as _group
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_3, _TORCH_GREATER_EQUAL_2_4
@@ -225,6 +226,7 @@ class ModelParallelStrategy(ParallelStrategy):
     def barrier(self, *args: Any, **kwargs: Any) -> None:
         if not _distributed_is_initialized():
             return
+        _validate_same_barrier_name(kwargs.get("name", args[0] if args else None), device=self.root_device)
         if torch.distributed.get_backend() == "nccl":
             torch.distributed.barrier(device_ids=[self.root_device.index])
         else:

--- a/src/lightning/fabric/utilities/distributed.py
+++ b/src/lightning/fabric/utilities/distributed.py
@@ -437,9 +437,7 @@ def _validate_same_barrier_name(name: Optional[str], device: Optional[torch.devi
                 status = _BARRIER_NAME_STRING
             except UnicodeEncodeError:
                 status = _BARRIER_NAME_INVALID_ENCODING
-    metadata = torch.tensor(
-        [status, len(encoded_name)], dtype=torch.long, device=device
-    )
+    metadata = torch.tensor([status, len(encoded_name)], dtype=torch.long, device=device)
     gathered_metadata = [torch.empty_like(metadata) for _ in range(world_size)]
     try:
         torch.distributed.all_gather(gathered_metadata, metadata)
@@ -457,7 +455,9 @@ def _validate_same_barrier_name(name: Optional[str], device: Optional[torch.devi
         raise RuntimeError(f"Invalid barrier names on rank {rank}: invalid names by rank are {{{reasons}}}.")
     if any(size < 0 or size > _BARRIER_NAME_MAX_BYTES for _, size in metadata_by_rank):
         sizes = ", ".join(f"{gathered_rank}: {size}" for gathered_rank, (_, size) in enumerate(metadata_by_rank))
-        raise RuntimeError(f"Barrier names exceed {_BARRIER_NAME_MAX_BYTES} bytes on rank {rank}: sizes by rank are {{{sizes}}}.")
+        raise RuntimeError(
+            f"Barrier names exceed {_BARRIER_NAME_MAX_BYTES} bytes on rank {rank}: sizes by rank are {{{sizes}}}."
+        )
 
     max_size = max(size for _, size in metadata_by_rank)
     names: list[Optional[str]] = []

--- a/src/lightning/fabric/utilities/distributed.py
+++ b/src/lightning/fabric/utilities/distributed.py
@@ -401,6 +401,93 @@ def _distributed_is_initialized() -> bool:
     return torch.distributed.is_available() and torch.distributed.is_initialized()
 
 
+_BARRIER_NAME_MAX_BYTES = 1024
+_BARRIER_NAME_NONE = 0
+_BARRIER_NAME_STRING = 1
+_BARRIER_NAME_INVALID_TYPE = 2
+_BARRIER_NAME_INVALID_ENCODING = 3
+_BARRIER_NAME_STATUS = {
+    _BARRIER_NAME_INVALID_TYPE: "invalid type",
+    _BARRIER_NAME_INVALID_ENCODING: "invalid UTF-8",
+}
+
+
+def _validate_same_barrier_name(name: Optional[str], device: Optional[torch.device] = None) -> None:
+    """Validate that every rank uses the same optional name before entering a barrier."""
+    if not _distributed_is_initialized() or torch.distributed.get_world_size() == 1:
+        return
+
+    rank = torch.distributed.get_rank()
+    world_size = torch.distributed.get_world_size()
+    backend = torch.distributed.get_backend()
+    device = torch.device("cpu") if backend == "gloo" else device
+    if device is None and backend == "nccl":
+        device = torch.device("cuda", torch.cuda.current_device())
+    if device is None:
+        raise RuntimeError(f"Failed to validate barrier {name!r} on rank {rank}: no collective device is available.")
+
+    status = _BARRIER_NAME_NONE
+    encoded_name = b""
+    if name is not None:
+        if not isinstance(name, str):
+            status = _BARRIER_NAME_INVALID_TYPE
+        else:
+            try:
+                encoded_name = name.encode("utf-8")
+                status = _BARRIER_NAME_STRING
+            except UnicodeEncodeError:
+                status = _BARRIER_NAME_INVALID_ENCODING
+    metadata = torch.tensor(
+        [status, len(encoded_name)], dtype=torch.long, device=device
+    )
+    gathered_metadata = [torch.empty_like(metadata) for _ in range(world_size)]
+    try:
+        torch.distributed.all_gather(gathered_metadata, metadata)
+    except Exception as ex:
+        raise RuntimeError(f"Failed to validate barrier {name!r} on rank {rank}.") from ex
+
+    metadata_by_rank = [tuple(item.cpu().tolist()) for item in gathered_metadata]
+    invalid_ranks = []
+    for gathered_rank, (gathered_status, _) in enumerate(metadata_by_rank):
+        if gathered_status not in (_BARRIER_NAME_NONE, _BARRIER_NAME_STRING):
+            reason = _BARRIER_NAME_STATUS.get(gathered_status, f"unknown status {gathered_status}")
+            invalid_ranks.append(f"{gathered_rank}: {reason}")
+    if invalid_ranks:
+        reasons = ", ".join(invalid_ranks)
+        raise RuntimeError(f"Invalid barrier names on rank {rank}: invalid names by rank are {{{reasons}}}.")
+    if any(size < 0 or size > _BARRIER_NAME_MAX_BYTES for _, size in metadata_by_rank):
+        sizes = ", ".join(f"{gathered_rank}: {size}" for gathered_rank, (_, size) in enumerate(metadata_by_rank))
+        raise RuntimeError(f"Barrier names exceed {_BARRIER_NAME_MAX_BYTES} bytes on rank {rank}: sizes by rank are {{{sizes}}}.")
+
+    max_size = max(size for _, size in metadata_by_rank)
+    names: list[Optional[str]] = []
+    if max_size:
+        padded_name = torch.zeros(max_size, dtype=torch.uint8, device=device)
+        if encoded_name:
+            padded_name[: len(encoded_name)] = torch.tensor(list(encoded_name), dtype=torch.uint8, device=device)
+        gathered_names = [torch.empty_like(padded_name) for _ in range(world_size)]
+        try:
+            torch.distributed.all_gather(gathered_names, padded_name)
+        except Exception as ex:
+            raise RuntimeError(f"Failed to validate barrier {name!r} on rank {rank}.") from ex
+        names = [
+            None
+            if gathered_status == _BARRIER_NAME_NONE
+            else bytes(gathered_name[:size].cpu().tolist()).decode("utf-8")
+            for (gathered_status, size), gathered_name in zip(metadata_by_rank, gathered_names)
+        ]
+    else:
+        names = [None if gathered_status == _BARRIER_NAME_NONE else "" for gathered_status, _ in metadata_by_rank]
+
+    if all(gathered_name == name for gathered_name in names):
+        return
+
+    rank_names = ", ".join(f"{gathered_rank}: {gathered_name!r}" for gathered_rank, gathered_name in enumerate(names))
+    raise RuntimeError(
+        f"Barrier name mismatch on rank {rank}: local name is {name!r}; names by rank are {{{rank_names}}}."
+    )
+
+
 class _InfiniteBarrier:
     """A barrier with an infinite timeout.
 

--- a/tests/tests_fabric/strategies/test_ddp.py
+++ b/tests/tests_fabric/strategies/test_ddp.py
@@ -220,3 +220,19 @@ def test_device_id_passed_for_cuda_devices(init_process_group_mock):
         timeout=cuda_strategy._timeout,
         **kwargs,
     )
+def test_ddp_barrier_validates_name_before_entering_the_collective():
+    import torch
+    from unittest.mock import ANY, Mock, patch
+
+    from lightning.fabric.strategies.ddp import DDPStrategy
+
+    validator = Mock()
+    with (
+        patch("lightning.fabric.strategies.ddp._distributed_is_initialized", return_value=True),
+        patch("lightning.fabric.strategies.ddp._validate_same_barrier_name", validator),
+        patch("torch.distributed.get_backend", return_value="gloo"),
+        patch("torch.distributed.barrier"),
+    ):
+        DDPStrategy(parallel_devices=[torch.device("cpu")]).barrier(name="test.ddp")
+
+    validator.assert_called_once_with("test.ddp", device=ANY)

--- a/tests/tests_fabric/strategies/test_ddp.py
+++ b/tests/tests_fabric/strategies/test_ddp.py
@@ -220,9 +220,12 @@ def test_device_id_passed_for_cuda_devices(init_process_group_mock):
         timeout=cuda_strategy._timeout,
         **kwargs,
     )
+
+
 def test_ddp_barrier_validates_name_before_entering_the_collective():
-    import torch
     from unittest.mock import ANY, Mock, patch
+
+    import torch
 
     from lightning.fabric.strategies.ddp import DDPStrategy
 

--- a/tests/tests_fabric/strategies/test_ddp_integration.py
+++ b/tests/tests_fabric/strategies/test_ddp_integration.py
@@ -130,6 +130,8 @@ def test_clip_gradients(clip_type, accelerator, precision):
     fabric = Fabric(accelerator=accelerator, devices=2, precision=precision, strategy="ddp")
     fabric.launch()
     _run_test_clip_gradients(fabric=fabric, clip_type=clip_type)
+
+
 def _barrier_name_mismatch_worker(rank, world_size, init_file):
     from datetime import timedelta
 

--- a/tests/tests_fabric/strategies/test_ddp_integration.py
+++ b/tests/tests_fabric/strategies/test_ddp_integration.py
@@ -130,3 +130,29 @@ def test_clip_gradients(clip_type, accelerator, precision):
     fabric = Fabric(accelerator=accelerator, devices=2, precision=precision, strategy="ddp")
     fabric.launch()
     _run_test_clip_gradients(fabric=fabric, clip_type=clip_type)
+def _barrier_name_mismatch_worker(rank, world_size, init_file):
+    from datetime import timedelta
+
+    import pytest
+    import torch
+    import torch.distributed
+
+    from lightning.fabric.strategies.ddp import DDPStrategy
+
+    torch.distributed.init_process_group(
+        "gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size, timeout=timedelta(seconds=10)
+    )
+    try:
+        strategy = DDPStrategy(parallel_devices=[torch.device("cpu")])
+        name = "test.ddp.rank_zero" if rank == 0 else "test.ddp.rank_one"
+        with pytest.raises(RuntimeError, match="Barrier name mismatch"):
+            strategy.barrier(name=name)
+        strategy.barrier(name="test.ddp.reuse")
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+@RunIf(standalone=True)
+def test_ddp_barrier_name_mismatch_fails_on_every_rank_and_the_group_is_reusable(tmp_path):
+    init_file = tmp_path / "barrier-name-init"
+    torch.multiprocessing.spawn(_barrier_name_mismatch_worker, args=(2, str(init_file)), nprocs=2, join=True)

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -699,6 +699,8 @@ def test_get_distributed_checkpoint_reader_missing_fsspec_module(monkeypatch):
     monkeypatch.setitem(sys.modules, "torch.distributed.checkpoint._fsspec_filesystem", None)
     with pytest.raises(ImportError, match=r"Remote .fsspec. distributed checkpoints require"):
         _get_distributed_checkpoint_reader("memory:///w/ckpt")
+
+
 def test_fsdp_barrier_validates_name_before_entering_the_collective():
     from unittest.mock import ANY, Mock, patch
 

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -699,3 +699,18 @@ def test_get_distributed_checkpoint_reader_missing_fsspec_module(monkeypatch):
     monkeypatch.setitem(sys.modules, "torch.distributed.checkpoint._fsspec_filesystem", None)
     with pytest.raises(ImportError, match=r"Remote .fsspec. distributed checkpoints require"):
         _get_distributed_checkpoint_reader("memory:///w/ckpt")
+def test_fsdp_barrier_validates_name_before_entering_the_collective():
+    from unittest.mock import ANY, Mock, patch
+
+    from lightning.fabric.strategies.fsdp import FSDPStrategy
+
+    validator = Mock()
+    with (
+        patch("lightning.fabric.strategies.fsdp._distributed_is_initialized", return_value=True),
+        patch("lightning.fabric.strategies.fsdp._validate_same_barrier_name", validator),
+        patch("torch.distributed.get_backend", return_value="gloo"),
+        patch("torch.distributed.barrier"),
+    ):
+        FSDPStrategy.barrier(Mock(), name="test.fsdp")
+
+    validator.assert_called_once_with("test.fsdp", device=ANY)

--- a/tests/tests_fabric/strategies/test_model_parallel.py
+++ b/tests/tests_fabric/strategies/test_model_parallel.py
@@ -434,6 +434,8 @@ def test_model_parallel_load_checkpoint_loads_non_tensor_metadata(monkeypatch, t
     mp._load_checkpoint(path=ckpt_dir, state=state, strict=False)
     assert isinstance(state["user_meta"], _NonTensorMeta)
     assert state["user_meta"].value == 42
+
+
 def test_model_parallel_barrier_validates_name_before_entering_the_collective():
     from unittest.mock import ANY, Mock, patch
 

--- a/tests/tests_fabric/strategies/test_model_parallel.py
+++ b/tests/tests_fabric/strategies/test_model_parallel.py
@@ -434,3 +434,18 @@ def test_model_parallel_load_checkpoint_loads_non_tensor_metadata(monkeypatch, t
     mp._load_checkpoint(path=ckpt_dir, state=state, strict=False)
     assert isinstance(state["user_meta"], _NonTensorMeta)
     assert state["user_meta"].value == 42
+def test_model_parallel_barrier_validates_name_before_entering_the_collective():
+    from unittest.mock import ANY, Mock, patch
+
+    from lightning.fabric.strategies.model_parallel import ModelParallelStrategy
+
+    validator = Mock()
+    with (
+        patch("lightning.fabric.strategies.model_parallel._distributed_is_initialized", return_value=True),
+        patch("lightning.fabric.strategies.model_parallel._validate_same_barrier_name", validator),
+        patch("torch.distributed.get_backend", return_value="gloo"),
+        patch("torch.distributed.barrier"),
+    ):
+        ModelParallelStrategy.barrier(Mock(), name="test.model_parallel")
+
+    validator.assert_called_once_with("test.model_parallel", device=ANY)

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -1388,3 +1388,11 @@ def test_fabric_load_raw_forwards_weights_only_to_strategy(weights_only):
     fabric.strategy.load_checkpoint.assert_called_with(
         path="path.pt", state=model, strict=True, weights_only=weights_only
     )
+def test_save_uses_a_stable_barrier_name(tmp_path):
+    fabric = Fabric()
+    fabric._strategy.save_checkpoint = Mock()
+    fabric.barrier = Mock()
+
+    fabric.save(tmp_path / "checkpoint.ckpt", {})
+
+    fabric.barrier.assert_called_once_with("lightning.fabric.save")

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -1388,6 +1388,8 @@ def test_fabric_load_raw_forwards_weights_only_to_strategy(weights_only):
     fabric.strategy.load_checkpoint.assert_called_with(
         path="path.pt", state=model, strict=True, weights_only=weights_only
     )
+
+
 def test_save_uses_a_stable_barrier_name(tmp_path):
     fabric = Fabric()
     fabric._strategy.save_checkpoint = Mock()

--- a/tests/tests_fabric/utilities/test_distributed.py
+++ b/tests/tests_fabric/utilities/test_distributed.py
@@ -337,6 +337,8 @@ def test_distributed_sampler_wrapper_set_epoch():
     wrapper.set_epoch(5)  # Should not raise
     assert wrapper.epoch == 5
     assert sampler_non_callable.set_epoch == "not a method"  # Should remain unchanged
+
+
 def _copy_barrier_name_collective(gathered, value):
     for output in gathered:
         output.copy_(value)
@@ -380,8 +382,9 @@ def test_validate_same_barrier_name_uses_gloo_cpu_and_round_trips_utf8():
 
 
 def test_validate_same_barrier_name_uses_the_strategy_root_device():
-    import torch
     from unittest.mock import patch
+
+    import torch
 
     from lightning.fabric.utilities.distributed import _validate_same_barrier_name
 
@@ -405,8 +408,9 @@ def test_validate_same_barrier_name_uses_the_strategy_root_device():
 
 
 def _assert_barrier_name_mismatch(local_name, names):
-    import torch
     from unittest.mock import patch
+
+    import torch
 
     from lightning.fabric.utilities.distributed import _validate_same_barrier_name
 

--- a/tests/tests_fabric/utilities/test_distributed.py
+++ b/tests/tests_fabric/utilities/test_distributed.py
@@ -337,3 +337,186 @@ def test_distributed_sampler_wrapper_set_epoch():
     wrapper.set_epoch(5)  # Should not raise
     assert wrapper.epoch == 5
     assert sampler_non_callable.set_epoch == "not a method"  # Should remain unchanged
+def _copy_barrier_name_collective(gathered, value):
+    for output in gathered:
+        output.copy_(value)
+
+
+def test_validate_same_barrier_name_noops_without_a_multi_process_group():
+    from unittest.mock import patch
+
+    from lightning.fabric.utilities.distributed import _validate_same_barrier_name
+
+    with patch("lightning.fabric.utilities.distributed._distributed_is_initialized", return_value=False):
+        _validate_same_barrier_name("save")
+    with (
+        patch("lightning.fabric.utilities.distributed._distributed_is_initialized", return_value=True),
+        patch("torch.distributed.get_world_size", return_value=1),
+    ):
+        _validate_same_barrier_name("save")
+
+
+def test_validate_same_barrier_name_uses_gloo_cpu_and_round_trips_utf8():
+    from unittest.mock import patch
+
+    from lightning.fabric.utilities.distributed import _validate_same_barrier_name
+
+    devices = []
+
+    def gather(gathered, value):
+        devices.append(value.device)
+        _copy_barrier_name_collective(gathered, value)
+
+    with (
+        patch("lightning.fabric.utilities.distributed._distributed_is_initialized", return_value=True),
+        patch("torch.distributed.get_world_size", return_value=2),
+        patch("torch.distributed.get_rank", return_value=0),
+        patch("torch.distributed.get_backend", return_value="gloo"),
+        patch("torch.distributed.all_gather", side_effect=gather),
+    ):
+        _validate_same_barrier_name("save-\u2713")
+
+    assert [device.type for device in devices] == ["cpu", "cpu"]
+
+
+def test_validate_same_barrier_name_uses_the_strategy_root_device():
+    import torch
+    from unittest.mock import patch
+
+    from lightning.fabric.utilities.distributed import _validate_same_barrier_name
+
+    root_device = torch.device("cpu")
+    devices = []
+
+    def gather(gathered, value):
+        devices.append(value.device)
+        _copy_barrier_name_collective(gathered, value)
+
+    with (
+        patch("lightning.fabric.utilities.distributed._distributed_is_initialized", return_value=True),
+        patch("torch.distributed.get_world_size", return_value=2),
+        patch("torch.distributed.get_rank", return_value=0),
+        patch("torch.distributed.get_backend", return_value="nccl"),
+        patch("torch.distributed.all_gather", side_effect=gather),
+    ):
+        _validate_same_barrier_name("save", device=root_device)
+
+    assert devices == [root_device, root_device]
+
+
+def _assert_barrier_name_mismatch(local_name, names):
+    import torch
+    from unittest.mock import patch
+
+    from lightning.fabric.utilities.distributed import _validate_same_barrier_name
+
+    def gather(gathered, value):
+        if value.dtype == torch.long:
+            for output, gathered_name in zip(gathered, names):
+                encoded_name = (gathered_name or "").encode()
+                output.copy_(
+                    torch.tensor([gathered_name is not None, len(encoded_name)], dtype=torch.long, device=value.device)
+                )
+            return
+        for output, gathered_name in zip(gathered, names):
+            encoded_name = (gathered_name or "").encode()
+            output.zero_()
+            if encoded_name:
+                output[: len(encoded_name)] = torch.tensor(list(encoded_name), dtype=torch.uint8, device=value.device)
+
+    with (
+        patch("lightning.fabric.utilities.distributed._distributed_is_initialized", return_value=True),
+        patch("torch.distributed.get_world_size", return_value=2),
+        patch("torch.distributed.get_rank", return_value=0),
+        patch("torch.distributed.get_backend", return_value="gloo"),
+        patch("torch.distributed.all_gather", side_effect=gather),
+        pytest.raises(RuntimeError, match="Barrier name mismatch on rank 0") as exc_info,
+    ):
+        _validate_same_barrier_name(local_name)
+
+    expected_mapping = ", ".join(f"{rank}: {name!r}" for rank, name in enumerate(names))
+    assert f"names by rank are {{{expected_mapping}}}" in str(exc_info.value)
+
+
+def test_validate_same_barrier_name_rejects_mismatched_strings():
+    _assert_barrier_name_mismatch("save", ["save", "load"])
+
+
+def test_validate_same_barrier_name_rejects_empty_string_and_none():
+    _assert_barrier_name_mismatch("", ["", None])
+
+
+def test_validate_same_barrier_name_handles_unequal_utf8_lengths_and_padding():
+    _assert_barrier_name_mismatch("\u00e9", ["\u00e9", "\u65e5\u672c"])
+
+
+def test_validate_same_barrier_name_allows_exactly_maximum_size():
+    from unittest.mock import patch
+
+    from lightning.fabric.utilities.distributed import _BARRIER_NAME_MAX_BYTES, _validate_same_barrier_name
+
+    with (
+        patch("lightning.fabric.utilities.distributed._distributed_is_initialized", return_value=True),
+        patch("torch.distributed.get_world_size", return_value=2),
+        patch("torch.distributed.get_rank", return_value=0),
+        patch("torch.distributed.get_backend", return_value="gloo"),
+        patch("torch.distributed.all_gather", side_effect=_copy_barrier_name_collective),
+    ):
+        _validate_same_barrier_name("a" * _BARRIER_NAME_MAX_BYTES)
+
+
+def test_validate_same_barrier_name_rejects_oversize_after_metadata_exchange():
+    from unittest.mock import Mock, patch
+
+    from lightning.fabric.utilities.distributed import _BARRIER_NAME_MAX_BYTES, _validate_same_barrier_name
+
+    all_gather = Mock(side_effect=_copy_barrier_name_collective)
+    with (
+        patch("lightning.fabric.utilities.distributed._distributed_is_initialized", return_value=True),
+        patch("torch.distributed.get_world_size", return_value=2),
+        patch("torch.distributed.get_rank", return_value=0),
+        patch("torch.distributed.get_backend", return_value="gloo"),
+        patch("torch.distributed.all_gather", all_gather),
+        pytest.raises(RuntimeError, match="exceed"),
+    ):
+        _validate_same_barrier_name("a" * (_BARRIER_NAME_MAX_BYTES + 1))
+
+    assert all_gather.call_count == 1
+
+
+@pytest.mark.parametrize(("name", "match"), [(object(), "invalid type"), (chr(0xD800), "invalid UTF-8")])
+def test_validate_same_barrier_name_rejects_invalid_values_after_metadata_exchange(name, match):
+    from unittest.mock import Mock, patch
+
+    from lightning.fabric.utilities.distributed import _validate_same_barrier_name
+
+    all_gather = Mock(side_effect=_copy_barrier_name_collective)
+    with (
+        patch("lightning.fabric.utilities.distributed._distributed_is_initialized", return_value=True),
+        patch("torch.distributed.get_world_size", return_value=2),
+        patch("torch.distributed.get_rank", return_value=1),
+        patch("torch.distributed.get_backend", return_value="gloo"),
+        patch("torch.distributed.all_gather", all_gather),
+        pytest.raises(RuntimeError, match=match),
+    ):
+        _validate_same_barrier_name(name)  # type: ignore[arg-type]
+
+    assert all_gather.call_count == 1
+
+
+def test_validate_same_barrier_name_wraps_collective_failures():
+    from unittest.mock import patch
+
+    from lightning.fabric.utilities.distributed import _validate_same_barrier_name
+
+    with (
+        patch("lightning.fabric.utilities.distributed._distributed_is_initialized", return_value=True),
+        patch("torch.distributed.get_world_size", return_value=2),
+        patch("torch.distributed.get_rank", return_value=1),
+        patch("torch.distributed.get_backend", return_value="gloo"),
+        patch("torch.distributed.all_gather", side_effect=RuntimeError("collective failed")),
+        pytest.raises(RuntimeError, match="barrier 'save' on rank 1") as exc_info,
+    ):
+        _validate_same_barrier_name("save")
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)


### PR DESCRIPTION
## What

- validate optional Fabric barrier names across distributed ranks before the backend barrier
- preserve existing Gloo, NCCL, and PrivateUse1 device behavior
- report deterministic rank-to-name mismatches on every participating rank
- give the internal `Fabric.save()` synchronization a stable name

Fixes #20027

## Tests

- focused Fabric barrier suite: 15 passed, 1 standalone test skipped, 0 failed
- Python compile check: passed for all 11 changed files
- staged secret scan: clean

## Draft status

The two-rank standalone Gloo regression is included but its local standalone process terminated without a report. CI verification is still required before this is ready to merge.
