### PR TITLE
Warn when a dataloader init argument cannot be read back

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -28,7 +28,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed type checking for the `BitsandbytesPrecision` plugin and raised the supported `bitsandbytes` ceiling to `<0.50` (compatible with 0.48/0.49) ([#21858](https://github.com/Lightning-AI/pytorch-lightning/pull/21858))
 
-- Fixed a re-instantiated custom `DataLoader` silently falling back to default arguments when an `__init__` argument is stored under a different attribute name; a warning is now raised naming the arguments ([#21850](https://github.com/Lightning-AI/pytorch-lightning/pull/21850))
+- Fixed a re-instantiated custom `DataLoader` silently falling back to default arguments when an `__init__` argument is stored under a different attribute name; a warning is now raised naming the arguments ([#21864](https://github.com/Lightning-AI/pytorch-lightning/pull/21864))
 
 - Fixed DeepSpeed checkpoint path validation rejecting remote filesystem URIs (S3, GCS, HDFS) ([#21636](https://github.com/Lightning-AI/pytorch-lightning/pull/21636))
 

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed type checking for the `BitsandbytesPrecision` plugin and raised the supported `bitsandbytes` ceiling to `<0.50` (compatible with 0.48/0.49) ([#21858](https://github.com/Lightning-AI/pytorch-lightning/pull/21858))
 
+- Fixed a re-instantiated custom `DataLoader` silently falling back to default arguments when an `__init__` argument is stored under a different attribute name; a warning is now raised naming the arguments ([#21850](https://github.com/Lightning-AI/pytorch-lightning/pull/21850))
+
 - Fixed DeepSpeed checkpoint path validation rejecting remote filesystem URIs (S3, GCS, HDFS) ([#21636](https://github.com/Lightning-AI/pytorch-lightning/pull/21636))
 
 - Fixed `FSDPStrategy` raising `RuntimeError` under PyTorch 2.5+ when `root_device` is CPU, by passing an explicit `torch.device("cpu")` instead of `device_id=None` (relevant only when the GPU-accelerator guard is bypassed) ([#21774](https://github.com/Lightning-AI/pytorch-lightning/pull/21774))

--- a/src/lightning/fabric/utilities/data.py
+++ b/src/lightning/fabric/utilities/data.py
@@ -167,7 +167,10 @@ def _get_dataloader_init_args_and_kwargs(
     required_args = {
         p.name
         for p in params.values()
-        if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+        # `KEYWORD_ONLY` is included so that a required keyword-only argument (`def __init__(self, *args, x,
+        # **kwargs)`) reports the message below rather than falling through to a raw `TypeError` from the
+        # re-instantiation: it has no default, so the warning above does not cover it either.
+        if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY)
         and p.default is p.empty
         and p.name not in dl_kwargs
         and p.name not in arg_names

--- a/src/lightning/fabric/utilities/data.py
+++ b/src/lightning/fabric/utilities/data.py
@@ -102,6 +102,9 @@ def _get_dataloader_init_args_and_kwargs(
 
     # get the dataloader instance `__init__` parameters
     params = dict(inspect.signature(dataloader.__init__).parameters)  # type: ignore[misc]
+    # the parameters the subclass declares itself, captured before `DataLoader`'s own are
+    # merged in below, so the check further down only reports the user's own arguments
+    subclass_params = dict(params)
     has_variadic_kwargs = any(p.kind is p.VAR_KEYWORD for p in params.values())
     if has_variadic_kwargs:
         # if the signature takes **kwargs, assume they will be passed down with `super().__init__(**kwargs)`
@@ -125,6 +128,34 @@ def _get_dataloader_init_args_and_kwargs(
         # kwargs to re-construct the dataloader
         dl_kwargs = {k: v for k, v in attrs.items() if k in non_defaults}
         dl_args = ()
+
+        # A subclass argument that is stored under a different attribute name (a common
+        # case being `self._x = x`) cannot be read back here, so the re-instantiated
+        # dataloader silently falls back to the default. The `required_args` check below
+        # already reports this for arguments without a default; without this warning the
+        # same situation passes unnoticed whenever the argument has one.
+        # only the arguments the subclass adds on top of `DataLoader`: the base class has
+        # defaulted parameters that it deliberately does not expose under the same name
+        base_params = set(inspect.signature(DataLoader.__init__).parameters)
+        unresolved = sorted(
+            name
+            for name, p in subclass_params.items()
+            if name != "self"
+            and name not in base_params
+            and p.kind in (p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY)
+            and p.default is not p.empty
+            and name not in attrs
+        )
+        if unresolved:
+            dataloader_cls_name = dataloader.__class__.__name__
+            missing = ", ".join(f"`self.{name}`" for name in unresolved)
+            rank_zero_warn(
+                f"Trying to re-instantiate the `{dataloader_cls_name}` instance, but the arguments"
+                f" {unresolved} are not available as instance attributes of the same name, so they"
+                " will fall back to their defaults and any value you passed will be lost."
+                f" HINT: If you wrote the `{dataloader_cls_name}` class, store them as {missing}"
+                " inside your `__init__`."
+            )
 
     dataset = dl_kwargs.get("dataset", original_dataset)
     if isinstance(dataset, IterableDataset):

--- a/tests/tests_fabric/utilities/test_data.py
+++ b/tests/tests_fabric/utilities/test_data.py
@@ -704,3 +704,42 @@ def test_state():
     assert "key1" not in state
     with pytest.raises(KeyError):
         del state.key3
+
+
+def test_update_dataloader_warns_when_init_arg_is_not_readable_back():
+    """An argument stored under a different attribute name cannot be recovered, so warn instead of
+    silently falling back to its default (see #20265)."""
+
+    class RenamedAttribute(DataLoader):
+        def __init__(self, *args, x=None, **kwargs):
+            super().__init__(*args, **kwargs)
+            # stored as `_x`, so `_update_dataloader` cannot read `x` back
+            self._x = x
+
+    dataloader = RenamedAttribute([1, 2, 3], batch_size=2, x=2)
+    with pytest.warns(UserWarning, match=r"arguments \['x'\] are not available as instance attributes"):
+        new_dataloader = _update_dataloader(dataloader, dataloader.sampler)
+    # the value is still lost, but no longer silently
+    assert new_dataloader._x is None
+
+
+def test_update_dataloader_does_not_warn_when_init_arg_is_readable_back():
+    """The documented convention (`self.x = x`) round-trips, so it must stay silent."""
+
+    class ConventionalAttribute(DataLoader):
+        def __init__(self, *args, x=None, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.x = x
+
+    dataloader = ConventionalAttribute([1, 2, 3], batch_size=2, x=2)
+    with no_warning_call(UserWarning, match="not available as instance attributes"):
+        new_dataloader = _update_dataloader(dataloader, dataloader.sampler)
+    assert new_dataloader.x == 2
+
+
+def test_update_dataloader_does_not_warn_for_plain_dataloader():
+    """`DataLoader`'s own defaulted parameters are not all exposed as same-named attributes, so the
+    check must only consider arguments a subclass adds."""
+    dataloader = DataLoader([1, 2, 3], batch_size=2)
+    with no_warning_call(UserWarning, match="not available as instance attributes"):
+        _update_dataloader(dataloader, dataloader.sampler)

--- a/tests/tests_fabric/utilities/test_data.py
+++ b/tests/tests_fabric/utilities/test_data.py
@@ -707,8 +707,8 @@ def test_state():
 
 
 def test_update_dataloader_warns_when_init_arg_is_not_readable_back():
-    """An argument stored under a different attribute name cannot be recovered, so warn instead of
-    silently falling back to its default (see #20265)."""
+    """An argument stored under a different attribute name cannot be recovered, so warn instead of silently falling
+    back to its default (see #20265)."""
 
     class RenamedAttribute(DataLoader):
         def __init__(self, *args, x=None, **kwargs):
@@ -738,8 +738,8 @@ def test_update_dataloader_does_not_warn_when_init_arg_is_readable_back():
 
 
 def test_update_dataloader_does_not_warn_for_plain_dataloader():
-    """`DataLoader`'s own defaulted parameters are not all exposed as same-named attributes, so the
-    check must only consider arguments a subclass adds."""
+    """`DataLoader`'s own defaulted parameters are not all exposed as same-named attributes, so the check must only
+    consider arguments a subclass adds."""
     dataloader = DataLoader([1, 2, 3], batch_size=2)
     with no_warning_call(UserWarning, match="not available as instance attributes"):
         _update_dataloader(dataloader, dataloader.sampler)

--- a/tests/tests_fabric/utilities/test_data.py
+++ b/tests/tests_fabric/utilities/test_data.py
@@ -737,6 +737,25 @@ def test_update_dataloader_does_not_warn_when_init_arg_is_readable_back():
     assert new_dataloader.x == 2
 
 
+def test_update_dataloader_reports_required_keyword_only_init_arg():
+    """A required keyword-only argument reports the missing-attribute message, not a raw TypeError.
+
+    It has no default, so the unresolved-argument warning does not apply; before ``KEYWORD_ONLY`` was added to
+    ``required_args`` it fell through both branches and surfaced as ``TypeError: missing 1 required keyword-only
+    argument``.
+    """
+
+    class RequiredKeywordOnly(DataLoader):
+        def __init__(self, *args, x, **kwargs):
+            super().__init__(*args, **kwargs)
+            # stored as `_x`, so `x` cannot be read back
+            self._x = x
+
+    dataloader = RequiredKeywordOnly([1, 2, 3], batch_size=2, x=2)
+    with pytest.raises(MisconfigurationException, match="`self.x`"):
+        _update_dataloader(dataloader, dataloader.sampler)
+
+
 def test_update_dataloader_does_not_warn_for_plain_dataloader():
     """`DataLoader`'s own defaulted parameters are not all exposed as same-named attributes, so the check must only
     consider arguments a subclass adds."""

--- a/tests/tests_fabric/utilities/test_data.py
+++ b/tests/tests_fabric/utilities/test_data.py
@@ -743,6 +743,7 @@ def test_update_dataloader_reports_required_keyword_only_init_arg():
     It has no default, so the unresolved-argument warning does not apply; before ``KEYWORD_ONLY`` was added to
     ``required_args`` it fell through both branches and surfaced as ``TypeError: missing 1 required keyword-only
     argument``.
+
     """
 
     class RequiredKeywordOnly(DataLoader):


### PR DESCRIPTION
## What does this PR do?

Fixes #20265

`_update_dataloader` rebuilds a dataloader by reading its `__init__` arguments back off the instance. An argument stored under a different attribute name (the common `self._x = x`) is not readable that way, so the rebuilt dataloader quietly gets the default instead of the value that was passed:

```python
class MyDataLoader(DataLoader):
    def __init__(self, *args, x=None, **kwargs):
        super().__init__(*args, **kwargs)
        self._x = x          # not `self.x`

orig = MyDataLoader(dataset, batch_size=2, x=2)
new = _update_dataloader(orig, orig.sampler)
# orig._x == 2, new._x is None
```

This bites during distributed training and `trainer.predict()`, where Lightning re-instantiates the dataloader to inject a sampler. The reporter hit it with DDP; it also reproduces on a single CPU device via `predict`.

The file already handles this case loudly for arguments *without* a default: `required_args` raises a `MisconfigurationException` whose message tells the user to `define self.<arg> inside your __init__`. The same situation slips through silently as soon as the argument has a default, because it is no longer "required" and the `missing_kwargs` check is skipped when the signature takes `**kwargs`.

So rather than guessing at the attribute (`_x` -> `x` is only a convention and could copy an unrelated private attribute), this warns and names the arguments, consistent with the guidance the existing error already gives:

```
Trying to re-instantiate the `MyDataLoader` instance, but the arguments ['x'] are not
available as instance attributes of the same name, so they will fall back to their
defaults and any value you passed will be lost. HINT: If you wrote the `MyDataLoader`
class, store them as `self.x` inside your `__init__`.
```

The check only looks at arguments a subclass adds on top of `DataLoader`. `DataLoader` itself has defaulted parameters it does not expose as same-named attributes, and including those made a plain `DataLoader` warn: I hit that while writing this and there is a regression test pinning it.

No behavior change beyond the warning, and nothing that was working starts failing.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? Yes, #20265.
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? Not needed, no public API change.
- Did you write any **new necessary tests**? Yes, three in `tests/tests_fabric/utilities/test_data.py`:
  - `test_update_dataloader_warns_when_init_arg_is_not_readable_back` (the issue's shape)
  - `test_update_dataloader_does_not_warn_when_init_arg_is_readable_back` (the documented `self.x = x` convention stays silent)
  - `test_update_dataloader_does_not_warn_for_plain_dataloader` (guards the false positive noted above)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request? None.
- Did you **update the CHANGELOG**? Yes, under `fabric` / Fixed.

</details>

### Test results

The first new test fails without the change (`DID NOT WARN`) and passes with it; the other two pass either way, since they exist to catch regressions.

```text
$ pytest tests/tests_fabric/utilities/test_data.py
53 passed, 9 skipped
```

Ran on Windows, CPU-only, `torch 2.13.0+cpu`. One unrelated pre-existing failure in this directory, `test_cloud_io.py::test_resolve_path_local_vs_remote`, comes from the space in my Windows username being percent-encoded; it fails identically with my changes stashed.

## PR review

Anyone in the community is welcome to review the PR.
