### PR TITLE
docs: remove duplicate and incorrect filename entry in ModelCheckpoint docstring

### DIFF
--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -95,10 +95,6 @@ class ModelCheckpoint(Checkpoint):
             (default: ``None``). If dirpath is ``None``, we only keep the ``k`` best checkpoints
             in memory, and do not save anything to disk.
 
-        filename: Checkpoint filename. Can contain named formatting options to be auto-filled.
-            If no name is provided, it will be ``None`` and the checkpoint will be saved to
-            ``{epoch}``.and if the Trainer uses a logger, the path will also contain logger name and version.
-
         filename: checkpoint filename. Can contain named formatting options to be auto-filled.
 
             Example::


### PR DESCRIPTION
The `filename` argument is documented twice in the `ModelCheckpoint` Args docstring. The first entry is a broken duplicate: it says the default is saved to ``{epoch}`` and contains the malformed fragment "``{epoch}``.and if the Trainer..." (missing space and a stray period mid-sentence). The default is actually `'{epoch}-{step}'` (built from `"{epoch}"` + `CHECKPOINT_JOIN_CHAR` + `"{step}"`), which the second `filename` entry already documents correctly. This removes the redundant, incorrect first entry and keeps the correct one as the single source of truth.