### PR TITLE
Use FutureWarning instead of DeprecationWarning for deprecation warnings

### DIFF
--- a/src/lightning/fabric/utilities/warnings.py
+++ b/src/lightning/fabric/utilities/warnings.py
@@ -15,12 +15,12 @@
 
 import warnings
 from pathlib import Path
-from typing import Optional, Type, Union
+from typing import Optional, Union
 
-from lightning.fabric.utilities.rank_zero import LightningDeprecationWarning
+from lightning.fabric.utilities.rank_zero import LightningFutureWarning
 
 # enable our warnings
-warnings.simplefilter("default", category=LightningDeprecationWarning)
+warnings.simplefilter("default", category=LightningFutureWarning)
 _default_format_warning = warnings.formatwarning
 
 
@@ -38,7 +38,7 @@ def disable_possible_user_warnings(module: str = "") -> None:
 
 
 def _custom_format_warning(
-    message: Union[Warning, str], category: Type[Warning], filename: str, lineno: int, line: Optional[str] = None
+    message: Union[Warning, str], category: type[Warning], filename: str, lineno: int, line: Optional[str] = None
 ) -> str:
     """Custom formatting that avoids an extra line in case warnings are emitted from the `rank_zero`-functions."""
     if _is_path_in_lightning(Path(filename)):


### PR DESCRIPTION
Closes #11525

Replaces DeprecationWarning with FutureWarning in warnings utilities.

Co-Authored-By: Claude <noreply@anthropic.com>