### PR TITLE
docs: Add usage example to scale_batch_size docstring

### DIFF
--- a/src/lightning/pytorch/tuner/batch_size_scaling.py
+++ b/src/lightning/pytorch/tuner/batch_size_scaling.py
@@ -350,11 +350,13 @@ def _adjust_batch_size(
         The new batch size for the next trial and a bool that signals whether the
         new value is different than the previous batch size.
 
-    
+
     Example::
         >>> from lightning.pytorch.tuner import Tuner
         >>> tuner = Tuner(trainer)
-        >>> tuner.scale_batch_size(model, datamodule)"""
+        >>> tuner.scale_batch_size(model, datamodule)
+
+    """
     model = trainer.lightning_module
     batch_size = lightning_getattr(model, batch_arg_name)
     assert batch_size is not None

--- a/src/lightning/pytorch/tuner/batch_size_scaling.py
+++ b/src/lightning/pytorch/tuner/batch_size_scaling.py
@@ -350,7 +350,11 @@ def _adjust_batch_size(
         The new batch size for the next trial and a bool that signals whether the
         new value is different than the previous batch size.
 
-    """
+    
+    Example::
+        >>> from lightning.pytorch.tuner import Tuner
+        >>> tuner = Tuner(trainer)
+        >>> tuner.scale_batch_size(model, datamodule)"""
     model = trainer.lightning_module
     batch_size = lightning_getattr(model, batch_arg_name)
     assert batch_size is not None


### PR DESCRIPTION
Adds a usage example to the `scale_batch_size` docstring.

Co-Authored-By: Claude <noreply@anthropic.com>