### PR TITLE
Fix the PPO example docstrings to name the arguments the constructors take

### DIFF
--- a/examples/pytorch/domain_templates/reinforce_learn_ppo.py
+++ b/examples/pytorch/domain_templates/reinforce_learn_ppo.py
@@ -60,8 +60,7 @@ class ActorCategorical(nn.Module):
     def __init__(self, actor_net):
         """
         Args:
-            input_shape: observation shape of the environment
-            n_actions: number of discrete actions available in the environment
+            actor_net: network that maps an observation to action logits
         """
         super().__init__()
 
@@ -95,8 +94,8 @@ class ActorContinuous(nn.Module):
     def __init__(self, actor_net, act_dim):
         """
         Args:
-            input_shape: observation shape of the environment
-            n_actions: number of discrete actions available in the environment
+            actor_net: network that maps an observation to the mean of the action distribution
+            act_dim: number of continuous action dimensions
         """
         super().__init__()
         self.actor_net = actor_net


### PR DESCRIPTION
## What does this PR do?

The two policy-network constructors in the PPO domain template document arguments they do not take. Both say:

```
Args:
    input_shape: observation shape of the environment
    n_actions: number of discrete actions available in the environment
```

but `ActorCategorical.__init__` takes only `actor_net`, and `ActorContinuous.__init__` takes `actor_net` and `act_dim`. The entries are left over from a version that built the network inside the constructor — `ExperienceSourceDataset` above them still takes the network from the caller.

This is a template people copy, so the wrong names travel. Replaced the four entries with the arguments that are actually there. Docstrings only; nothing else in the file changes.

One related thing I left alone: `LambdaCallback` documents `**kwargs`, while its `__init__` spells out every hook explicitly and has no `**kwargs`. Strictly it is the same defect, but the honest fix would mean listing fifty keyword arguments or rewording the entry, and that is your call rather than mine.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes? — no behaviour change; `ruff check` and `ruff format --check` pass on the file with the pinned `ruff==0.15.9`
- Did you list all the **breaking changes** introduced by this pull request? — none
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

</details>

## PR review

Anyone in the community is welcome to review the PR.
