### PR TITLE
docs: add 2.6 and 2.7 rows to the compatibility matrix

### DIFF
--- a/docs/source-pytorch/versioning.rst
+++ b/docs/source-pytorch/versioning.rst
@@ -83,6 +83,18 @@ Since the release of PyTorch `2.0`, Lightning strives to officially support the 
      - ``torch``
      - ``torchmetrics``
      - Python
+   * - 2.7
+     - 2.7
+     - 2.7
+     - ≥2.6 (▼ 2.13)
+     - ≥0.7.0
+     - ≥3.10 (▼ 3.13)
+   * - 2.6
+     - 2.6
+     - 2.6
+     - ≥2.1 (▼ 2.10)
+     - ≥0.7.0
+     - ≥3.10 (▼ 3.13)
    * - 2.5
      - 2.5
      - 2.5


### PR DESCRIPTION
## What does this PR do?

The compatibility matrix stopped at 2.5. Adds the missing 2.6 row and a 2.7 row reflecting the PyTorch floor raised to `>=2.6` in #21851.

Values come from the release tags and CI matrices:

- **2.6** (as of 2.6.5): torch `>=2.1.0, <2.10.0`, Python 3.10–3.13
- **2.7** (master): torch `>=2.6.0, <2.13.0`, torch 2.6–2.13 and Python 3.10–3.13 in CI

Note: 2.6.0 shipped `python_requires>=3.9`; 2.6.1 raised it to `>=3.10`. The row shows the current state of the 2.6.x line.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
