### PR TITLE
ci: bump torch ceiling to <2.14.0 and fix torch-tensorrt/DeepSpeed fallout

### DIFF
--- a/.lightning/workflows/pytorch.yml
+++ b/.lightning/workflows/pytorch.yml
@@ -122,10 +122,11 @@ run: |
   echo "Install package"
   extra=$(python -c "print({'lightning': 'pytorch-'}.get('${PACKAGE_NAME}', ''))")
 
-  # Use find-links to prefer CUDA-specific packages from PyTorch index
+  # Prefer CUDA-specific builds from the PyTorch index.
+  # torch-tensorrt is intentionally left to PyPI: since 2.13.0 its `+cuXXX` wheels no longer
+  # bundle `libtorchtrt.so`, which silently disables the TorchScript frontend.
   uv pip install -e ".[${extra}dev,${extra}test_gpu]" --upgrade \
-    --find-links="https://download.pytorch.org/whl/${UV_TORCH_BACKEND}" \
-    --find-links="https://download.pytorch.org/whl/${UV_TORCH_BACKEND}/torch-tensorrt"
+    --find-links="https://download.pytorch.org/whl/${UV_TORCH_BACKEND}"
   uv pip list
 
   echo "Ensure only a single package is installed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,8 @@ filterwarnings = [
     # deprecated in torch 2.12; the suggested replacement is a private API
     # TODO: migrate to torch.distributed._functional_collectives.all_gather_single for torch>=2.12
     "ignore:torch.distributed.nn.functional.all_gather is deprecated.*:FutureWarning",
+    # deprecated in torch 2.13; raised from inside DeepSpeed
+    "ignore:`torch.distributed.all_gather_into_tensor` is deprecated.*:FutureWarning",
     # PyTorch pytree LeafSpec deprecation triggered during doctest
     "ignore:`isinstance\\(treespec, LeafSpec\\)` is deprecated.*:FutureWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,8 +177,9 @@ filterwarnings = [
     # deprecated in torch 2.12; the suggested replacement is a private API
     # TODO: migrate to torch.distributed._functional_collectives.all_gather_single for torch>=2.12
     "ignore:torch.distributed.nn.functional.all_gather is deprecated.*:FutureWarning",
-    # torch 2.13 renamed the `*_tensor` collectives, which DeepSpeed's backend still calls
-    "ignore::FutureWarning:deepspeed.comm.torch",
+    # torch 2.13 renamed these collectives to their `_single` counterparts; DeepSpeed still calls the old names
+    "ignore:`torch.distributed.all_gather_into_tensor` is deprecated.*:FutureWarning",
+    "ignore:`torch.distributed.reduce_scatter_tensor` is deprecated.*:FutureWarning",
     # PyTorch pytree LeafSpec deprecation triggered during doctest
     "ignore:`isinstance\\(treespec, LeafSpec\\)` is deprecated.*:FutureWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,8 +177,8 @@ filterwarnings = [
     # deprecated in torch 2.12; the suggested replacement is a private API
     # TODO: migrate to torch.distributed._functional_collectives.all_gather_single for torch>=2.12
     "ignore:torch.distributed.nn.functional.all_gather is deprecated.*:FutureWarning",
-    # deprecated in torch 2.13; raised from inside DeepSpeed
-    "ignore:`torch.distributed.all_gather_into_tensor` is deprecated.*:FutureWarning",
+    # torch 2.13 renamed the `*_tensor` collectives, which DeepSpeed's backend still calls
+    "ignore::FutureWarning:deepspeed.comm.torch",
     # PyTorch pytree LeafSpec deprecation triggered during doctest
     "ignore:`isinstance\\(treespec, LeafSpec\\)` is deprecated.*:FutureWarning",
 ]

--- a/requirements/fabric/base.txt
+++ b/requirements/fabric/base.txt
@@ -1,7 +1,7 @@
 # NOTE: the upper bound for the package version is only set for CI stability, and it is dropped while installing this package
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
-torch >=2.6.0, <2.13.0
+torch >=2.6.0, <2.14.0
 fsspec[http] >=2022.5.0, <2026.4.0
 packaging >=23.0, <=26.0
 typing-extensions >4.5.0, <4.16.0

--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -1,7 +1,7 @@
 # NOTE: the upper bound for the package version is only set for CI stability, and it is dropped while installing this package
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
-torch >=2.6.0, <2.13.0
+torch >=2.6.0, <2.14.0
 tqdm >=4.57.0, <4.68.0
 PyYAML >5.4, <6.1.0
 fsspec[http] >=2022.5.0, <2026.4.0

--- a/tests/tests_pytorch/models/test_torch_tensorrt.py
+++ b/tests/tests_pytorch/models/test_torch_tensorrt.py
@@ -16,11 +16,19 @@ from tests_pytorch.helpers.runif import RunIf
 if _TORCH_TRT_AVAILABLE:
     from torch_tensorrt import ENABLED_FEATURES
 
-    # some prebuilt wheels (e.g. torch-tensorrt>=2.13) drop the legacy TorchScript
-    # frontend entirely, so `ir="ts"` raises a ValueError rather than compiling.
-    _TORCH_TRT_TS_AVAILABLE = ENABLED_FEATURES.torchscript_frontend
+    # the TS frontend ships in `libtorchtrt.so`, which the `+cuXXX` wheels omit since 2.13.0
+    _TORCH_TRT_TS_AVAILABLE = bool(ENABLED_FEATURES.torchscript_frontend)
 else:
     _TORCH_TRT_TS_AVAILABLE = False
+
+# keep both `ir="ts"` skips separate so the report names the one that applies
+_skip_ts_ir = [
+    pytest.mark.skipif(bool(_TORCH_EQUAL_2_9), reason="TorchScript IR crashes with torch_tensorrt on PyTorch 2.9"),
+    pytest.mark.skipif(
+        not _TORCH_TRT_TS_AVAILABLE,
+        reason="torch_tensorrt build does not include the TorchScript frontend (libtorchtrt.so)",
+    ),
+]
 
 
 @pytest.mark.skipif(_TORCH_TRT_AVAILABLE, reason="Run this test only if tensorrt is not available.")
@@ -109,15 +117,7 @@ def test_tensorrt_saves_on_multi_gpu(tmp_path):
     [
         ("default", torch.fx.GraphModule),
         ("dynamo", torch.fx.GraphModule),
-        pytest.param(
-            "ts",
-            torch.jit.ScriptModule,
-            marks=pytest.mark.skipif(
-                _TORCH_EQUAL_2_9 or not _TORCH_TRT_TS_AVAILABLE,
-                reason="TorchScript IR crashes with torch_tensorrt on PyTorch 2.9, and is unavailable in "
-                "some torch-tensorrt builds (e.g. >=2.13)",
-            ),
-        ),
+        pytest.param("ts", torch.jit.ScriptModule, marks=_skip_ts_ir),
     ],
 )
 @RunIf(tensorrt=True, min_cuda_gpus=1, min_torch="2.2.0")
@@ -138,14 +138,7 @@ def test_tensorrt_save_ir_type(ir, export_type):
     [
         "default",
         "dynamo",
-        pytest.param(
-            "ts",
-            marks=pytest.mark.skipif(
-                _TORCH_EQUAL_2_9 or not _TORCH_TRT_TS_AVAILABLE,
-                reason="TorchScript IR crashes with torch_tensorrt on PyTorch 2.9, and is unavailable in "
-                "some torch-tensorrt builds (e.g. >=2.13)",
-            ),
-        ),
+        pytest.param("ts", marks=_skip_ts_ir),
     ],
 )
 @RunIf(tensorrt=True, min_cuda_gpus=1, min_torch="2.2.0")

--- a/tests/tests_pytorch/models/test_torch_tensorrt.py
+++ b/tests/tests_pytorch/models/test_torch_tensorrt.py
@@ -13,6 +13,15 @@ from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from lightning.pytorch.utilities.imports import _TORCH_EQUAL_2_9
 from tests_pytorch.helpers.runif import RunIf
 
+if _TORCH_TRT_AVAILABLE:
+    from torch_tensorrt import ENABLED_FEATURES
+
+    # some prebuilt wheels (e.g. torch-tensorrt>=2.13) drop the legacy TorchScript
+    # frontend entirely, so `ir="ts"` raises a ValueError rather than compiling.
+    _TORCH_TRT_TS_AVAILABLE = ENABLED_FEATURES.torchscript_frontend
+else:
+    _TORCH_TRT_TS_AVAILABLE = False
+
 
 @pytest.mark.skipif(_TORCH_TRT_AVAILABLE, reason="Run this test only if tensorrt is not available.")
 def test_missing_tensorrt_package():
@@ -104,8 +113,9 @@ def test_tensorrt_saves_on_multi_gpu(tmp_path):
             "ts",
             torch.jit.ScriptModule,
             marks=pytest.mark.skipif(
-                _TORCH_EQUAL_2_9,
-                reason="TorchScript IR crashes with torch_tensorrt on PyTorch 2.9",
+                _TORCH_EQUAL_2_9 or not _TORCH_TRT_TS_AVAILABLE,
+                reason="TorchScript IR crashes with torch_tensorrt on PyTorch 2.9, and is unavailable in "
+                "some torch-tensorrt builds (e.g. >=2.13)",
             ),
         ),
     ],
@@ -131,8 +141,9 @@ def test_tensorrt_save_ir_type(ir, export_type):
         pytest.param(
             "ts",
             marks=pytest.mark.skipif(
-                _TORCH_EQUAL_2_9,
-                reason="TorchScript IR crashes with torch_tensorrt on PyTorch 2.9",
+                _TORCH_EQUAL_2_9 or not _TORCH_TRT_TS_AVAILABLE,
+                reason="TorchScript IR crashes with torch_tensorrt on PyTorch 2.9, and is unavailable in "
+                "some torch-tensorrt builds (e.g. >=2.13)",
             ),
         ),
     ],


### PR DESCRIPTION
## What does this PR do?

Raises the `torch` ceiling to `<2.14.0` — a follow-up to #21851, which capped it at `<2.13.0` only because `torch-tensorrt` had no build past it. That build shipped on 2026-07-28.

Moving past 2.13 surfaced two unrelated CI failures, both fixed here.

**TorchScript frontend missing**
- `torch-tensorrt`'s TS frontend lives in the compiled `libtorchtrt.so`.
- The `2.13.0+cu130` wheel from the PyTorch index ships without it (608 KB, zero `.so` files, vs. 4 MB for `2.12.1+cu130`).
- A local version like `+cu130` always outranks a plain PyPI release, so `find-links` kept winning that resolution — even though PyPI's `2.13.0` does bundle the libraries.
- Fix: drop the CUDA-specific `find-links` for `torch-tensorrt` so it resolves from PyPI instead. Tests also now feature-detect via `ENABLED_FEATURES.torchscript_frontend` and skip gracefully on any build that lacks it.

**Torch 2.13 collective deprecations**
- Torch 2.13 deprecated `all_gather_into_tensor` and `reduce_scatter_tensor` in favor of their `*_single` counterparts; `error::FutureWarning` turned that into a test failure.
- Both calls come from DeepSpeed's ZeRO-3 checkpointing path — neither API is used in Lightning — so they're filtered by message.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
