### PR TITLE
Add sync_dist_op to LightningModule logging

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added a `sync_dist_op` argument to `LightningModule.log` and `LightningModule.log_dict` to configure the reduction across devices independently from the epoch reduction ([#17831](https://github.com/Lightning-AI/pytorch-lightning/issues/17831))
+
 - Added `suggest_integrations` flag to `Trainer` to control whether optional integration suggestions (e.g., litmodels, litlogger) are shown in logs ([#21632](https://github.com/Lightning-AI/pytorch-lightning/pull/21632))
 
 - Fixed ``ModelParallelStrategy`` single-file checkpointing when ``torch.compile`` wraps the model so optimizer states no longer raise ``KeyError`` during save ([#21357](https://github.com/Lightning-AI/pytorch-lightning/issues/21357))

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -37,6 +37,7 @@ import torch
 from lightning_utilities.core.apply_func import apply_to_collection
 from lightning_utilities.core.imports import RequirementCache
 from torch import ScriptModule, Tensor
+from torch.distributed import ReduceOp
 from torch.nn import Module
 from torch.optim.optimizer import Optimizer
 from torchmetrics import Metric, MetricCollection
@@ -394,6 +395,7 @@ class LightningModule(
         batch_size: Optional[int] = None,
         metric_attribute: Optional[str] = None,
         rank_zero_only: bool = False,
+        sync_dist_op: Optional[Union[ReduceOp, str]] = None,
     ) -> None:
         """Log a key, value pair.
 
@@ -423,6 +425,9 @@ class LightningModule(
             sync_dist: if ``True``, reduces the metric across devices. Use with care as this may lead to a significant
                 communication overhead.
             sync_dist_group: the DDP group to sync across.
+            sync_dist_op: the reduction operation for values across devices. Defaults to the operation inferred from
+                ``reduce_fx`` for backward compatibility. Has no effect unless ``sync_dist`` is ``True`` and the
+                strategy is distributed.
             add_dataloader_idx: if ``True``, appends the index of the current dataloader to
                 the name (when using multiple dataloaders). If False, user needs to give unique names for
                 each dataloader to not mix the values.
@@ -546,6 +551,7 @@ class LightningModule(
             sync_dist_group=sync_dist_group,
             metric_attribute=metric_attribute,
             rank_zero_only=rank_zero_only,
+            sync_dist_op=sync_dist_op,
         )
 
         trainer._logger_connector._current_fx = self._current_fx_name
@@ -564,6 +570,7 @@ class LightningModule(
         add_dataloader_idx: bool = True,
         batch_size: Optional[int] = None,
         rank_zero_only: bool = False,
+        sync_dist_op: Optional[Union[ReduceOp, str]] = None,
     ) -> None:
         """Log a dictionary of values at once.
 
@@ -591,6 +598,9 @@ class LightningModule(
             sync_dist: if ``True``, reduces the metric across GPUs/TPUs. Use with care as this may lead to a significant
                 communication overhead.
             sync_dist_group: the ddp group to sync across.
+            sync_dist_op: the reduction operation for values across devices. Defaults to the operation inferred from
+                ``reduce_fx`` for backward compatibility. Has no effect unless ``sync_dist`` is ``True`` and the
+                strategy is distributed.
             add_dataloader_idx: if ``True``, appends the index of the current dataloader to
                 the name (when using multiple). If ``False``, user needs to give unique names for
                 each dataloader to not mix values.
@@ -627,6 +637,7 @@ class LightningModule(
                 add_dataloader_idx=add_dataloader_idx,
                 batch_size=batch_size,
                 rank_zero_only=rank_zero_only,
+                sync_dist_op=sync_dist_op,
             )
         return None
 

--- a/src/lightning/pytorch/trainer/connectors/logger_connector/result.py
+++ b/src/lightning/pytorch/trainer/connectors/logger_connector/result.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Optional, Union, cast
 import torch
 from lightning_utilities.core.apply_func import apply_to_collection
 from torch import Tensor
+from torch.distributed import ReduceOp
 from torchmetrics import Metric
 from typing_extensions import TypedDict, override
 
@@ -51,7 +52,7 @@ class _Sync:
     fn: Optional[Callable] = None
     _should: bool = False
     rank_zero_only: bool = False
-    _op: Optional[str] = None
+    _op: Optional[Union[ReduceOp, str]] = None
     _group: Optional[Any] = None
 
     def __post_init__(self) -> None:
@@ -68,11 +69,11 @@ class _Sync:
         self._generate_sync_fn()
 
     @property
-    def op(self) -> Optional[str]:
+    def op(self) -> Optional[Union[ReduceOp, str]]:
         return self._op
 
     @op.setter
-    def op(self, op: Optional[str]) -> None:
+    def op(self, op: Optional[Union[ReduceOp, str]]) -> None:
         self._op = op
         # `self._fn` needs to be re-generated.
         self._generate_sync_fn()
@@ -371,6 +372,7 @@ class _ResultCollection(dict):
         batch_size: Optional[int] = None,
         metric_attribute: Optional[str] = None,
         rank_zero_only: bool = False,
+        sync_dist_op: Optional[Union[ReduceOp, str]] = None,
     ) -> None:
         """See :meth:`~lightning.pytorch.core.LightningModule.log`"""
         # no metrics should be logged with graphs
@@ -397,7 +399,13 @@ class _ResultCollection(dict):
             dataloader_idx=self.dataloader_idx,
             metric_attribute=metric_attribute,
         )
-        meta.sync = _Sync(_should=sync_dist, fn=sync_dist_fn, _group=sync_dist_group, rank_zero_only=rank_zero_only)
+        meta.sync = _Sync(
+            _should=sync_dist,
+            fn=sync_dist_fn,
+            _group=sync_dist_group,
+            rank_zero_only=rank_zero_only,
+            _op=sync_dist_op,
+        )
 
         # register logged value if it doesn't exist
         if key not in self:

--- a/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
+++ b/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
@@ -333,6 +333,14 @@ class LoggingSyncDistModel(BoringModel):
         self.log("foo_9", value, on_step=False, on_epoch=True, sync_dist=True, reduce_fx="mean")
         self.log("foo_10", batch_idx, on_step=False, on_epoch=True, sync_dist=True, reduce_fx="max")
         self.log("foo_11", batch_idx + self.rank, on_step=True, on_epoch=True, sync_dist=True, reduce_fx="mean")
+        self.log_dict(
+            {"foo_12": batch_idx + self.rank},
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+            reduce_fx="max",
+            sync_dist_op="sum",
+        )
         return super().training_step(batch, batch_idx)
 
     def validation_step(self, batch, batch_idx):
@@ -346,6 +354,7 @@ class LoggingSyncDistModel(BoringModel):
     ("devices", "accelerator"),
     [
         (1, "cpu"),
+        pytest.param(1, "gpu", marks=RunIf(min_cuda_gpus=1)),
         pytest.param(2, "cpu", marks=_xfail_gloo_windows),
         pytest.param(2, "gpu", marks=RunIf(min_cuda_gpus=2)),
     ],
@@ -382,6 +391,7 @@ def test_logging_sync_dist_true(tmp_path, devices, accelerator):
     assert metrics["foo_10"] == 2
     assert metrics["foo_11_step"] == (2 + 3) / 2 if use_multiple_devices else fake_result * 2
     assert metrics["foo_11"] == (0 + 1 + 1 + 2 + 2 + 3) / (devices * 3) if use_multiple_devices else fake_result
+    assert metrics["foo_12"] == (5 if use_multiple_devices else 2)
     assert metrics["bar"] == fake_result * 3 * devices
     assert metrics["bar_2"] == fake_result
     assert metrics["bar_3"] == 2 + int(use_multiple_devices)


### PR DESCRIPTION
## What does this PR do?

Adds a `sync_dist_op` argument to `LightningModule.log` and `LightningModule.log_dict` so the reduction across distributed ranks can be configured independently from the reduction across epoch steps.

When `sync_dist_op` is omitted, the distributed operation still falls back to `reduce_fx`, preserving existing behavior. The argument is appended to the public signatures to avoid shifting existing positional arguments. The API docstrings and PyTorch changelog are updated.

The regression test covers CPU, single-GPU, two-process CPU DDP, and two-GPU DDP. It logs rank-dependent values with `sync_dist_op="sum"` and `reduce_fx="max"`, verifying the two reduction stages produce the expected metric.

Validation:

- `python -m pytest -q tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py::test_logging_sync_dist_true` (`4 passed`)
- `CUDA_VISIBLE_DEVICES= python -m pytest -q tests/tests_pytorch/core/test_results.py tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py` (`31 passed, 4 skipped`)
- `PL_RUN_STANDALONE_TESTS=1 python -m pytest -q tests/tests_pytorch/strategies/test_ddp_integration.py::test_ddp_gradients_synced[...]` (all four automatic/manual and static/non-static variants passed when run individually)
- `ruff check` and `ruff format --check` on the changed Python files
- `mypy` on the changed source files
- `uv build --offline --wheel` for the `pytorch` package

AI assistance disclosure: AI tools assisted with implementation and test preparation. The contributor reviewed the complete diff and validated the change on CPU and GPU.

Fixes #17831

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

No breaking changes are intended. The default distributed reduction remains unchanged.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs) Yes, in #17831.
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary) Yes, the public API docstrings are updated.
- Did you write any **new necessary tests**? (not for typos and docs) Yes.
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request? None.
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors) Yes.

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
