### PR TITLE
Fix CombinedLoader max_size_cycle with empty iterable

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `CombinedLoader` in `max_size_cycle` mode to continue when an iterable is empty ([#21894](https://github.com/Lightning-AI/pytorch-lightning/pull/21894))
+
 - Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
 
 - Fixed PyTorch Lightning profiler not capturing dataloader worker initialization time ([#21771](https://github.com/Lightning-AI/pytorch-lightning/issues/21771))

--- a/src/lightning/pytorch/utilities/combined_loader.py
+++ b/src/lightning/pytorch/utilities/combined_loader.py
@@ -82,7 +82,8 @@ class _MaxSizeCycle(_ModeIterator):
                     raise
                 # reset the consumed dataloader
                 self.iterators[i] = iter(self.iterables[i])
-                out[i] = next(self.iterators[i])
+                with contextlib.suppress(StopIteration):
+                    out[i] = next(self.iterators[i])
         index = self._idx
         self._idx += 1
         return out, index, 0

--- a/tests/tests_pytorch/utilities/test_combined_loader.py
+++ b/tests/tests_pytorch/utilities/test_combined_loader.py
@@ -85,6 +85,12 @@ def test_combined_loader_length_must_call_iter_first():
         len(loader)
 
 
+def test_combined_loader_max_size_cycle_with_empty_iterable():
+    loader = CombinedLoader([[], [1, 2, 3]], mode="max_size_cycle")
+
+    assert list(loader) == [([None, 1], 0, 0), ([None, 2], 1, 0), ([None, 3], 2, 0)]
+
+
 def test_combined_loader_modes_for_dict():
     """Test `CombinedLoaderIterator` given mapping iterables."""
     iterables = {


### PR DESCRIPTION
## What does this PR do?

Fixes #21893

`CombinedLoader(..., mode=max_size_cycle)` reported the longest iterable's length but yielded no batches when another iterable was empty. On reset, the empty iterable raised a second `StopIteration`, terminating the combined iterator. This keeps that slot as `None`, allowing the non-empty iterable to run through the documented maximum length.

## Reproduction / Before

`list(CombinedLoader([[], [1, 2, 3]], mode=max_size_cycle))` returned `[]` even though `len()` returned `3`.

## After

The same loader yields three batches with `None` for the empty source.

## Tests

- `.\.venv\Scripts\python.exe -m pytest tests/tests_pytorch/utilities/test_combined_loader.py::test_combined_loader_max_size_cycle_with_empty_iterable -v`
- `.\.venv\Scripts\python.exe -m pytest tests/tests_pytorch/utilities/test_combined_loader.py -v`
- `.\.venv\Scripts\python.exe -m pytest tests/tests_pytorch/loops/test_fetchers.py -v`
- `.\.venv\Scripts\pre-commit.exe run --files src/lightning/pytorch/utilities/combined_loader.py tests/tests_pytorch/utilities/test_combined_loader.py`
- `.\.venv\Scripts\mypy.exe src\lightning\pytorch\utilities\combined_loader.py`

## AI assistance disclosure

I identified and reproduced the issue, then used OpenAI Codex to assist with the implementation and regression-test work. I personally reviewed the resulting diff and ran the validation commands listed above to verify the fix. Any full-suite or local-environment limitations are documented in the validation section.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the contributor guideline, Pull Request section?
- [x] Did you make sure this PR does only one thing?
- [x] Did you write the necessary regression test?
- [x] Did you verify new and existing relevant tests pass locally?
- [x] Did you update the CHANGELOG?

</details>