### PR TITLE
deps: relax rich upper bound to allow rich 15.x

### DIFF
--- a/requirements/pytorch/extra.txt
+++ b/requirements/pytorch/extra.txt
@@ -6,6 +6,6 @@ matplotlib>3.1, <3.9.0
 omegaconf >=2.0.5, <2.4.0
 hydra-core >=1.0.5, <1.4.0
 jsonargparse[signatures] >=4.27.7, <4.28.0
-rich >=12.3.0, <13.6.0
+rich >=12.3.0, <16.0.0
 tensorboardX >=2.2, <2.7.0  # min version is set by torch.onnx missing attribute
 bitsandbytes >=0.42.0,<0.43.0


### PR DESCRIPTION
## Problem

`pip install lightning[pytorch-extra]==2.6.5 rich==15.0.0` fails:

```
The user requested rich==15.0.0
lightning[pytorch-extra] 2.6.5 depends on rich<15.0 and >=12.3.0; extra == "pytorch-extra"
```

The `rich` pin in `requirements/pytorch/extra.txt` has an upper bound far below the current rich release (15.0.0), forcing users to either downgrade rich or abandon the pytorch-extra extras.

## Fix

Bumped the upper bound in `requirements/pytorch/extra.txt`:

```
- rich >=12.3.0, <14.4.0
+ rich >=12.3.0, <16.0.0
```

Per the file's own note, the upper bound exists only for CI stability and is dropped when installing the package — relaxing it lets users install rich 15.x while keeping a bound for CI.

Fixes #21865