### PR TITLE
docs: fix broken examples exploration link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ pip install -iU https://test.pypi.org/simple/ pytorch-lightning
 <!-- end skipping PyPI description -->
 
 ### PyTorch Lightning example
-Define the training workflow. Here's a toy example ([explore real examples](https://lightning.ai/lightning-ai/studios?view=public&section=featured&query=pytorch+lightning&utm_source=ptl_readme&utm_medium=referral&utm_campaign=ptl_readme)):
+Define the training workflow. Here's a toy example ([explore real examples](https://lightning.ai/studios?view=public&section=featured&query=pytorch+lightning&utm_source=ptl_readme&utm_medium=referral&utm_campaign=ptl_readme)):
 
 ```python
 # main.py


### PR DESCRIPTION
## Problem

The "explore real examples" link in README.md points to:

`https://lightning.ai/lightning-ai/studios?view=public...`

which 404s because of the extra `/lightning-ai` path segment.

## Fix

Removed the extra segment:

`https://lightning.ai/studios?view=public...`

Fixes #21445