### PR TITLE
Fix BaseFinetuning re-freezing unfrozen modules on resume

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -51,6 +51,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed arbitrary code execution in `load_from_checkpoint` by restricting the `_instantiator` hyperparameter to an allowlist of trusted instantiators ([#21832](https://github.com/Lightning-AI/pytorch-lightning/pull/21832))
 
+- Fixed `BaseFinetuning` leaving previously unfrozen modules frozen when resuming from a checkpoint, by restoring `requires_grad` on the param groups it had added ([#21901](https://github.com/Lightning-AI/pytorch-lightning/issues/21901))
+
 ---
 
 ## [2.6.4] - 2026-05-20

--- a/src/lightning/pytorch/callbacks/finetuning.py
+++ b/src/lightning/pytorch/callbacks/finetuning.py
@@ -117,10 +117,17 @@ class BaseFinetuning(Callback):
                 named_parameters = dict(pl_module.named_parameters())
                 for opt_idx, optimizer in enumerate(trainer.optimizers):
                     if opt_idx in self._internal_optimizer_metadata:
+                        # the groups the optimizer currently holds are the ones `configure_optimizers` just
+                        # created, so anything past them was added by unfreezing in the previous run
+                        num_initial_groups = len(optimizer.param_groups)
                         param_groups = self._apply_mapping_to_param_groups(
                             self._internal_optimizer_metadata[opt_idx], named_parameters
                         )
                         optimizer.param_groups = param_groups
+                        # `setup()` has re-applied `freeze_before_training()`, which froze those modules again
+                        for group in param_groups[num_initial_groups:]:
+                            for param in group["params"]:
+                                param.requires_grad = True
             self._restarting = False
 
     @staticmethod

--- a/tests/tests_pytorch/callbacks/test_finetuning_callback.py
+++ b/tests/tests_pytorch/callbacks/test_finetuning_callback.py
@@ -421,6 +421,45 @@ def test_callbacks_restore_backbone(tmp_path):
     trainer.fit(BackboneBoringModel(), ckpt_path=ckpt.last_model_path)
 
 
+@pytest.mark.parametrize(("unfreeze_backbone_at_epoch", "expected_requires_grad"), [(1, True), (3, False)])
+def test_finetuning_restores_requires_grad_on_resume(tmp_path, unfreeze_backbone_at_epoch, expected_requires_grad):
+    """Test that resuming restores the frozen state the modules had when the training was interrupted."""
+
+    class HeadOptimizerModel(BackboneBoringModel):
+        def configure_optimizers(self):
+            # only the head is optimized to begin with, the callback adds the backbone when it unfreezes it
+            return SGD(self.layer.parameters(), lr=0.1)
+
+    def fit(max_epochs, callbacks, ckpt_path=None):
+        model = HeadOptimizerModel()
+        trainer = Trainer(
+            default_root_dir=tmp_path,
+            limit_train_batches=2,
+            limit_val_batches=0,
+            max_epochs=max_epochs,
+            num_sanity_val_steps=0,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+            callbacks=callbacks,
+        )
+        trainer.fit(model, ckpt_path=ckpt_path)
+        return model
+
+    ckpt = ModelCheckpoint(dirpath=tmp_path, save_last=True)
+    fit(2, [BackboneFinetuning(unfreeze_backbone_at_epoch=unfreeze_backbone_at_epoch), ckpt])
+
+    # `setup()` freezes the backbone again on the resumed run, so whatever was unfrozen before the interruption
+    # has to be made trainable again, and nothing else
+    model = fit(
+        3,
+        [BackboneFinetuning(unfreeze_backbone_at_epoch=unfreeze_backbone_at_epoch)],
+        ckpt_path=ckpt.last_model_path,
+    )
+    assert model.backbone.weight.requires_grad is expected_requires_grad
+    assert model.backbone.bias.requires_grad is expected_requires_grad
+
+
 @RunIf(deepspeed=True)
 def test_unsupported_strategies(tmp_path):
     model = BackboneBoringModel()


### PR DESCRIPTION
## What does this PR do?

Fixes #21901

`BaseFinetuning` restores half of its state when a run is resumed. `setup()` calls `freeze_before_training()` on every fit, including a resumed one, because it has to run before `configure_optimizers()`. `on_fit_start()` then puts the saved param groups back on the optimizer, but it only restores group membership, never `param.requires_grad`.

The result is that modules unfrozen before the interruption come back frozen. They sit in the optimizer with the right learning rate and get no gradients, so they never update again. `BackboneFinetuning.finetune_function()` unfreezes only on the exact epoch `epoch == unfreeze_backbone_at_epoch` and only rescales the learning rate afterwards, so nothing puts `requires_grad` back.

This restores `requires_grad` for the param groups that were added after the ones `configure_optimizers()` created. Those are precisely the groups `unfreeze_and_add_param_group()` appended in the previous run, so the frozen state is restored as it was rather than blanket-unfrozen. Resuming before the unfreeze epoch adds no extra groups and therefore changes nothing.

Same 4 epochs, tracking `requires_grad` and whether the backbone weights actually change, interrupted after epoch 1:

```
                uninterrupted           resumed at epoch 2
 epoch  requires_grad  weights_moved requires_grad  weights_moved
     0          False          False         False          False
     1           True           True          True           True
     2           True           True         False          False     <- before
     3           True           True         False          False     <- before
```

After the fix the resumed columns match the uninterrupted ones for every epoch.

With a schedule that unfreezes block `i` at epoch `i`, resuming at epoch 2:

```
uninterrupted : [True, True, True, False]
resumed before: [False, False, True, False]
resumed after : [True, True, True, False]
```

Known limitation, not addressed here: `freeze_module()` also sets `track_running_stats = False` on `BatchNorm` layers, and that flag is not recoverable from the saved param groups. A `BatchNorm` that was unfrozen with `train_bn=False` will have its affine parameters trainable again but keep `track_running_stats=False`, and one with `affine=False` has no parameters in any group at all. Restoring that would need the callback to persist which modules it unfroze, which is a larger change to the checkpoint contents.

The bug only appears when the unfrozen modules were added to the optimizer as a new param group, which is the pattern the `BackboneFinetuning` docstring shows. If `configure_optimizers()` already hands every parameter to the optimizer, `unfreeze_and_add_param_group()` drops them in `filter_on_optimizer()`, no group is recorded, and there is nothing in the metadata to restore from.

`test_callbacks_restore_backbone` already walks this resume path but asserts nothing after the second `fit()`, which is why the suite stayed green. The new test covers both directions: unfrozen stays unfrozen, and still-frozen stays frozen.

```
$ pytest callbacks/test_finetuning_callback.py -q
10 passed, 1 skipped, 34 warnings in 1.10s
```

With only the change to `finetuning.py` reverted:

```
$ pytest callbacks/test_finetuning_callback.py::test_finetuning_restores_requires_grad_on_resume -q
FAILED callbacks/test_finetuning_callback.py::test_finetuning_restores_requires_grad_on_resume[1-True] - assert False is True
1 failed, 1 passed
```

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

</details>

## PR review

Anyone in the community is welcome to review the PR.
