### PR TITLE
Fix: don't swallow non-cross-device PermissionError in _atomic_save

### DIFF
--- a/src/lightning/fabric/utilities/cloud_io.py
+++ b/src/lightning/fabric/utilities/cloud_io.py
@@ -130,6 +130,9 @@ def _atomic_save(checkpoint: dict[str, Any], filepath: _PATH) -> None:
             raise RuntimeError(
                 'Upgrade fsspec to enable cross-device local checkpoints: pip install "fsspec[http]>=2025.5.0"',
             ) from e
+        # Any other PermissionError (e.g. writing to a read-only directory) must not be swallowed,
+        # otherwise training silently continues without ever having saved a checkpoint.
+        raise
 
 
 def _is_object_storage(fs: AbstractFileSystem) -> bool:

--- a/tests/tests_fabric/utilities/test_cloud_io.py
+++ b/tests/tests_fabric/utilities/test_cloud_io.py
@@ -164,6 +164,24 @@ def test_atomic_save_uses_write_for_local(tmp_path):
     torch.testing.assert_close(loaded["key"], checkpoint["key"])
 
 
+def test_atomic_save_reraises_non_cross_device_permission_error(tmp_path):
+    """A PermissionError that isn't caused by a cross-device rename must propagate instead of being swallowed.
+
+    Regression test for https://github.com/Lightning-AI/pytorch-lightning/issues/21800: `_atomic_save` used to
+    catch `PermissionError` to special-case cross-device (`EXDEV`) renames, but any other `PermissionError` (e.g.
+    writing into a read-only directory) was silently discarded, making `_atomic_save` return normally without
+    ever having written a checkpoint.
+    """
+    checkpoint = {"key": torch.tensor([1, 2, 3])}
+    filepath = tmp_path / "checkpoint.ckpt"
+
+    with (
+        mock.patch("lightning.fabric.utilities.cloud_io.torch.save", side_effect=PermissionError("denied")),
+        pytest.raises(PermissionError, match="denied"),
+    ):
+        _atomic_save(checkpoint, filepath)
+
+
 def test_resolve_path_local_vs_remote(tmp_path):
     resolved = _resolve_path(str(tmp_path / "ckpt"))
     assert isinstance(resolved, Path)

--- a/tests/tests_fabric/utilities/test_cloud_io.py
+++ b/tests/tests_fabric/utilities/test_cloud_io.py
@@ -171,6 +171,7 @@ def test_atomic_save_reraises_non_cross_device_permission_error(tmp_path):
     catch `PermissionError` to special-case cross-device (`EXDEV`) renames, but any other `PermissionError` (e.g.
     writing into a read-only directory) was silently discarded, making `_atomic_save` return normally without
     ever having written a checkpoint.
+
     """
     checkpoint = {"key": torch.tensor([1, 2, 3])}
     filepath = tmp_path / "checkpoint.ckpt"


### PR DESCRIPTION
## What does this PR do?

`_atomic_save()` in `src/lightning/fabric/utilities/cloud_io.py` catches `PermissionError` in order to special-case cross-device (`EXDEV`) renames and raise a helpful `RuntimeError` telling the user to upgrade `fsspec`. However, the same `except PermissionError` block silently swallowed *any other* `PermissionError` as well (for example when writing a checkpoint to a read-only directory or a path without write permissions). As a result, `_atomic_save()` would return normally without ever having written the checkpoint file, and training would silently continue as if the save had succeeded.

This PR re-raises the original `PermissionError` when it is not caused by a cross-device rename (`EXDEV`), so permission failures are surfaced to the user instead of being silently discarded.

A regression test (`test_atomic_save_reraises_non_cross_device_permission_error`) is added to `tests/tests_fabric/utilities/test_cloud_io.py`, verifying that a generic `PermissionError` raised by `torch.save` propagates out of `_atomic_save` instead of being swallowed.

### Before
```python
try:
    ...
except PermissionError as e:
    if isinstance(e.__context__, OSError) and getattr(e.__context__, "errno", None) == errno.EXDEV:
        raise RuntimeError(...) from e
    # falls through here and the exception is discarded
```

### After
```python
except PermissionError as e:
    if isinstance(e.__context__, OSError) and getattr(e.__context__, "errno", None) == errno.EXDEV:
        raise RuntimeError(...) from e
    raise
```

### Testing

```
python -m pytest tests/tests_fabric/utilities/test_cloud_io.py -q
```
All 19 tests pass, including the new regression test.