### PR TITLE
fix: `LightningCLI` emitting `jsonargparse` deprecation warnings

### DIFF
--- a/requirements/pytorch/extra.txt
+++ b/requirements/pytorch/extra.txt
@@ -5,7 +5,7 @@
 matplotlib>3.1, <3.11.0
 omegaconf >=2.2.3, <2.4.0
 hydra-core >=1.2.0, <1.4.0
-jsonargparse[signatures,jsonnet] >=4.39.0, <4.48.0
+jsonargparse[signatures,jsonnet] >=4.39.0, <4.51.0
 rich >=12.3.0, <14.4.0
 tensorboardX >=2.2, <2.7.0  # min version is set by torch.onnx missing attribute
 bitsandbytes >=0.45.2,<0.50.0; platform_system != "Darwin"

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `LightningCLI` emitting `jsonargparse` deprecation warnings with `jsonargparse>=4.49` ([#21900](https://github.com/Lightning-AI/pytorch-lightning/issues/21900))
+
 - Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
 
 - Fixed PyTorch Lightning profiler not capturing dataloader worker initialization time ([#21771](https://github.com/Lightning-AI/pytorch-lightning/issues/21771))

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed `LightningCLI` emitting `jsonargparse` deprecation warnings with `jsonargparse>=4.49` ([#21900](https://github.com/Lightning-AI/pytorch-lightning/issues/21900))
+- Fixed `LightningCLI` emitting `jsonargparse` deprecation warnings ([#21900](https://github.com/Lightning-AI/pytorch-lightning/issues/21900))
 
 - Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
 

--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -14,6 +14,7 @@
 import inspect
 import os
 import sys
+import warnings
 from collections.abc import Iterable
 from functools import partial, update_wrapper
 from pathlib import Path
@@ -37,6 +38,11 @@ from lightning.pytorch.utilities.model_helpers import is_overridden
 from lightning.pytorch.utilities.rank_zero import rank_zero_warn
 
 _JSONARGPARSE_SIGNATURES_AVAILABLE = RequirementCache("jsonargparse[jsonnet,signatures]>=4.39")
+# 4.49 deprecated `ArgumentParser.instantiate_classes` in favor of `ArgumentParser.instantiate`, and 4.50 the
+# `skip_none` argument of `dump`/`save` in favor of `skip_unset`. Only the later one is gated on: `instantiate` does
+# exist in 4.49, but `skip_unset` does not, and since `dump`/`save` accept `**kwargs` passing it to 4.49 would be
+# silently ignored, dropping `None` entries from the saved config.
+_JSONARGPARSE_GREATER_EQUAL_4_50 = RequirementCache("jsonargparse>=4.50.0")
 
 if _JSONARGPARSE_SIGNATURES_AVAILABLE:
     import docstring_parser
@@ -63,6 +69,19 @@ else:
     locals()["Namespace"] = object
 
 ModuleType = TypeVar("ModuleType")
+
+# `skip_none` and `skip_unset` both mean "drop entries whose value is the unset sentinel", which defaults to `None`
+if _JSONARGPARSE_GREATER_EQUAL_4_50:
+    _KEEP_NONE_KWARGS: dict[str, bool] = {"skip_unset": False}
+else:
+    _KEEP_NONE_KWARGS = {"skip_none": False}
+
+
+def _instantiate(parser: "ArgumentParser", cfg: "Namespace") -> "Namespace":
+    """Instantiate the classes of a parsed config, using the API available in the installed jsonargparse."""
+    if _JSONARGPARSE_GREATER_EQUAL_4_50:
+        return parser.instantiate(cfg)
+    return parser.instantiate_classes(cfg)
 
 
 class ReduceLROnPlateau(torch.optim.lr_scheduler.ReduceLROnPlateau):
@@ -288,7 +307,11 @@ class SaveConfigCallback(Callback):
                 # but it hasn't logged anything at this point
                 fs.makedirs(log_dir, exist_ok=True)
                 self.parser.save(
-                    self.config, config_path, skip_none=False, overwrite=self.overwrite, multifile=self.multifile
+                    self.config,
+                    config_path,
+                    overwrite=self.overwrite,
+                    multifile=self.multifile,
+                    **_KEEP_NONE_KWARGS,
                 )
 
         if trainer.is_global_zero:
@@ -587,29 +610,39 @@ class LightningCLI:
         if hasattr(self, "config_dump"):
             return
         self.config_dump = yaml.safe_load(
-            self.parser.dump(self.config, skip_link_targets=False, skip_none=False, format="yaml")
+            self.parser.dump(self.config, skip_link_targets=False, format="yaml", **_KEEP_NONE_KWARGS)
         )
         if "subcommand" in self.config:
             self.config_dump = self.config_dump[self.config.subcommand]
 
     def _add_instantiators(self) -> None:
-        self.parser.add_instantiator(
-            _InstantiatorFn(cli=self, key="model"),
-            _get_module_type(self._model_class),
-            subclasses=self.subclass_mode_model,
-        )
-        self.parser.add_instantiator(
-            _InstantiatorFn(cli=self, key="data"),
-            _get_module_type(self._datamodule_class),
-            subclasses=self.subclass_mode_data,
-        )
+        # jsonargparse 4.49 deprecated `ArgumentParser.add_instantiator` in favor of the global
+        # `jsonargparse.add_instantiator`, which is deliberately not used here: it registers the instantiator
+        # process-wide instead of on `self.parser`, so it would leak into every other parser in the process, including
+        # the ones of separate `LightningCLI` instances. Since there is no non-deprecated way to keep the per-parser
+        # scoping, the warning is silenced instead.
+        # TODO: revisit for jsonargparse v5.0, which removes the parser-scoped method
+        # the filter is by category rather than by message because jsonargparse emits a separate one-time banner
+        # warning alongside the deprecation itself
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            self.parser.add_instantiator(
+                _InstantiatorFn(cli=self, key="model"),
+                _get_module_type(self._model_class),
+                subclasses=self.subclass_mode_model,
+            )
+            self.parser.add_instantiator(
+                _InstantiatorFn(cli=self, key="data"),
+                _get_module_type(self._datamodule_class),
+                subclasses=self.subclass_mode_data,
+            )
 
     def before_instantiate_classes(self) -> None:
         """Implement to run some code before instantiating the classes."""
 
     def instantiate_classes(self) -> None:
         """Instantiates the classes and sets their attributes."""
-        self.config_init = self.parser.instantiate_classes(self.config)
+        self.config_init = _instantiate(self.parser, self.config)
         self.datamodule = self._get(self.config_init, "data")
         self.model = self._get(self.config_init, "model")
         self._add_configure_optimizers_method_to_model(self.subcommand)
@@ -901,5 +934,5 @@ def instantiate_module(class_type: type[ModuleType], config: dict[str, Any]) -> 
     else:
         parser.add_class_arguments(class_type, "module", fail_untyped=False)
     cfg = parser.parse_object({"module": config})
-    init = parser.instantiate_classes(cfg)
+    init = _instantiate(parser, cfg)
     return init.module

--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -38,10 +38,9 @@ from lightning.pytorch.utilities.model_helpers import is_overridden
 from lightning.pytorch.utilities.rank_zero import rank_zero_warn
 
 _JSONARGPARSE_SIGNATURES_AVAILABLE = RequirementCache("jsonargparse[jsonnet,signatures]>=4.39")
-# 4.49 deprecated `ArgumentParser.instantiate_classes` in favor of `ArgumentParser.instantiate`, and 4.50 the
-# `skip_none` argument of `dump`/`save` in favor of `skip_unset`. Only the later one is gated on: `instantiate` does
-# exist in 4.49, but `skip_unset` does not, and since `dump`/`save` accept `**kwargs` passing it to 4.49 would be
-# silently ignored, dropping `None` entries from the saved config.
+# 4.50 deprecated `ArgumentParser.instantiate_classes` in favor of `instantiate`, and the `skip_none` argument of
+# `dump`/`save` in favor of `skip_unset`. A single gate covers both: `instantiate` already exists in 4.49, while
+# `skip_unset` does not and would be silently swallowed by `**kwargs` there.
 _JSONARGPARSE_GREATER_EQUAL_4_50 = RequirementCache("jsonargparse>=4.50.0")
 
 if _JSONARGPARSE_SIGNATURES_AVAILABLE:
@@ -70,15 +69,11 @@ else:
 
 ModuleType = TypeVar("ModuleType")
 
-# `skip_none` and `skip_unset` both mean "drop entries whose value is the unset sentinel", which defaults to `None`
-if _JSONARGPARSE_GREATER_EQUAL_4_50:
-    _KEEP_NONE_KWARGS: dict[str, bool] = {"skip_unset": False}
-else:
-    _KEEP_NONE_KWARGS = {"skip_none": False}
+# both flags mean "drop entries whose value is unset", which for these parsers is `None`
+_KEEP_NONE_KWARGS: dict[str, bool] = {"skip_unset": False} if _JSONARGPARSE_GREATER_EQUAL_4_50 else {"skip_none": False}
 
 
 def _instantiate(parser: "ArgumentParser", cfg: "Namespace") -> "Namespace":
-    """Instantiate the classes of a parsed config, using the API available in the installed jsonargparse."""
     if _JSONARGPARSE_GREATER_EQUAL_4_50:
         return parser.instantiate(cfg)
     return parser.instantiate_classes(cfg)
@@ -616,15 +611,11 @@ class LightningCLI:
             self.config_dump = self.config_dump[self.config.subcommand]
 
     def _add_instantiators(self) -> None:
-        # jsonargparse 4.49 deprecated `ArgumentParser.add_instantiator` in favor of the global
-        # `jsonargparse.add_instantiator`, which is deliberately not used here: it registers the instantiator
-        # process-wide instead of on `self.parser`, so it would leak into every other parser in the process, including
-        # the ones of separate `LightningCLI` instances. Since there is no non-deprecated way to keep the per-parser
-        # scoping, the warning is silenced instead.
-        # TODO: revisit for jsonargparse v5.0, which removes the parser-scoped method
-        # the filter is by category rather than by message because jsonargparse emits a separate one-time banner
-        # warning alongside the deprecation itself
+        # the global `jsonargparse.add_instantiator` replacing this deprecated method registers process-wide, leaking
+        # into the parsers of every other `LightningCLI`, so the per-parser method is kept and its warning silenced
+        # TODO: revisit for jsonargparse v5.0, which removes the per-parser method
         with warnings.catch_warnings():
+            # by category, since jsonargparse pairs the deprecation with a separate one-time banner warning
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             self.parser.add_instantiator(
                 _InstantiatorFn(cli=self, key="model"),

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -15,6 +15,7 @@ import glob
 import inspect
 import json
 import os
+import warnings
 from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
@@ -31,10 +32,12 @@ from tensorboard.plugins.hparams.plugin_data_pb2 import HParamsPluginData
 from torch.optim import SGD
 from torch.optim.lr_scheduler import ReduceLROnPlateau, StepLR
 
+import lightning.pytorch.cli as cli_module
 from lightning.fabric.plugins.environments import SLURMEnvironment
 from lightning.pytorch import Callback, LightningDataModule, LightningModule, Trainer, __version__, seed_everything
 from lightning.pytorch.callbacks import LearningRateMonitor, ModelCheckpoint
 from lightning.pytorch.cli import (
+    _JSONARGPARSE_GREATER_EQUAL_4_50,
     _JSONARGPARSE_SIGNATURES_AVAILABLE,
     LightningArgumentParser,
     LightningCLI,
@@ -136,7 +139,7 @@ def test_lightning_cli(trainer_class, model_class, monkeypatch):
         save_callback[0].on_train_start(trainer, model)
 
     def on_train_start(callback, trainer, _):
-        config_dump = callback.parser.dump(callback.config, skip_none=False)
+        config_dump = callback.parser.dump(callback.config, **cli_module._KEEP_NONE_KWARGS)
         for k, v in expected_model.items():
             assert f"  {k}: {v}" in config_dump
         for k, v in expected_trainer.items():
@@ -1976,3 +1979,23 @@ def test_lightning_cli_callback_trainer_default(cleandir):
             run=False,
         )
     assert any(isinstance(c, ModelCheckpoint) for c in cli.trainer.callbacks)
+
+
+@pytest.mark.skipif(not _JSONARGPARSE_GREATER_EQUAL_4_50, reason="deprecated APIs still current before 4.50")
+def test_cli_no_jsonargparse_deprecation_warnings(cleandir):
+    """The CLI must not use jsonargparse APIs that are deprecated and slated for removal in its v5.0."""
+    cli_args = ["--trainer.logger=false", "--trainer.max_epochs=1"]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with mock.patch("sys.argv", ["any.py"] + cli_args):
+            cli = LightningCLI(BoringModel, run=False)
+        cli.trainer.fit(cli.model)
+
+    # the warnings are reported against the caller, so they point back at `lightning/pytorch/cli.py`
+    deprecations = [
+        f"{w.filename}:{w.lineno}: {w.message}"
+        for w in caught
+        if issubclass(w.category, DeprecationWarning) and w.filename == cli_module.__file__
+    ]
+    assert not deprecations

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -15,7 +15,6 @@ import glob
 import inspect
 import json
 import os
-import warnings
 from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
@@ -32,13 +31,12 @@ from tensorboard.plugins.hparams.plugin_data_pb2 import HParamsPluginData
 from torch.optim import SGD
 from torch.optim.lr_scheduler import ReduceLROnPlateau, StepLR
 
-import lightning.pytorch.cli as cli_module
 from lightning.fabric.plugins.environments import SLURMEnvironment
 from lightning.pytorch import Callback, LightningDataModule, LightningModule, Trainer, __version__, seed_everything
 from lightning.pytorch.callbacks import LearningRateMonitor, ModelCheckpoint
 from lightning.pytorch.cli import (
-    _JSONARGPARSE_GREATER_EQUAL_4_50,
     _JSONARGPARSE_SIGNATURES_AVAILABLE,
+    _KEEP_NONE_KWARGS,
     LightningArgumentParser,
     LightningCLI,
     LRSchedulerCallable,
@@ -139,7 +137,7 @@ def test_lightning_cli(trainer_class, model_class, monkeypatch):
         save_callback[0].on_train_start(trainer, model)
 
     def on_train_start(callback, trainer, _):
-        config_dump = callback.parser.dump(callback.config, **cli_module._KEEP_NONE_KWARGS)
+        config_dump = callback.parser.dump(callback.config, **_KEEP_NONE_KWARGS)
         for k, v in expected_model.items():
             assert f"  {k}: {v}" in config_dump
         for k, v in expected_trainer.items():
@@ -1979,23 +1977,3 @@ def test_lightning_cli_callback_trainer_default(cleandir):
             run=False,
         )
     assert any(isinstance(c, ModelCheckpoint) for c in cli.trainer.callbacks)
-
-
-@pytest.mark.skipif(not _JSONARGPARSE_GREATER_EQUAL_4_50, reason="deprecated APIs still current before 4.50")
-def test_cli_no_jsonargparse_deprecation_warnings(cleandir):
-    """The CLI must not use jsonargparse APIs that are deprecated and slated for removal in its v5.0."""
-    cli_args = ["--trainer.logger=false", "--trainer.max_epochs=1"]
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        with mock.patch("sys.argv", ["any.py"] + cli_args):
-            cli = LightningCLI(BoringModel, run=False)
-        cli.trainer.fit(cli.model)
-
-    # the warnings are reported against the caller, so they point back at `lightning/pytorch/cli.py`
-    deprecations = [
-        f"{w.filename}:{w.lineno}: {w.message}"
-        for w in caught
-        if issubclass(w.category, DeprecationWarning) and w.filename == cli_module.__file__
-    ]
-    assert not deprecations


### PR DESCRIPTION
## What does this PR do?

Fixes #21900.

`LightningCLI` calls jsonargparse APIs that are deprecated and slated for removal in jsonargparse v5.0, so recent versions emit deprecation warnings.

**Migrated**, gated on `jsonargparse>=4.50`:

| deprecated | replacement |
| --- | --- |
| `ArgumentParser.instantiate_classes` | `ArgumentParser.instantiate` |
| `skip_none` argument of `dump`/`save` | `skip_unset` |

A single 4.50 gate covers both: `instantiate` already exists in 4.49, whereas `skip_unset` does not — and since `dump`/`save` accept `**kwargs`, passing it to 4.49 would be silently ignored and drop `None` entries from the saved config.

**Not migrated:** `ArgumentParser.add_instantiator`. Its replacement, the global `jsonargparse.add_instantiator`, registers process-wide instead of on a single parser, and the registry is keyed by class type — so a second `LightningCLI` using the same model class would overwrite the first one's instantiator. With no non-deprecated way to keep the per-parser scoping, the warning is silenced instead, with a `TODO` for jsonargparse v5.0.

The jsonargparse upper pin is raised from `<4.48.0` to `<4.51.0` so CI actually exercises the new code path.

Verified against jsonargparse 4.47, 4.49 and 4.50.
