### PR TITLE
feat: enable storage_options support in FSDP and ModelParallel strategies

### DIFF
--- a/docs/source-fabric/guide/checkpoint/distributed_checkpoint.rst
+++ b/docs/source-fabric/guide/checkpoint/distributed_checkpoint.rst
@@ -53,6 +53,19 @@ This reduces memory peaks and speeds up the saving to disk.
     The path can also be a remote filesystem URL supported by `fsspec <https://filesystem-spec.readthedocs.io/>`_, such as ``s3://my-bucket/checkpoint``, ``gs://my-bucket/checkpoint``, or ``abfs://my-container/checkpoint``.
     This requires the corresponding fsspec implementation to be installed (e.g., ``s3fs``, ``gcsfs``, or ``adlfs``).
 
+    You can configure ``storage_options`` (such as ``{"thread_count": 8}`` to increase parallel I/O threads per rank, or remote filesystem credentials) either in the strategy or directly during ``save``/``load``:
+
+    .. code-block:: python
+
+        # Set default storage options on the strategy
+        strategy = FSDPStrategy(
+            state_dict_type="sharded",
+            storage_options={"thread_count": 8},
+        )
+
+        # Or pass storage options per save
+        fabric.save("path/to/checkpoint", state, storage_options={"thread_count": 8})
+
 .. collapse:: Full example
 
     .. code-block:: python

--- a/docs/source-pytorch/advanced/model_parallel/fsdp.rst
+++ b/docs/source-pytorch/advanced/model_parallel/fsdp.rst
@@ -405,6 +405,20 @@ The “sharded” checkpoint format is the most efficient to save and load in Li
     The checkpoint path can also be a remote filesystem URL supported by `fsspec <https://filesystem-spec.readthedocs.io/>`_, such as ``s3://my-bucket/checkpoint``, ``gs://my-bucket/checkpoint``, or ``abfs://my-container/checkpoint``.
     This requires the corresponding fsspec implementation to be installed (e.g., ``s3fs``, ``gcsfs``, or ``adlfs``).
 
+    You can also configure ``storage_options`` (such as ``{"thread_count": 8}`` for multi-threaded shard saving, or remote filesystem credentials) either on the strategy or during ``save_checkpoint``:
+
+    .. code-block:: python
+
+        # Configure at strategy level
+        strategy = FSDPStrategy(
+            state_dict_type="sharded",
+            storage_options={"thread_count": 8},
+        )
+        trainer = L.Trainer(strategy=strategy, ...)
+
+        # Or override during save_checkpoint
+        trainer.save_checkpoint("path/to/checkpoint", storage_options={"thread_count": 8})
+
 **Which checkpoint format should I use?**
 
 - ``state_dict_type="sharded"``: Use for pre-training very large models. It is fast and uses less memory, but it is less portable. An extra step is needed to :doc:`convert the sharded checkpoint into a regular checkpoint file <../../common/checkpointing_expert>`.

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added support for remote storage (fsspec URLs) in checkpoint consolidation (`python -m lightning.fabric.utilities.consolidate_checkpoint` and the `lightning consolidate` CLI) ([#21826](https://github.com/Lightning-AI/pytorch-lightning/pull/21826))
 
+- Added `storage_options` support to `FSDPStrategy`, `ModelParallelStrategy`, `TorchCheckpointIO`, and `Fabric.save`/`Fabric.load` for configuring PyTorch DCP writers/readers (e.g. `thread_count`) and filesystem options
+
 ### Changed
 
 -

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -822,6 +822,7 @@ class Fabric:
         path: Union[str, Path],
         state: dict[str, Union[nn.Module, Optimizer, Any]],
         filter: Optional[dict[str, Callable[[str, Any], bool]]] = None,
+        storage_options: Optional[Any] = None,
     ) -> None:
         r"""Save checkpoint contents to a file.
 
@@ -836,6 +837,8 @@ class Fabric:
             filter: An optional dictionary containing filter callables that return a boolean indicating whether the
                 given item should be saved (``True``) or filtered out (``False``). Each filter key should match a
                 state key, where its filter will be applied to the ``state_dict`` generated.
+            storage_options: Optional parameters when saving to storage (e.g. ``{"thread_count": 8}`` for PyTorch DCP
+                or fsspec storage options).
 
         Raises:
             TypeError: If filter is not a dictionary or contains non-callable values.
@@ -863,7 +866,9 @@ class Fabric:
             for k, v in filter.items():
                 if not callable(v):
                     raise TypeError(f"Expected `fabric.save(filter=...)` for key {k!r} to be a callable, given {v!r}")
-        self._strategy.save_checkpoint(path=path, state=_unwrap_objects(state), filter=filter)
+        self._strategy.save_checkpoint(
+            path=path, state=_unwrap_objects(state), filter=filter, storage_options=storage_options
+        )
         self.barrier()
 
     def load(
@@ -873,6 +878,7 @@ class Fabric:
         strict: bool = True,
         *,
         weights_only: Optional[bool] = None,
+        storage_options: Optional[Any] = None,
     ) -> dict[str, Any]:
         """Load a checkpoint from a file and restore the state of objects (modules, optimizers, etc.).
 
@@ -889,6 +895,7 @@ class Fabric:
                 an ``nn.Module``, use ``weights_only=False``. If loading checkpoint from an untrusted source, we
                 recommend using ``weights_only=True``. For more information, please refer to the
                 `PyTorch Developer Notes on Serialization Semantics <https://docs.pytorch.org/docs/main/notes/serialization.html#id3>`_.
+            storage_options: Optional parameters when loading from storage (e.g. fsspec or DCP reader storage options).
 
         Returns:
             The remaining items that were not restored into the given state dictionary. If no state dictionary is
@@ -911,6 +918,7 @@ class Fabric:
             state=unwrapped_state,
             strict=strict,
             weights_only=weights_only,
+            storage_options=storage_options,
         )
         self.barrier()
         if state is not None:

--- a/src/lightning/fabric/plugins/io/torch_io.py
+++ b/src/lightning/fabric/plugins/io/torch_io.py
@@ -40,22 +40,12 @@ class TorchCheckpointIO(CheckpointIO):
         Args:
             checkpoint: dict containing model and trainer state
             path: write-target path
-            storage_options: not used in ``TorchCheckpointIO.save_checkpoint``
-
-        Raises:
-            TypeError:
-                If ``storage_options`` arg is passed in
+            storage_options: Optional parameters when saving to storage.
 
         """
-        if storage_options is not None:
-            raise TypeError(
-                "`Trainer.save_checkpoint(..., storage_options=...)` with `storage_options` arg"
-                f" is not supported for `{self.__class__.__name__}`. Please implement your custom `CheckpointIO`"
-                " to define how you'd like to use `storage_options`."
-            )
-        fs = get_filesystem(path)
+        fs = get_filesystem(path, **(storage_options or {}))
         fs.makedirs(os.path.dirname(path), exist_ok=True)
-        _atomic_save(checkpoint, path)
+        _atomic_save(checkpoint, path, storage_options=storage_options)
 
     @override
     def load_checkpoint(

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -51,6 +51,7 @@ from lightning.fabric.utilities.cloud_io import (
     _atomic_save,
     _checkpoint_join,
     _get_distributed_checkpoint_reader,
+    _get_distributed_checkpoint_writer,
     _is_checkpoint_dir,
     _is_local_file_protocol,
     _load,
@@ -157,6 +158,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
         sharding_strategy: "_SHARDING_STRATEGY" = "FULL_SHARD",
         state_dict_type: Literal["full", "sharded"] = "sharded",
         device_mesh: Optional[Union[tuple[int, int], "DeviceMesh"]] = None,
+        storage_options: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -184,6 +186,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
         self.sharding_strategy = _init_sharding_strategy(sharding_strategy, self._fsdp_kwargs)
         self.cpu_offload = _init_cpu_offload(cpu_offload)
         self.mixed_precision = mixed_precision
+        self._storage_options = storage_options
 
     @property
     @override
@@ -437,11 +440,6 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
         creates a metadata file `meta.pt` with the rest of the user's state (only saved from rank 0).
 
         """
-        if storage_options is not None:
-            raise TypeError(
-                "`FSDPStrategy.save_checkpoint(..., storage_options=...)` is not supported because"
-                " `FSDPStrategy` does not use the `CheckpointIO`."
-            )
         if filter is not None and self._state_dict_type == "sharded":
             # https://github.com/pytorch/pytorch/issues/105379
             raise NotImplementedError(
@@ -470,6 +468,9 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
             )
         module = modules[0]
 
+        opts = storage_options if storage_options is not None else self._storage_options
+        save_kwargs = {"storage_options": opts} if opts is not None else {}
+
         if self._state_dict_type == "sharded":
             _prepare_directory_checkpoint(path)
 
@@ -493,10 +494,10 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
                         target_dict = metadata
                     _apply_filter(key, filter or {}, converted, target_dict)
 
-            _distributed_checkpoint_save(converted_state, path)
+            _distributed_checkpoint_save(converted_state, path, **save_kwargs)
 
             if self.global_rank == 0:
-                _atomic_save(metadata, _checkpoint_join(path, _METADATA_FILENAME))
+                _atomic_save(metadata, _checkpoint_join(path, _METADATA_FILENAME), **save_kwargs)
 
         elif self._state_dict_type == "full":
             if _is_sharded_checkpoint(path):
@@ -515,7 +516,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
                     _apply_filter(key, filter or {}, converted, full_state)
 
             if self.global_rank == 0:
-                _atomic_save(full_state, path)
+                _atomic_save(full_state, path, **save_kwargs)
         else:
             raise ValueError(f"Unknown state_dict_type: {self._state_dict_type}")
 
@@ -526,6 +527,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
         state: Optional[Union[Module, Optimizer, dict[str, Union[Module, Optimizer, Any]]]] = None,
         strict: bool = True,
         weights_only: Optional[bool] = None,
+        storage_options: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
         """Load the contents from a checkpoint and restore the state of the given objects."""
         if not state:
@@ -567,18 +569,21 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
             )
         module_key, module = list(modules.items())[0]
 
+        opts = storage_options if storage_options is not None else self._storage_options
+        load_kwargs = {"storage_options": opts} if opts is not None else {}
+
         if _is_sharded_checkpoint(path):
             state_dict_ctx = _get_sharded_state_dict_context(module)
 
             with state_dict_ctx:
                 module_state = {module_key: module.state_dict()}
-                _distributed_checkpoint_load(module_state, path)
+                _distributed_checkpoint_load(module_state, path, **load_kwargs)
                 module.load_state_dict(module_state[module_key], strict=strict)
 
                 if optimizers:
                     # TODO: replace with newer APIs
                     # https://github.com/pytorch/pytorch/issues/119800#issuecomment-1942156271
-                    reader = _get_distributed_checkpoint_reader(path)
+                    reader = _get_distributed_checkpoint_reader(path, **(opts or {}))
                     # the optimizer states must be loaded separately
                     for optim_key, optim in optimizers.items():
                         optim_state = load_sharded_optimizer_state_dict(
@@ -598,6 +603,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
             metadata = _load(
                 _checkpoint_join(path, _METADATA_FILENAME),
                 weights_only=False if weights_only is None else weights_only,
+                **load_kwargs,
             )
             requested_metadata_keys = state.keys() - modules.keys() - optimizers.keys()
             _validate_keys_for_strict_loading(requested_metadata_keys, metadata.keys(), strict=strict)
@@ -613,7 +619,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
             checkpoint = (
                 _lazy_load(path)
                 if _is_local_file_protocol(str(path))
-                else _load(path, weights_only=False if weights_only is None else weights_only)
+                else _load(path, weights_only=False if weights_only is None else weights_only, **load_kwargs)
             )
 
             from lightning.fabric.strategies.model_parallel import (
@@ -952,13 +958,19 @@ def _move_torchmetrics_to_device(module: torch.nn.Module, device: torch.device) 
         metric.to(device)  # `.to()` is in-place
 
 
-def _distributed_checkpoint_save(converted_state: dict[str, Any], path: _PATH) -> None:
+def _distributed_checkpoint_save(
+    converted_state: dict[str, Any], path: _PATH, storage_options: Optional[dict[str, Any]] = None
+) -> None:
     from torch.distributed.checkpoint import save
 
-    save(converted_state, checkpoint_id=path)
+    writer = _get_distributed_checkpoint_writer(path, **(storage_options or {}))
+    save(converted_state, storage_writer=writer)
 
 
-def _distributed_checkpoint_load(module_state: dict[str, Any], path: _PATH) -> None:
+def _distributed_checkpoint_load(
+    module_state: dict[str, Any], path: _PATH, storage_options: Optional[dict[str, Any]] = None
+) -> None:
     from torch.distributed.checkpoint import load
 
-    load(module_state, checkpoint_id=path)
+    reader = _get_distributed_checkpoint_reader(path, **(storage_options or {}))
+    load(module_state, storage_reader=reader)

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -289,7 +289,6 @@ class ModelParallelStrategy(ParallelStrategy):
                 " a model instance to reload is required. Pass it in like so:"
                 f" {type(self).__name__}.load_checkpoint(..., state={{'model': model, ...}})"
             )
-        opts = storage_options if storage_options is not None else self._storage_options
         # broadcast the path from rank 0 to ensure all the states are loaded from a common path
         path = _resolve_path(self.broadcast(path))
 

--- a/src/lightning/fabric/strategies/model_parallel.py
+++ b/src/lightning/fabric/strategies/model_parallel.py
@@ -101,6 +101,7 @@ class ModelParallelStrategy(ParallelStrategy):
         save_distributed_checkpoint: bool = True,
         process_group_backend: Optional[str] = None,
         timeout: Optional[timedelta] = default_pg_timeout,
+        storage_options: Optional[dict[str, Any]] = None,
     ) -> None:
         super().__init__()
         self._parallelize_fn = parallelize_fn
@@ -111,6 +112,7 @@ class ModelParallelStrategy(ParallelStrategy):
         self._process_group_backend: Optional[str] = process_group_backend
         self._timeout: Optional[timedelta] = timeout
         self._backward_sync_control = _ParallelBackwardSyncControl()
+        self._storage_options = storage_options
 
         self._device_mesh: Optional[DeviceMesh] = None
 
@@ -253,17 +255,13 @@ class ModelParallelStrategy(ParallelStrategy):
         written to a single file containing the weights, optimizer state and other metadata.
 
         """
-        if storage_options is not None:
-            raise TypeError(
-                f"`{type(self).__name__}.save_checkpoint(..., storage_options=...)` is not supported because"
-                f" `{type(self).__name__}` does not use the `CheckpointIO`."
-            )
         if filter is not None and self._save_distributed_checkpoint:
             # https://github.com/pytorch/pytorch/issues/105379
             raise NotImplementedError(
                 f"{type(self).__name__} doesn't support loading distributed filtered checkpoints,"
                 " so saving them is disabled."
             )
+        opts = storage_options if storage_options is not None else self._storage_options
         # broadcast the path from rank 0 to ensure all the states are saved in a common path
         path = _resolve_path(self.broadcast(path))
         _save_checkpoint(
@@ -272,6 +270,7 @@ class ModelParallelStrategy(ParallelStrategy):
             full_state_dict=(not self._save_distributed_checkpoint),
             rank=self.global_rank,
             filter=filter,
+            storage_options=opts,
         )
 
     @override
@@ -281,6 +280,7 @@ class ModelParallelStrategy(ParallelStrategy):
         state: Optional[Union[Module, Optimizer, dict[str, Union[Module, Optimizer, Any]]]] = None,
         strict: bool = True,
         weights_only: Optional[bool] = None,
+        storage_options: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
         """Load the contents from a checkpoint and restore the state of the given objects."""
         if not state:
@@ -289,6 +289,7 @@ class ModelParallelStrategy(ParallelStrategy):
                 " a model instance to reload is required. Pass it in like so:"
                 f" {type(self).__name__}.load_checkpoint(..., state={{'model': model, ...}})"
             )
+        opts = storage_options if storage_options is not None else self._storage_options
         # broadcast the path from rank 0 to ensure all the states are loaded from a common path
         path = _resolve_path(self.broadcast(path))
 
@@ -359,6 +360,7 @@ def _save_checkpoint(
     full_state_dict: bool,
     rank: int,
     filter: Optional[dict[str, Callable[[str, Any], bool]]] = None,
+    storage_options: Optional[dict[str, Any]] = None,
 ) -> None:
     if _is_checkpoint_dir(path) and full_state_dict and not _is_sharded_checkpoint(path):
         raise IsADirectoryError(f"The checkpoint path exists and is a directory: {path}")
@@ -399,17 +401,19 @@ def _save_checkpoint(
             target_dict = metadata
         _apply_filter(key, filter or {}, converted, target_dict)
 
+    save_kwargs = {"storage_options": storage_options} if storage_options is not None else {}
+
     if full_state_dict:
         if _is_sharded_checkpoint(path):
             _remove_checkpoint(path)
         converted_state.update(metadata)
         if rank == 0:
-            _atomic_save(converted_state, path)
+            _atomic_save(converted_state, path, **save_kwargs)
     else:
         _prepare_directory_checkpoint(path)
-        _distributed_checkpoint_save(converted_state, path)
+        _distributed_checkpoint_save(converted_state, path, **save_kwargs)
         if rank == 0:
-            _atomic_save(metadata, _checkpoint_join(path, _METADATA_FILENAME))
+            _atomic_save(metadata, _checkpoint_join(path, _METADATA_FILENAME), **save_kwargs)
 
 
 def _load_checkpoint(
@@ -418,6 +422,7 @@ def _load_checkpoint(
     strict: bool = True,
     optimizer_states_from_list: bool = False,
     weights_only: Optional[bool] = None,
+    storage_options: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     from torch.distributed.checkpoint.state_dict import (
         StateDictOptions,
@@ -442,23 +447,26 @@ def _load_checkpoint(
         )
     module_key, module = list(modules.items())[0]
 
+    load_kwargs = {"storage_options": storage_options} if storage_options is not None else {}
+
     if _is_sharded_checkpoint(path):
         state_dict_options = StateDictOptions(cpu_offload=True)
 
         module_state = {module_key: get_model_state_dict(module)}
-        _distributed_checkpoint_load(module_state, path)
+        _distributed_checkpoint_load(module_state, path, **load_kwargs)
         module.load_state_dict(module_state[module_key], strict=strict)
 
         # the optimizer states must be loaded separately
         for optim_key, optim in optimizers.items():
             optim_state = {optim_key: get_optimizer_state_dict(module, optim)}
-            _distributed_checkpoint_load(optim_state, path)
+            _distributed_checkpoint_load(optim_state, path, **load_kwargs)
             set_optimizer_state_dict(module, optim, optim_state_dict=optim_state[optim_key], options=state_dict_options)
 
         # Load metadata (anything not a module or optimizer)
         metadata = _load(
             _checkpoint_join(path, _METADATA_FILENAME),
             weights_only=False if weights_only is None else weights_only,
+            **load_kwargs,
         )
         requested_metadata_keys = state.keys() - modules.keys() - optimizers.keys()
         _validate_keys_for_strict_loading(requested_metadata_keys, metadata.keys(), strict=strict)
@@ -475,7 +483,7 @@ def _load_checkpoint(
         if _is_local_file_protocol(str(path)):
             checkpoint = torch.load(path, mmap=True, map_location="cpu", weights_only=weights_only)
         else:
-            checkpoint = _load(path, map_location="cpu", weights_only=weights_only)
+            checkpoint = _load(path, map_location="cpu", weights_only=weights_only, **load_kwargs)
         _load_raw_module_state(checkpoint.pop(module_key), module, strict=strict)
 
         state_dict_options = StateDictOptions(

--- a/src/lightning/fabric/utilities/cloud_io.py
+++ b/src/lightning/fabric/utilities/cloud_io.py
@@ -37,6 +37,7 @@ def _load(
     path_or_url: Union[IO, _PATH],
     map_location: _MAP_LOCATION_TYPE = None,
     weights_only: Optional[bool] = None,
+    storage_options: Optional[dict[str, Any]] = None,
 ) -> Any:
     """Loads a checkpoint.
 
@@ -48,6 +49,7 @@ def _load(
             ``weights_only=False``. If loading checkpoint from an untrusted source, we recommend using
             ``weights_only=True``. For more information, please refer to the
             `PyTorch Developer Notes on Serialization Semantics <https://docs.pytorch.org/docs/main/notes/serialization.html#id3>`_.
+        storage_options: Optional parameters when reading from storage.
 
     """
     if not isinstance(path_or_url, (str, Path)):
@@ -70,7 +72,7 @@ def _load(
             map_location=map_location,  # type: ignore[arg-type]
             weights_only=weights_only,
         )
-    fs = get_filesystem(path_or_url)
+    fs = get_filesystem(path_or_url, **(storage_options or {}))
     with fs.open(path_or_url, "rb") as f:
         return torch.load(
             f,
@@ -84,7 +86,9 @@ def get_filesystem(path: _PATH, **kwargs: Any) -> AbstractFileSystem:
     return fs
 
 
-def _atomic_save(checkpoint: dict[str, Any], filepath: _PATH) -> None:
+def _atomic_save(
+    checkpoint: dict[str, Any], filepath: _PATH, storage_options: Optional[dict[str, Any]] = None
+) -> None:
     """Saves a checkpoint atomically, avoiding the creation of incomplete checkpoints.
 
     Args:
@@ -93,13 +97,14 @@ def _atomic_save(checkpoint: dict[str, Any], filepath: _PATH) -> None:
             accepts.
         filepath: The path to which the checkpoint will be saved.
             This points to the file that the checkpoint will be stored in.
+        storage_options: Optional parameters when saving to storage.
 
     """
     log.debug(f"Saving checkpoint: {filepath}")
 
     try:
         # We use a transaction here to avoid file corruption if the save gets interrupted
-        fs, urlpath = fsspec.core.url_to_fs(str(filepath))
+        fs, urlpath = fsspec.core.url_to_fs(str(filepath), **(storage_options or {}))
         with fs.transaction:
             if _is_object_storage(fs):
                 is_azure = False
@@ -250,23 +255,25 @@ def _remove_checkpoint(path: Union[str, Path]) -> None:
         fs.rm(str(path), recursive=True)
 
 
-def _get_distributed_checkpoint_writer(path: _PATH) -> Any:
+def _get_distributed_checkpoint_writer(path: _PATH, **kwargs: Any) -> Any:
     if _is_local_file_protocol(str(path)):
         from torch.distributed.checkpoint import FileSystemWriter
 
         # FSDP's FileSystemWriter streams the tensors to disk to minimize memory peaks
-        return FileSystemWriter(path=path, single_file_per_rank=True)
+        kwargs.setdefault("single_file_per_rank", True)
+        return FileSystemWriter(path=path, **kwargs)
     FsspecWriter = _import_fsspec_dcp_filesystem("FsspecWriter")
-    return FsspecWriter(path=str(path), single_file_per_rank=True)
+    kwargs.setdefault("single_file_per_rank", True)
+    return FsspecWriter(path=str(path), **kwargs)
 
 
-def _get_distributed_checkpoint_reader(path: _PATH) -> Any:
+def _get_distributed_checkpoint_reader(path: _PATH, **kwargs: Any) -> Any:
     if _is_local_file_protocol(str(path)):
         from torch.distributed.checkpoint import FileSystemReader
 
-        return FileSystemReader(path=path)
+        return FileSystemReader(path=path, **kwargs)
     FsspecReader = _import_fsspec_dcp_filesystem("FsspecReader")
-    return FsspecReader(path=str(path))
+    return FsspecReader(path=str(path), **kwargs)
 
 
 def _import_fsspec_dcp_filesystem(name: str) -> Any:

--- a/src/lightning/fabric/utilities/cloud_io.py
+++ b/src/lightning/fabric/utilities/cloud_io.py
@@ -86,9 +86,7 @@ def get_filesystem(path: _PATH, **kwargs: Any) -> AbstractFileSystem:
     return fs
 
 
-def _atomic_save(
-    checkpoint: dict[str, Any], filepath: _PATH, storage_options: Optional[dict[str, Any]] = None
-) -> None:
+def _atomic_save(checkpoint: dict[str, Any], filepath: _PATH, storage_options: Optional[dict[str, Any]] = None) -> None:
     """Saves a checkpoint atomically, avoiding the creation of incomplete checkpoints.
 
     Args:

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -241,7 +241,9 @@ def _move_state_into(
             destination[key] = state
 
 
-def _load_distributed_checkpoint(checkpoint_folder: _PATH) -> dict[str, Any]:
+def _load_distributed_checkpoint(
+    checkpoint_folder: _PATH, storage_options: Optional[dict[str, Any]] = None
+) -> dict[str, Any]:
     """Loads a sharded checkpoint saved with the `torch.distributed.checkpoint` into a full state dict.
 
     The current implementation assumes that the entire checkpoint fits in CPU memory. Supports checkpoints stored on
@@ -254,15 +256,17 @@ def _load_distributed_checkpoint(checkpoint_folder: _PATH) -> dict[str, Any]:
     checkpoint: dict[str, Any] = {}
     _load_state_dict(
         checkpoint,
-        storage_reader=_get_distributed_checkpoint_reader(checkpoint_folder),
+        storage_reader=_get_distributed_checkpoint_reader(checkpoint_folder, **(storage_options or {})),
         planner=_EmptyStateDictLoadPlanner(),
         no_dist=True,
     )
 
     # This is the extra file saved by Fabric, with user data separate from weights and optimizer states
     extra_file = _checkpoint_join(checkpoint_folder, _METADATA_FILENAME)
-    fs = get_filesystem(checkpoint_folder)
-    extra = _load(extra_file, map_location="cpu") if fs.isfile(str(extra_file)) else {}
+    fs = get_filesystem(checkpoint_folder, **(storage_options or {}))
+    extra = (
+        _load(extra_file, map_location="cpu", storage_options=storage_options) if fs.isfile(str(extra_file)) else {}
+    )
     checkpoint.update(extra)
 
     return checkpoint

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -264,9 +264,7 @@ def _load_distributed_checkpoint(
     # This is the extra file saved by Fabric, with user data separate from weights and optimizer states
     extra_file = _checkpoint_join(checkpoint_folder, _METADATA_FILENAME)
     fs = get_filesystem(checkpoint_folder, **(storage_options or {}))
-    extra = (
-        _load(extra_file, map_location="cpu", storage_options=storage_options) if fs.isfile(str(extra_file)) else {}
-    )
+    extra = _load(extra_file, map_location="cpu", storage_options=storage_options) if fs.isfile(str(extra_file)) else {}
     checkpoint.update(extra)
 
     return checkpoint

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added support for remote storage (fsspec URLs) when saving and loading distributed checkpoints with `ModelParallelStrategy` ([#21797](https://github.com/Lightning-AI/pytorch-lightning/issues/21797))
 
+- Added `storage_options` support to `FSDPStrategy` and `ModelParallelStrategy` for configuring PyTorch DCP writers/readers (e.g. `thread_count`) and filesystem options
+
 ### Changed
 
 -

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -170,6 +170,7 @@ class FSDPStrategy(ParallelStrategy):
         sharding_strategy: "_SHARDING_STRATEGY" = "FULL_SHARD",
         state_dict_type: Literal["full", "sharded"] = "full",
         device_mesh: Optional[Union[tuple[int, int], "DeviceMesh"]] = None,
+        storage_options: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -185,6 +186,7 @@ class FSDPStrategy(ParallelStrategy):
         self.cpu_offload = _init_cpu_offload(cpu_offload)
         self.mixed_precision = mixed_precision
         self.kwargs = _auto_wrap_policy_kwargs(auto_wrap_policy, kwargs)
+        self._storage_options = storage_options
 
         if device_mesh is not None:
             self.kwargs["device_mesh"] = device_mesh
@@ -566,15 +568,12 @@ class FSDPStrategy(ParallelStrategy):
     def save_checkpoint(
         self, checkpoint: dict[str, Any], filepath: _PATH, storage_options: Optional[Any] = None
     ) -> None:
-        if storage_options is not None:
-            raise TypeError(
-                "`FSDPStrategy.save_checkpoint(..., storage_options=...)` is not supported because"
-                " `FSDPStrategy` does not use the `CheckpointIO`."
-            )
-
+        opts = storage_options if storage_options is not None else self._storage_options
         path = _resolve_path(self.broadcast(filepath))
         if self._state_dict_type == "full" and _is_checkpoint_dir(path) and not _is_sharded_checkpoint(path):
             raise IsADirectoryError(f"The checkpoint path exists and is a directory: {path}")
+
+        save_kwargs = {"storage_options": opts} if opts is not None else {}
 
         if self._state_dict_type == "sharded":
             _prepare_directory_checkpoint(path)
@@ -585,19 +584,24 @@ class FSDPStrategy(ParallelStrategy):
                 for idx, optim_state in enumerate(checkpoint.pop("optimizer_states", []))
             })
 
-            _distributed_checkpoint_save(converted_state, path)
+            _distributed_checkpoint_save(converted_state, path, **save_kwargs)
 
             if self.global_rank == 0:
-                _atomic_save(checkpoint, _checkpoint_join(path, _METADATA_FILENAME))
+                _atomic_save(checkpoint, _checkpoint_join(path, _METADATA_FILENAME), **save_kwargs)
         elif self._state_dict_type == "full":
             if _is_sharded_checkpoint(path):
                 _remove_checkpoint(path)
-            return super().save_checkpoint(checkpoint=checkpoint, filepath=path)
+            return super().save_checkpoint(checkpoint=checkpoint, filepath=path, storage_options=opts)
         else:
             raise ValueError(f"Unknown state_dict_type: {self._state_dict_type}")
 
     @override
-    def load_checkpoint(self, checkpoint_path: _PATH, weights_only: Optional[bool] = None) -> dict[str, Any]:
+    def load_checkpoint(
+        self,
+        checkpoint_path: _PATH,
+        weights_only: Optional[bool] = None,
+        storage_options: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         # broadcast the path from rank 0 to ensure all the states are loaded from a common path
         path = _resolve_path(self.broadcast(checkpoint_path))
 
@@ -606,6 +610,9 @@ class FSDPStrategy(ParallelStrategy):
         assert self.model is not None
         assert self.lightning_module is not None
 
+        opts = storage_options if storage_options is not None else self._storage_options
+        load_kwargs = {"storage_options": opts} if opts is not None else {}
+
         if _is_sharded_checkpoint(path):
             from torch.distributed.checkpoint.optimizer import load_sharded_optimizer_state_dict
 
@@ -613,13 +620,13 @@ class FSDPStrategy(ParallelStrategy):
 
             with state_dict_ctx:
                 module_state = {"model": self.model.state_dict()}
-                _distributed_checkpoint_load(module_state, path)
+                _distributed_checkpoint_load(module_state, path, **load_kwargs)
                 self.model.load_state_dict(module_state["model"], strict=self.lightning_module.strict_loading)
 
                 if self.lightning_module.trainer.state.fn == TrainerFn.FITTING and self.optimizers:
                     # TODO: replace with newer APIs
                     # https://github.com/pytorch/pytorch/issues/119800#issuecomment-1942156271
-                    reader = _get_distributed_checkpoint_reader(path)
+                    reader = _get_distributed_checkpoint_reader(path, **(opts or {}))
                     # the optimizer states must be loaded separately
                     for idx, optim in enumerate(self.optimizers):
                         optim_key = f"optimizer_{idx}"
@@ -640,6 +647,7 @@ class FSDPStrategy(ParallelStrategy):
             metadata = _load(
                 _checkpoint_join(path, _METADATA_FILENAME),
                 weights_only=False if weights_only is None else weights_only,
+                **load_kwargs,
             )
             return metadata
 
@@ -647,7 +655,7 @@ class FSDPStrategy(ParallelStrategy):
             checkpoint = (
                 _lazy_load(path)
                 if _is_local_file_protocol(str(path))
-                else _load(path, weights_only=False if weights_only is None else weights_only)
+                else _load(path, weights_only=False if weights_only is None else weights_only, **load_kwargs)
             )
             _load_raw_module_state(
                 checkpoint.pop("state_dict"),

--- a/src/lightning/pytorch/strategies/model_parallel.py
+++ b/src/lightning/pytorch/strategies/model_parallel.py
@@ -90,6 +90,7 @@ class ModelParallelStrategy(ParallelStrategy):
         save_distributed_checkpoint: bool = True,
         process_group_backend: Optional[str] = None,
         timeout: Optional[timedelta] = default_pg_timeout,
+        storage_options: Optional[dict[str, Any]] = None,
     ) -> None:
         super().__init__()
         self._data_parallel_size = data_parallel_size
@@ -97,6 +98,7 @@ class ModelParallelStrategy(ParallelStrategy):
         self._save_distributed_checkpoint = save_distributed_checkpoint
         self._process_group_backend: Optional[str] = process_group_backend
         self._timeout: Optional[timedelta] = timeout
+        self._storage_options = storage_options
         self._device_mesh: Optional[DeviceMesh] = None
         self.num_nodes = 1
 
@@ -302,15 +304,13 @@ class ModelParallelStrategy(ParallelStrategy):
     def save_checkpoint(
         self, checkpoint: dict[str, Any], filepath: _PATH, storage_options: Optional[Any] = None
     ) -> None:
-        if storage_options is not None:
-            raise TypeError(
-                f"`{type(self).__name__}.save_checkpoint(..., storage_options=...)` is not supported because"
-                f" `{type(self).__name__}` does not use the `CheckpointIO`."
-            )
+        opts = storage_options if storage_options is not None else self._storage_options
         # broadcast the path from rank 0 to ensure all the checkpoints are saved to a common path
         path = _resolve_path(self.broadcast(filepath))
         if _is_checkpoint_dir(path) and not self._save_distributed_checkpoint and not _is_sharded_checkpoint(path):
             raise IsADirectoryError(f"The checkpoint path exists and is a directory: {path}")
+
+        save_kwargs = {"storage_options": opts} if opts is not None else {}
 
         if self._save_distributed_checkpoint:
             _prepare_directory_checkpoint(path)
@@ -320,17 +320,22 @@ class ModelParallelStrategy(ParallelStrategy):
                 f"optimizer_{idx}": optim_state
                 for idx, optim_state in enumerate(checkpoint.pop("optimizer_states", []))
             })
-            _distributed_checkpoint_save(converted_state, path)
+            _distributed_checkpoint_save(converted_state, path, **save_kwargs)
 
             if self.global_rank == 0:
-                _atomic_save(checkpoint, _checkpoint_join(path, _METADATA_FILENAME))
+                _atomic_save(checkpoint, _checkpoint_join(path, _METADATA_FILENAME), **save_kwargs)
         else:
             if _is_sharded_checkpoint(path):
                 _remove_checkpoint(path)
-            return super().save_checkpoint(checkpoint=checkpoint, filepath=path)
+            return super().save_checkpoint(checkpoint=checkpoint, filepath=path, storage_options=opts)
 
     @override
-    def load_checkpoint(self, checkpoint_path: _PATH, weights_only: Optional[bool] = None) -> dict[str, Any]:
+    def load_checkpoint(
+        self,
+        checkpoint_path: _PATH,
+        weights_only: Optional[bool] = None,
+        storage_options: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         # broadcast the path from rank 0 to ensure all the states are loaded from a common path
         path = _resolve_path(self.broadcast(checkpoint_path))
         state = {
@@ -338,12 +343,15 @@ class ModelParallelStrategy(ParallelStrategy):
             **{f"optimizer_{idx}": optimizer for idx, optimizer in enumerate(self.optimizers)},
         }
         assert self.lightning_module is not None
+        opts = storage_options if storage_options is not None else self._storage_options
+        load_kwargs = {"storage_options": opts} if opts is not None else {}
         return _load_checkpoint(
             path=path,
             state=state,
             strict=self.lightning_module.strict_loading,
             optimizer_states_from_list=True,
             weights_only=weights_only,
+            **load_kwargs,
         )
 
     def _setup_distributed(self) -> None:

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -240,11 +240,25 @@ def test_grad_clipping_norm_error():
         strategy.clip_gradients_norm(Mock(), Mock(), Mock())
 
 
-def test_save_checkpoint_storage_options(tmp_path):
-    """Test that the FSDP strategy does not accept storage options for saving checkpoints."""
-    strategy = FSDPStrategy()
-    with pytest.raises(TypeError, match=escape("FSDPStrategy.save_checkpoint(..., storage_options=...)` is not")):
-        strategy.save_checkpoint(path=tmp_path, state=Mock(), storage_options=Mock())
+@mock.patch("lightning.fabric.strategies.fsdp.FSDPStrategy.broadcast", lambda _, x: x)
+@mock.patch("lightning.fabric.strategies.fsdp._get_sharded_state_dict_context")
+@mock.patch("lightning.fabric.strategies.fsdp._atomic_save")
+@mock.patch("lightning.fabric.strategies.fsdp._distributed_checkpoint_save")
+def test_save_checkpoint_storage_options(dcp_save_mock, atomic_save_mock, _, tmp_path):
+    """Test that the FSDP strategy forwards storage options for saving checkpoints."""
+    model = Mock(spec=FullyShardedDataParallel)
+    model.modules.return_value = [model]
+
+    strategy = FSDPStrategy(state_dict_type="sharded", storage_options={"thread_count": 4})
+    strategy.save_checkpoint(path=tmp_path, state={"model": model})
+    dcp_save_mock.assert_called_once_with({"model": model.state_dict()}, tmp_path, storage_options={"thread_count": 4})
+    atomic_save_mock.assert_called_once_with({}, tmp_path / "meta.pt", storage_options={"thread_count": 4})
+
+    dcp_save_mock.reset_mock()
+    atomic_save_mock.reset_mock()
+    strategy.save_checkpoint(path=tmp_path, state={"model": model}, storage_options={"thread_count": 8})
+    dcp_save_mock.assert_called_once_with({"model": model.state_dict()}, tmp_path, storage_options={"thread_count": 8})
+    atomic_save_mock.assert_called_once_with({}, tmp_path / "meta.pt", storage_options={"thread_count": 8})
 
 
 @mock.patch("lightning.fabric.strategies.fsdp.FSDPStrategy.broadcast", lambda _, x: x)
@@ -539,12 +553,16 @@ def test_distributed_checkpoint_reader_writer_selection(tmp_path):
         _get_distributed_checkpoint_writer,
     )
 
-    assert isinstance(_get_distributed_checkpoint_writer(str(tmp_path)), FileSystemWriter)
+    writer = _get_distributed_checkpoint_writer(str(tmp_path), thread_count=4)
+    assert isinstance(writer, FileSystemWriter)
+    assert writer.thread_count == 4
     assert isinstance(_get_distributed_checkpoint_reader(str(tmp_path)), FileSystemReader)
 
     from torch.distributed.checkpoint._fsspec_filesystem import FsspecReader, FsspecWriter
 
-    assert isinstance(_get_distributed_checkpoint_writer("memory:///w/ckpt"), FsspecWriter)
+    writer_remote = _get_distributed_checkpoint_writer("memory:///w/ckpt", thread_count=6)
+    assert isinstance(writer_remote, FsspecWriter)
+    assert writer_remote.thread_count == 6
     assert isinstance(_get_distributed_checkpoint_reader("memory:///w/ckpt"), FsspecReader)
 
 

--- a/tests/tests_fabric/strategies/test_model_parallel.py
+++ b/tests/tests_fabric/strategies/test_model_parallel.py
@@ -133,13 +133,24 @@ def test_no_backward_sync():
 
 
 @RunIf(min_torch="2.4")
-def test_save_checkpoint_storage_options(tmp_path):
-    """Test that the strategy does not accept storage options for saving checkpoints."""
-    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m))
-    with pytest.raises(
-        TypeError, match=escape("ModelParallelStrategy.save_checkpoint(..., storage_options=...)` is not")
-    ):
-        strategy.save_checkpoint(path=tmp_path, state=Mock(), storage_options=Mock())
+@mock.patch("lightning.fabric.strategies.model_parallel.ModelParallelStrategy.broadcast", lambda _, x: x)
+@mock.patch("lightning.fabric.strategies.model_parallel._has_dtensor_modules", return_value=True)
+@mock.patch("torch.distributed.checkpoint.state_dict.get_model_state_dict", return_value={})
+@mock.patch("lightning.fabric.strategies.model_parallel._atomic_save")
+@mock.patch("lightning.fabric.strategies.model_parallel._distributed_checkpoint_save")
+def test_save_checkpoint_storage_options(dcp_save_mock, atomic_save_mock, _, __, tmp_path):
+    """Test that the ModelParallel strategy forwards storage options for saving checkpoints."""
+    model = Mock(spec=torch.nn.Module)
+    strategy = ModelParallelStrategy(parallelize_fn=(lambda m, _: m), storage_options={"thread_count": 4})
+    strategy.save_checkpoint(path=tmp_path, state={"model": model})
+    dcp_save_mock.assert_called_once_with({"model": {}}, tmp_path, storage_options={"thread_count": 4})
+    atomic_save_mock.assert_called_once_with({}, tmp_path / "meta.pt", storage_options={"thread_count": 4})
+
+    dcp_save_mock.reset_mock()
+    atomic_save_mock.reset_mock()
+    strategy.save_checkpoint(path=tmp_path, state={"model": model}, storage_options={"thread_count": 8})
+    dcp_save_mock.assert_called_once_with({"model": {}}, tmp_path, storage_options={"thread_count": 8})
+    atomic_save_mock.assert_called_once_with({}, tmp_path / "meta.pt", storage_options={"thread_count": 8})
 
 
 @RunIf(min_torch="2.4")

--- a/tests/tests_pytorch/checkpointing/test_trainer_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_trainer_checkpoint.py
@@ -105,13 +105,10 @@ def test_trainer_save_checkpoint_storage_options(tmp_path, xla_available):
         save_mock.assert_called_with(checkpoint_mock, instance_path, storage_options=instance_storage_options)
 
     torch_checkpoint_io = TorchCheckpointIO()
-    with pytest.raises(
-        TypeError,
-        match=r"`Trainer.save_checkpoint\(..., storage_options=...\)` with `storage_options` arg"
-        f" is not supported for `{torch_checkpoint_io.__class__.__name__}`. Please implement your custom `CheckpointIO`"
-        " to define how you'd like to use `storage_options`.",
-    ):
-        torch_checkpoint_io.save_checkpoint({}, instance_path, storage_options=instance_storage_options)
+    with mock.patch("lightning.fabric.plugins.io.torch_io._atomic_save") as atomic_save_mock:
+        torch_checkpoint_io.save_checkpoint({}, instance_path, storage_options={"storage_opt": 1})
+        atomic_save_mock.assert_called_once_with({}, instance_path, storage_options={"storage_opt": 1})
+
     xla_checkpoint_io = XLACheckpointIO()
     with pytest.raises(
         TypeError,

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -754,11 +754,23 @@ def test_configure_model(precision, expected_dtype, tmp_path):
     trainer.fit(model)
 
 
-def test_save_checkpoint_storage_options(tmp_path):
-    """Test that the FSDP strategy does not accept storage options for saving checkpoints."""
-    strategy = FSDPStrategy()
-    with pytest.raises(TypeError, match=escape("FSDPStrategy.save_checkpoint(..., storage_options=...)` is not")):
-        strategy.save_checkpoint(filepath=tmp_path, checkpoint=Mock(), storage_options=Mock())
+@mock.patch("lightning.pytorch.strategies.fsdp.FSDPStrategy.broadcast", lambda _, x: x)
+@mock.patch("lightning.pytorch.strategies.fsdp._atomic_save")
+@mock.patch("lightning.pytorch.strategies.fsdp._distributed_checkpoint_save")
+def test_save_checkpoint_storage_options(dcp_save_mock, atomic_save_mock, tmp_path):
+    """Test that the FSDP strategy forwards storage options for saving checkpoints."""
+    strategy = FSDPStrategy(state_dict_type="sharded", storage_options={"thread_count": 4})
+    checkpoint = {"state_dict": {}, "optimizer_states": []}
+    strategy.save_checkpoint(filepath=tmp_path, checkpoint=checkpoint)
+    dcp_save_mock.assert_called_once_with({"model": {}}, tmp_path, storage_options={"thread_count": 4})
+    atomic_save_mock.assert_called_once_with({}, tmp_path / "meta.pt", storage_options={"thread_count": 4})
+
+    dcp_save_mock.reset_mock()
+    atomic_save_mock.reset_mock()
+    checkpoint = {"state_dict": {}, "optimizer_states": []}
+    strategy.save_checkpoint(filepath=tmp_path, checkpoint=checkpoint, storage_options={"thread_count": 8})
+    dcp_save_mock.assert_called_once_with({"model": {}}, tmp_path, storage_options={"thread_count": 8})
+    atomic_save_mock.assert_called_once_with({}, tmp_path / "meta.pt", storage_options={"thread_count": 8})
 
 
 @mock.patch("lightning.pytorch.strategies.fsdp.FSDPStrategy.broadcast", lambda _, x: x)

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 from datetime import timedelta
 from functools import partial
 from pathlib import Path
-from re import escape
 from typing import Optional
 from unittest import mock
 from unittest.mock import ANY, MagicMock, Mock

--- a/tests/tests_pytorch/strategies/test_model_parallel.py
+++ b/tests/tests_pytorch/strategies/test_model_parallel.py
@@ -109,13 +109,23 @@ def test_configure_model_required():
 
 
 @RunIf(min_torch="2.4")
-def test_save_checkpoint_storage_options(tmp_path):
-    """Test that the strategy does not accept storage options for saving checkpoints."""
-    strategy = ModelParallelStrategy()
-    with pytest.raises(
-        TypeError, match=escape("ModelParallelStrategy.save_checkpoint(..., storage_options=...)` is not")
-    ):
-        strategy.save_checkpoint(checkpoint=Mock(), filepath=tmp_path, storage_options=Mock())
+@mock.patch("lightning.pytorch.strategies.model_parallel.ModelParallelStrategy.broadcast", lambda _, x: x)
+@mock.patch("lightning.pytorch.strategies.model_parallel._atomic_save")
+@mock.patch("lightning.pytorch.strategies.model_parallel._distributed_checkpoint_save")
+def test_save_checkpoint_storage_options(dcp_save_mock, atomic_save_mock, tmp_path):
+    """Test that the ModelParallel strategy forwards storage options for saving checkpoints."""
+    strategy = ModelParallelStrategy(storage_options={"thread_count": 4})
+    checkpoint = {"state_dict": {}, "optimizer_states": []}
+    strategy.save_checkpoint(checkpoint=checkpoint, filepath=tmp_path)
+    dcp_save_mock.assert_called_once_with({"state_dict": {}}, tmp_path, storage_options={"thread_count": 4})
+    atomic_save_mock.assert_called_once_with({}, tmp_path / "meta.pt", storage_options={"thread_count": 4})
+
+    dcp_save_mock.reset_mock()
+    atomic_save_mock.reset_mock()
+    checkpoint = {"state_dict": {}, "optimizer_states": []}
+    strategy.save_checkpoint(checkpoint=checkpoint, filepath=tmp_path, storage_options={"thread_count": 8})
+    dcp_save_mock.assert_called_once_with({"state_dict": {}}, tmp_path, storage_options={"thread_count": 8})
+    atomic_save_mock.assert_called_once_with({}, tmp_path / "meta.pt", storage_options={"thread_count": 8})
 
 
 @RunIf(min_torch="2.4")

--- a/tests/tests_pytorch/strategies/test_model_parallel.py
+++ b/tests/tests_pytorch/strategies/test_model_parallel.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from datetime import timedelta
-from re import escape
 from unittest import mock
 from unittest.mock import Mock
 


### PR DESCRIPTION

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #21905

This PR enables unified support for the `storage_options` parameter across `FSDPStrategy`, `ModelParallelStrategy`, `TorchCheckpointIO`, and `Fabric.save`/`Fabric.load`. It removes the legacy `TypeError` guards and wires `storage_options` directly through to the underlying DCP storage writers/readers, `fsspec`, and atomic saving utilities.

### Key Changes

1. **`lightning.fabric.utilities.cloud_io`**:
   - Updated `_get_distributed_checkpoint_writer` and `_get_distributed_checkpoint_reader` to accept `**kwargs` and pass them to `FileSystemWriter`/`FsspecWriter` and `FileSystemReader`/`FsspecReader` (enabling `thread_count`, `per_thread_copy_ahead`, etc.).
   - Updated `_load` and `_atomic_save` to accept `storage_options: Optional[dict[str, Any]] = None` and forward to `get_filesystem` and `fsspec.core.url_to_fs`.

2. **`lightning.fabric.plugins.io.torch_io`**:
   - Removed the `TypeError` guard in `TorchCheckpointIO.save_checkpoint` and forwarded `storage_options` to `get_filesystem` and `_atomic_save`.

3. **`FSDPStrategy` (`Fabric` & `PyTorch`)**:
   - Added `storage_options: Optional[dict[str, Any]] = None` to `FSDPStrategy.__init__`.
   - Forwarded `storage_options` in `save_checkpoint` and `load_checkpoint` to `_distributed_checkpoint_save`, `_distributed_checkpoint_load`, `_get_distributed_checkpoint_reader`, and `_atomic_save`.

4. **`ModelParallelStrategy` (`Fabric` & `PyTorch`)**:
   - Added `storage_options: Optional[dict[str, Any]] = None` to `ModelParallelStrategy.__init__`.
   - Forwarded `storage_options` in `save_checkpoint`, `load_checkpoint`, `_save_checkpoint`, and `_load_checkpoint`.

5. **`Fabric` & Utilities**:
   - Added `storage_options` parameter to `Fabric.save` and `Fabric.load`.
   - Added `storage_options` parameter to `_load_distributed_checkpoint`.

6. **Tests**:
   - Updated existing tests that previously asserted `TypeError` on `storage_options` across Fabric and PyTorch test suites (`test_fsdp.py`, `test_model_parallel.py`, `test_trainer_checkpoint.py`).
   - Added assertions ensuring `storage_options` (e.g. `thread_count`) are passed through to `_distributed_checkpoint_save`, `_atomic_save`, `FileSystemWriter`, and `FsspecWriter`.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
