### PR TITLE
fix(mypy): cast OmegaConf result in `load_hparams_from_yaml`

### DIFF
--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -22,7 +22,7 @@ from argparse import Namespace
 from copy import deepcopy
 from enum import Enum
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import IO, TYPE_CHECKING, Any, Callable, Optional, Union, cast
 from warnings import warn
 
 import torch
@@ -324,7 +324,8 @@ def load_hparams_from_yaml(config_yaml: _PATH, use_omegaconf: bool = True) -> di
         from omegaconf.errors import UnsupportedValueType, ValidationError
 
         with contextlib.suppress(UnsupportedValueType, ValidationError):
-            return OmegaConf.create(hparams)
+            # OmegaConf containers are mapping-like but not `dict` subclasses
+            return cast("dict[str, Any]", OmegaConf.create(hparams))
     return hparams
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #21908
```python
src/lightning/pytorch/core/saving.py:327: error: Incompatible return value type (got "DictConfig | ListConfig", expected "dict[str, Any]")  [return-value]
Found 1 error in 1 file (checked 266 source files)
```

`types-PyYAML` `6.0.12.20260815` changed `yaml.full_load` to return `_YAMLObject` (`TypeAlias = Any`) instead of a bare `Any`. 

mypy's ambiguous-overload fallback only applies to a *bare* `Any`, so it now resolves `OmegaConf.create()` to the first matching overload, `-> DictConfig | ListConfig`, and flags it against the declared `dict[str, Any]`.

Makes the conversion explicit with a `cast`.

## PR review

Anyone in the community is welcome to review the PR.
