### PR TITLE
Prevent ModelCheckpoint from deleting resumed remote checkpoints

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `RichProgressBar` showing a nonsensical negative epoch total (e.g. `Epoch 5/-2`) when `Trainer(max_epochs=-1)` (unlimited epochs) is used and training stops via another condition ([#21925](https://github.com/Lightning-AI/pytorch-lightning/issues/21925))
 
+- Fixed `ModelCheckpoint` deleting resumed-from checkpoints on remote filesystems ([#21910](https://github.com/Lightning-AI/pytorch-lightning/pull/21910))
+
 - Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
 
 - Fixed PyTorch Lightning profiler not capturing dataloader worker initialization time ([#21771](https://github.com/Lightning-AI/pytorch-lightning/issues/21771))

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -26,12 +26,13 @@ import time
 import warnings
 from copy import deepcopy
 from datetime import timedelta
-from pathlib import Path
+from pathlib import Path, PurePath, PurePosixPath
 from typing import Any, Literal, Optional, Union
 from weakref import proxy
 
 import torch
 import yaml
+from fsspec.core import url_to_fs
 from torch import Tensor
 from typing_extensions import override
 
@@ -1009,21 +1010,39 @@ class ModelCheckpoint(Checkpoint):
 
         A checkpoint won't be deleted if any of the cases apply:
         - The previous checkpoint is the same as the current checkpoint (means the old was already overwritten by new)
-        - The previous checkpoint is not in the current checkpoint directory and the filesystem is local
-        - The previous checkpoint is the checkpoint the Trainer resumed from and the filesystem is local
+        - The previous checkpoint is not in the current checkpoint directory
+        - The previous checkpoint is the checkpoint the Trainer resumed from
 
         """
         if previous == current:
             return False
-        if not _is_local_file_protocol(previous):
-            return True
-        previous = Path(previous).absolute()
-        resume_path = Path(trainer.ckpt_path).absolute() if trainer.ckpt_path is not None else None
-        if resume_path is not None and previous == resume_path:
+
+        previous_path: PurePath
+        resume_path: Optional[PurePath]
+        dirpath: PurePath
+        if _is_local_file_protocol(previous):
+            previous_path = Path(previous).absolute()
+            resume_path = Path(trainer.ckpt_path).absolute() if trainer.ckpt_path is not None else None
+            assert self.dirpath is not None
+            dirpath = Path(self.dirpath).absolute()
+        else:
+            previous_fs, previous_path_str = url_to_fs(previous)
+            previous_path = PurePosixPath(previous_path_str)
+            resume_path = None
+            if trainer.ckpt_path is not None:
+                resume_fs, resume_path_str = url_to_fs(trainer.ckpt_path)
+                if previous_fs.protocol == resume_fs.protocol:
+                    resume_path = PurePosixPath(resume_path_str)
+
+            assert self.dirpath is not None
+            dirpath_fs, dirpath_str = url_to_fs(self.dirpath)
+            if previous_fs.protocol != dirpath_fs.protocol:
+                return False
+            dirpath = PurePosixPath(dirpath_str)
+
+        if resume_path is not None and previous_path == resume_path:
             return False
-        assert self.dirpath is not None
-        dirpath = Path(self.dirpath).absolute()
-        return dirpath in previous.parents
+        return dirpath in previous_path.parents
 
     def _remove_checkpoint(self, trainer: "pl.Trainer", filepath: str) -> None:
         """Calls the strategy to remove the checkpoint file."""

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -34,6 +34,7 @@ from torch.utils.data.dataloader import DataLoader
 
 import lightning.pytorch as pl
 from lightning.fabric.utilities.cloud_io import _load as pl_load
+from lightning.fabric.utilities.cloud_io import get_filesystem
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import Callback, ModelCheckpoint
 from lightning.pytorch.demos.boring_classes import BoringModel, RandomIterableDataset
@@ -1996,6 +1997,38 @@ def test_resume_and_old_checkpoint_files_remain(same_resume_folder, tmp_path):
     else:
         assert set(os.listdir(first)) == {"epoch=0-step=2.ckpt", "epoch=0-step=4.ckpt"}  # no files deleted
         assert set(os.listdir(second)) == {"epoch=0-step=6.ckpt", "epoch=0-step=8.ckpt"}
+
+
+@pytest.mark.parametrize("same_resume_folder", [True, False])
+def test_resume_training_preserves_old_remote_checkpoint(same_resume_folder, tmp_path):
+    root = f"memory:///{tmp_path.as_posix().lstrip('/')}"
+    first = f"{root}/first"
+    second = first if same_resume_folder else f"{root}/second"
+    filesystem = get_filesystem(root)
+    trainer_kwargs = {
+        "accelerator": "cpu",
+        "limit_val_batches": 0,
+        "enable_progress_bar": False,
+        "enable_model_summary": False,
+        "logger": False,
+    }
+    checkpoint_kwargs = {
+        "every_n_train_steps": 1,
+        "save_top_k": 1,
+        "monitor": None,
+        "save_on_train_epoch_end": False,
+    }
+
+    callback = ModelCheckpoint(dirpath=first, **checkpoint_kwargs)
+    Trainer(max_steps=2, callbacks=callback, **trainer_kwargs).fit(BoringModel())
+    resume_path = callback.best_model_path
+    assert filesystem.exists(resume_path)
+    assert not filesystem.exists(f"{first}/epoch=0-step=1.ckpt")
+
+    callback = ModelCheckpoint(dirpath=second, **checkpoint_kwargs)
+    Trainer(max_steps=3, callbacks=callback, **trainer_kwargs).fit(BoringModel(), ckpt_path=resume_path)
+
+    assert filesystem.exists(resume_path)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

This prevents `ModelCheckpoint` from deleting checkpoints on remote filesystems when they belong to a previous run or are the checkpoint the `Trainer` resumed from.

The local-filesystem path already applies both safety guards, but the remote-filesystem branch returned `True` before either check. The updated logic normalizes remote paths through fsspec and applies the same directory containment and resume-path checks used for local checkpoints. It still removes superseded checkpoints inside the active remote directory, preserving `save_top_k` behavior.

Fixes #21813

## Validation

- Added regression coverage with fsspec's `memory://` filesystem for same-directory and changed-directory resumes.
- Verified the regression test fails before the implementation change and passes afterward.
- `python -m pytest tests/tests_pytorch/checkpointing/test_model_checkpoint.py -q` (`139 passed, 1 skipped`)
- `mypy src/lightning/pytorch/callbacks/model_checkpoint.py` (`Success: no issues found`)
- `pre-commit run --files src/lightning/pytorch/callbacks/model_checkpoint.py tests/tests_pytorch/checkpointing/test_model_checkpoint.py` (all hooks passed)

## Checklist

- [x] Read the contributor guidelines.
- [x] Kept the change focused on one bug.
- [x] Added regression tests and ran the existing checkpoint tests.
- [x] Added an entry to the unreleased changelog.
