### PR TITLE
fix(core): pin explicit Any type for yaml.full_load result in load_hparams_from_yaml

### DIFF
--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -317,7 +317,7 @@ def load_hparams_from_yaml(config_yaml: _PATH, use_omegaconf: bool = True) -> di
         return {}
 
     with fs.open(config_yaml, "r") as fp:
-        hparams = yaml.full_load(fp)
+        hparams: Any = yaml.full_load(fp)
 
     if _OMEGACONF_AVAILABLE and use_omegaconf:
         from omegaconf import OmegaConf


### PR DESCRIPTION
## What does this PR do?

Fixes #21908

The `types-PyYAML` stub update to `6.0.12.20260815` changed `yaml.full_load`'s
return type from a bare `Any` to a type alias `_YAMLObject` (itself defined
as `= Any`). mypy's "an expression built from `Any` stays `Any`" fallback
only triggers for a *bare* `Any`, not an aliased one, so in
`src/lightning/pytorch/core/saving.py::load_hparams_from_yaml`,
`OmegaConf.create(hparams)` now resolves via its first overload
`create(obj: str) -> Union[DictConfig, ListConfig]` instead of falling back
to `Any`, producing a real `DictConfig | ListConfig` type that no longer
matches the function's declared `dict[str, Any]` return annotation.

The fix annotates the intermediate variable explicitly:

```python
hparams: Any = yaml.full_load(fp)
```

This forces mypy to treat `hparams` (and everything derived from it) as a
bare `Any` again, regardless of how the yaml stub aliases its return type,
restoring the previous (correct) type-checking behavior. No runtime
behavior changes.

## Verification

Reproduced and verified locally with the exact pinned versions from the
issue: `mypy==1.20.0`, `omegaconf==2.3.1`, `types-PyYAML==6.0.12.20260815`.

**Before fix** (`mypy --ignore-missing-imports --follow-imports=silent src/lightning/pytorch/core/saving.py`):
```
src\lightning\pytorch\core\saving.py:200: error: Unused "type: ignore" comment  [unused-ignore]
src\lightning\pytorch\core\saving.py:327: error: Incompatible return value type (got "DictConfig | ListConfig", expected "dict[str, Any]")  [return-value]
Found 2 errors in 1 file (checked 1 source file)
```

**After fix**:
```
src\lightning\pytorch\core\saving.py:200: error: Unused "type: ignore" comment  [unused-ignore]
Found 1 error in 1 file (checked 1 source file)
```

The `return-value` error on line 327 is gone. The remaining line-200
`unused-ignore` error is pre-existing and unrelated to this issue (present
on `master` before this change too).

Also ran the runtime test suites touching this code path to confirm no
behavior regression:

```
pytest tests/tests_pytorch/models/test_hparams.py -k "yaml or hparams_from" -q
2 passed, 66 deselected

pytest tests/tests_pytorch/core/test_saving.py -q
18 passed, 16 skipped
```

## Does your PR introduce any breaking changes?

No. This is a type-annotation-only change with no effect on runtime behavior.