### PR TITLE
fix(checkpoint): prevent arbitrary code execution via `_class_path` in `load_from_checkpoint`

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -51,7 +51,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed arbitrary code execution in `load_from_checkpoint` by restricting the `_instantiator` hyperparameter to an allowlist of trusted instantiators ([#21832](https://github.com/Lightning-AI/pytorch-lightning/pull/21832))
 
-- Fixed the remaining arbitrary code execution path in `load_from_checkpoint` by rejecting a checkpoint `_class_path` that does not resolve to an already imported subclass of the loaded class ([#21913](https://github.com/Lightning-AI/pytorch-lightning/issues/21913))
+- Fixed arbitrary code execution in `load_from_checkpoint` by rejecting a checkpoint `_class_path` that does not resolve to an already imported subclass of the loaded class ([#21914](https://github.com/Lightning-AI/pytorch-lightning/pull/21914))
 
 ---
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -51,6 +51,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed arbitrary code execution in `load_from_checkpoint` by restricting the `_instantiator` hyperparameter to an allowlist of trusted instantiators ([#21832](https://github.com/Lightning-AI/pytorch-lightning/pull/21832))
 
+- Fixed the remaining arbitrary code execution path in `load_from_checkpoint` by rejecting a checkpoint `_class_path` that does not resolve to an already imported subclass of the loaded class ([#21913](https://github.com/Lightning-AI/pytorch-lightning/issues/21913))
+
 ---
 
 ## [2.6.4] - 2026-05-20

--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -18,6 +18,7 @@ import csv
 import inspect
 import logging
 import os
+import sys
 from argparse import Namespace
 from copy import deepcopy
 from enum import Enum
@@ -162,11 +163,18 @@ def _load_state(
     instantiator = None
     instantiator_path = _cls_kwargs.pop("_instantiator", None)
     if instantiator_path is not None:
-        if instantiator_path not in _ALLOWED_INSTANTIATORS:
+        if not isinstance(instantiator_path, str) or instantiator_path not in _ALLOWED_INSTANTIATORS:
             raise ValueError(
                 f"The instantiator {instantiator_path!r} from the checkpoint is not in the allowlist of trusted"
                 " instantiators and was blocked to prevent arbitrary code execution. If you trust this checkpoint,"
                 " add the path to `lightning.pytorch.core.saving._ALLOWED_INSTANTIATORS` before loading."
+            )
+        class_path = _cls_kwargs.get("_class_path")
+        if class_path is not None and not _is_imported_subclass(class_path, cls):
+            raise ValueError(
+                f"The class {class_path!r} requested by the checkpoint does not resolve to an already imported"
+                f" subclass of {cls.__name__} and was blocked to prevent arbitrary code execution. If you trust this"
+                " checkpoint, import the module that defines the class before loading."
             )
         module_path, name = instantiator_path.rsplit(".", 1)
         instantiator = getattr(__import__(module_path, fromlist=[name]), name)
@@ -210,6 +218,15 @@ def _load_state(
             )
 
     return obj
+
+
+def _is_imported_subclass(class_path: Any, cls: type) -> bool:
+    """Resolve a class path from a checkpoint without importing anything, so that loading cannot execute new code."""
+    if not isinstance(class_path, str):
+        return False
+    module_path, _, name = class_path.rpartition(".")
+    target = getattr(sys.modules.get(module_path), name, None)
+    return isinstance(target, type) and issubclass(target, cls)
 
 
 def _convert_loaded_hparams(

--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -221,7 +221,11 @@ def _load_state(
 
 
 def _is_imported_subclass(class_path: Any, cls: type) -> bool:
-    """Resolve a class path from a checkpoint without importing anything, so that loading cannot execute new code."""
+    """Check whether ``class_path`` names an already imported subclass of ``cls``.
+
+    Resolution reads ``sys.modules`` only, so validating a checkpoint never imports new code.
+
+    """
     if not isinstance(class_path, str):
         return False
     module_path, _, name = class_path.rpartition(".")

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -1,3 +1,4 @@
+import sys
 from unittest.mock import ANY, Mock
 
 import pytest
@@ -187,5 +188,90 @@ def test_load_from_checkpoint_allows_lightning_instantiator(tmp_path, monkeypatc
 
     # the allowlisted path resolves without raising and the instantiator is used to build the model
     model = BoringModel.load_from_checkpoint(ckpt_path, strict=False)
+    assert isinstance(model, BoringModel)
+    instantiator.assert_called_once()
+
+
+def test_load_from_checkpoint_blocks_non_string_instantiator(tmp_path):
+    """A non-string ``_instantiator`` must be rejected instead of failing on the allowlist lookup."""
+    checkpoint = {
+        "state_dict": {},
+        "hyper_parameters": {"_instantiator": ["os", "system"]},
+        "pytorch-lightning_version": pl.__version__,
+    }
+    ckpt_path = tmp_path / "malicious.ckpt"
+    torch.save(checkpoint, ckpt_path)
+
+    with pytest.raises(ValueError, match="not in the allowlist of trusted instantiators"):
+        BoringModel.load_from_checkpoint(ckpt_path, strict=False)
+
+
+def test_load_from_checkpoint_blocks_unimported_class_path(tmp_path, monkeypatch):
+    """A ``_class_path`` living in a module that is not imported yet must not be imported to resolve it."""
+    module_name = "unimported_checkpoint_class_path"
+    (tmp_path / f"{module_name}.py").write_text("raise AssertionError('the module must not be imported')")
+    monkeypatch.syspath_prepend(tmp_path)
+
+    checkpoint = {
+        "state_dict": {},
+        "hyper_parameters": {
+            "_instantiator": "lightning.pytorch.cli.instantiate_module",
+            "_class_path": f"{module_name}.AnyModel",
+        },
+        "pytorch-lightning_version": pl.__version__,
+    }
+    ckpt_path = tmp_path / "malicious.ckpt"
+    torch.save(checkpoint, ckpt_path)
+
+    with pytest.raises(ValueError, match="does not resolve to an already imported subclass"):
+        pl.LightningModule.load_from_checkpoint(ckpt_path, strict=False)
+    assert module_name not in sys.modules
+
+
+@pytest.mark.parametrize(
+    "class_path",
+    [
+        "collections.OrderedDict",
+        "subprocess.Popen",
+        f"{BoringDataModule.__module__}.{BoringDataModule.__qualname__}",
+        ["not", "a", "string"],
+    ],
+)
+def test_load_from_checkpoint_blocks_class_path_outside_hierarchy(tmp_path, class_path):
+    """An imported ``_class_path`` that is not a subclass of the loaded class must be rejected."""
+    checkpoint = {
+        "state_dict": {},
+        "hyper_parameters": {
+            "_instantiator": "lightning.pytorch.cli.instantiate_module",
+            "_class_path": class_path,
+        },
+        "pytorch-lightning_version": pl.__version__,
+    }
+    ckpt_path = tmp_path / "malicious.ckpt"
+    torch.save(checkpoint, ckpt_path)
+
+    with pytest.raises(ValueError, match="does not resolve to an already imported subclass"):
+        pl.LightningModule.load_from_checkpoint(ckpt_path, strict=False)
+
+
+def test_load_from_checkpoint_allows_imported_subclass_class_path(tmp_path, monkeypatch):
+    """A ``_class_path`` naming an already imported subclass is still accepted."""
+    import lightning.pytorch.cli as cli
+
+    instantiator = Mock(side_effect=lambda cls, kwargs: BoringModel())
+    monkeypatch.setattr(cli, "instantiate_module", instantiator)
+
+    checkpoint = {
+        "state_dict": {},
+        "hyper_parameters": {
+            "_instantiator": "lightning.pytorch.cli.instantiate_module",
+            "_class_path": f"{BoringModel.__module__}.{BoringModel.__qualname__}",
+        },
+        "pytorch-lightning_version": pl.__version__,
+    }
+    ckpt_path = tmp_path / "checkpoint.ckpt"
+    torch.save(checkpoint, ckpt_path)
+
+    model = pl.LightningModule.load_from_checkpoint(ckpt_path, strict=False)
     assert isinstance(model, BoringModel)
     instantiator.assert_called_once()

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -186,7 +186,6 @@ def test_load_from_checkpoint_allows_lightning_instantiator(tmp_path, monkeypatc
     ckpt_path = tmp_path / "checkpoint.ckpt"
     torch.save(checkpoint, ckpt_path)
 
-    # the allowlisted path resolves without raising and the instantiator is used to build the model
     model = BoringModel.load_from_checkpoint(ckpt_path, strict=False)
     assert isinstance(model, BoringModel)
     instantiator.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Follow-up to #21832 / #21822 (CVE-2026-58659). Related to #21913.

#21832 restricted the checkpoint `_instantiator` hyperparameter to an allowlist, but the
only allowlisted value `lightning.pytorch.cli.instantiate_module`  takes a **second**
attacker-controlled import path out of the same checkpoint:

- `instantiate_module` passes `config["_class_path"]` to jsonargparse (`cli.py:893`)
- jsonargparse resolves it with `import_object` (`_typehints.py:1092` → `_util.py:136`)
- `import_object` calls `__import__` on the named module **before** validating that the
  class is a subclass of the expected type

So a `torch.load(weights_only=True)` checkpoint can still cause an arbitrary module import,
and therefore module-level code execution the same primitive the CVE describes, one hop
later. The allowlist stops the first hop only.

### Fix

`_load_state` now rejects a `_class_path` that does not resolve to an **already imported**
subclass of the class being loaded. Resolution reads `sys.modules` only, so loading a
checkpoint never imports anything new.

Also rejects a non-string `_instantiator` (a list is valid under `weights_only=True`), which
previously escaped as `TypeError: unhashable type: 'list'` from the allowlist lookup rather
than the intended `ValueError`.

### Verification

Reverting only the `saving.py` change makes all 6 new tests fail, and the pre-fix failure text
is the giveaway:

```
Problem with given class_path 'unimported_checkpoint_class_path.AnyModel':
  the module must not be imported
```

That string is an `AssertionError` raised by the *body* of a throwaway module the test writes
fix, the module is never touched (`assert module_name not in sys.modules`).

Local runs (CPU): `tests_pytorch/core/` 99 passed / 27 skipped · `test_cli.py` 79 passed /
5 skipped · `models/test_hparams.py` 68 passed · `ruff check` and `ruff format` clean.

### Not addressed here

jsonargparse also resolves import paths from *nested* hparams plain strings for
`Callable`/`Type` params, and `{"class_path": ...}` dicts under `Any`-typed params when
`fail_untyped=False` (`_typehints.py:1558`). Closing that would mean gating every
dotted-looking string in hparams, which is a design call for maintainers rather than a
minimal security fix. Happy to follow up if you want it closed.

### Breaking changes

None for checkpoints produced by Lightning: `_class_path` is always
`cls.__module__ + "." + cls.__name__`, and that module is in `sys.modules` whenever the class
is imported. Behaviour changes only for a checkpoint naming a class whose module is not
loaded, which is now an explicit error with remediation instead of a silent import. A
`_class_path` pointing at a *nested* class (`pkg.Outer.Inner`) is also rejected; this is
deliberate, since resolving it requires walking `getattr` through a package and can trigger a
lazy-import side effect.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>
