### PR TITLE
Fix scale_batch_size running zero batches when the search starts mid-training

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `RichProgressBar` showing a nonsensical negative epoch total (e.g. `Epoch 5/-2`) when `Trainer(max_epochs=-1)` (unlimited epochs) is used and training stops via another condition ([#21925](https://github.com/Lightning-AI/pytorch-lightning/issues/21925))
 
+- Fixed `scale_batch_size` running zero batches per trial when the search starts after training has begun, which made every trial succeed and returned an unusable batch size ([#21903](https://github.com/Lightning-AI/pytorch-lightning/issues/21903))
+
 - Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
 
 - Fixed PyTorch Lightning profiler not capturing dataloader worker initialization time ([#21771](https://github.com/Lightning-AI/pytorch-lightning/issues/21771))

--- a/src/lightning/pytorch/tuner/batch_size_scaling.py
+++ b/src/lightning/pytorch/tuner/batch_size_scaling.py
@@ -143,7 +143,11 @@ def __scale_batch_reset_params(trainer: "pl.Trainer", steps_per_trial: int) -> N
     if isinstance(loop, pl.loops._FitLoop):
         trainer.limit_train_batches = 1.0
         trainer.limit_val_batches = steps_per_trial
-        trainer.fit_loop.epoch_loop.max_steps = steps_per_trial
+        # `max_steps` is compared against the absolute `global_step` in `_FitLoop.done`,
+        # so it has to carry the offset the trials restore to. Without it a search
+        # started after training has begun is already done on entry and every trial
+        # runs zero batches. `lr_finder` applies the same offset.
+        trainer.fit_loop.epoch_loop.max_steps = steps_per_trial + trainer.global_step
     elif isinstance(loop, pl.loops._EvaluationLoop):
         stage = trainer.state.stage
         assert stage is not None
@@ -401,6 +405,13 @@ def _try_loop_run(trainer: "pl.Trainer", params: dict[str, Any]) -> None:
     assert loop is not None
     loop.load_state_dict(deepcopy(params["loop_state_dict"]))
     loop.restarting = False
+    if isinstance(loop, pl.loops._FitLoop):
+        # The dumped state carries the batch position of the epoch that was in flight
+        # when the search started. Restoring it verbatim starts every trial partway
+        # through the epoch, so a trial whose dataloader is shorter than that position
+        # runs no batches at all. `reset_on_run` clears `current` and leaves the
+        # cumulative `total` alone, which is restored with the rest of the state.
+        loop.epoch_loop.batch_progress.reset_on_run()
     loop.run()
 
 

--- a/tests/tests_pytorch/tuner/test_scale_batch_size.py
+++ b/tests/tests_pytorch/tuner/test_scale_batch_size.py
@@ -634,3 +634,69 @@ def test_scale_batch_size_max_trials_modes(tmp_path, max_trials, mode, init_val,
         init_val=init_val,
     )
     assert result == expected
+
+
+class BatchCountingModel(BoringModel):
+    """Records how many training batches actually ran, per epoch."""
+
+    def __init__(self, batch_size=2):
+        super().__init__()
+        self.batch_size = batch_size
+        self.steps_in_epoch = {}
+
+    def training_step(self, batch, batch_idx):
+        epoch = self.trainer.current_epoch
+        self.steps_in_epoch[epoch] = self.steps_in_epoch.get(epoch, 0) + 1
+        return super().training_step(batch, batch_idx)
+
+    def train_dataloader(self):
+        return DataLoader(RandomDataset(32, 64), batch_size=self.batch_size)
+
+
+class MidRunBatchSizeFinder(BatchSizeFinder):
+    """The milestone pattern the `BatchSizeFinder` docstring documents."""
+
+    def __init__(self, milestones, **kwargs):
+        super().__init__(**kwargs)
+        self.milestones = milestones
+        self.batches_run_during_search = []
+
+    def on_fit_start(self, *args, **kwargs):
+        return
+
+    def on_train_epoch_start(self, trainer, pl_module):
+        if trainer.current_epoch in self.milestones:
+            before = sum(pl_module.steps_in_epoch.values())
+            self.scale_batch_size(trainer, pl_module)
+            self.batches_run_during_search.append(sum(pl_module.steps_in_epoch.values()) - before)
+
+
+def test_scale_batch_size_after_training_has_begun_runs_batches(tmp_path):
+    """A search started mid-run must still run batches in each trial.
+
+    `max_steps` is compared against the absolute `global_step`, and the restored loop
+    state carries the batch position of the epoch in flight, so every trial used to be
+    a no-op: nothing raised an OOM, the search kept doubling, and it returned a batch
+    size the model cannot run.
+    """
+    model = BatchCountingModel(batch_size=2)
+    finder = MidRunBatchSizeFinder(milestones=(1,), max_trials=2, batch_arg_name="batch_size", steps_per_trial=3)
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        max_epochs=2,
+        limit_train_batches=5,
+        limit_val_batches=0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
+        callbacks=[finder],
+        accelerator="cpu",
+        devices=1,
+    )
+    trainer.fit(model)
+
+    assert finder.batches_run_during_search, "the milestone search never ran"
+    assert finder.batches_run_during_search[0] > 0, (
+        "scale_batch_size ran no training batches across its trials, so the search "
+        "cannot observe an OOM and will return an unusable batch size"
+    )

--- a/tests/tests_pytorch/tuner/test_scale_batch_size.py
+++ b/tests/tests_pytorch/tuner/test_scale_batch_size.py
@@ -678,6 +678,7 @@ def test_scale_batch_size_after_training_has_begun_runs_batches(tmp_path):
     state carries the batch position of the epoch in flight, so every trial used to be
     a no-op: nothing raised an OOM, the search kept doubling, and it returned a batch
     size the model cannot run.
+
     """
     model = BatchCountingModel(batch_size=2)
     finder = MidRunBatchSizeFinder(milestones=(1,), max_trials=2, batch_arg_name="batch_size", steps_per_trial=3)


### PR DESCRIPTION
## What does this PR do?

Fixes #21903.

`scale_batch_size` runs **zero** training batches per trial when the search starts after training has already taken optimizer steps. Nothing raises an OOM, so every trial "succeeds", the search keeps doubling, and it returns a batch size the model cannot actually run. Training then dies with the OOM the finder exists to prevent.

That is the pattern the `BatchSizeFinder` docstring itself documents: calling `scale_batch_size` from `on_train_epoch_start` at a set of milestones.

There are two independent causes, and fixing either alone is not enough.

### 1. `max_steps` is absolute, but was set as if it were relative

`__scale_batch_reset_params` set:

```python
trainer.fit_loop.epoch_loop.max_steps = steps_per_trial
```

`_FitLoop.done` compares that against the **absolute** `global_step`:

```python
stop_steps = _is_max_limit_reached(self.epoch_loop.global_step, self.max_steps)
```

`_try_loop_run` restores the dumped loop state before every trial, so `global_step` is whatever it was when the search started. Once `global_step >= steps_per_trial`, `done` is `True` on entry and the trial is a no-op.

The sibling tuner already gets this right (`lr_finder.py`):

```python
trainer.fit_loop.epoch_loop.max_steps = num_training + trainer.global_step
```

so this change applies the same offset.

### 2. The restored `batch_progress` starts each trial partway through an epoch

The loop state dumped at search start carries `batch_progress.current.ready` from the epoch already in flight, and every trial restores it verbatim. A trial whose dataloader has fewer batches than that value finishes instantly.

`_try_loop_run` now calls `batch_progress.reset_on_run()` after restoring. `reset_on_run` clears `current` and deliberately leaves the cumulative `total` alone, which is restored with the rest of the loop state by `__scale_batch_restore_params` afterwards, so no counter the rest of the run depends on is disturbed.

## Testing

`test_scale_batch_size_after_training_has_begun_runs_batches` in `tests/tests_pytorch/tuner/test_scale_batch_size.py` reproduces the documented milestone pattern with a model that records how many training batches actually ran, and asserts the search ran more than zero.

On `master`:

```
E   AssertionError: scale_batch_size ran 0 training batches across its trials; every trial
    was a no-op so the search cannot detect an OOM
E   assert 0 > 0
1 failed in 418.98s
```

With this change:

```
1 passed in 358.32s
```

Exactly zero before, which matches the report rather than merely being "fewer than expected".

Whole-file regression control, same tree:

```
python3 -m pytest tests/tests_pytorch/tuner/test_scale_batch_size.py -q
51 passed, 4 skipped in 28.48s
```

`ruff check` and `ruff format --check` are clean on both touched files.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (#21903)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (not user-facing; CHANGELOG updated)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request? (none)

## PR review

Two things worth a reviewer's attention:

1. The `reset_on_run()` call is gated on `isinstance(loop, pl.loops._FitLoop)`, so the evaluation-loop path that `scale_batch_size` also serves is untouched.
2. For a search that starts at `global_step == 0`, both changes are no-ops: the offset adds zero and `batch_progress.current` is already clear. So the existing behaviour for the common `Tuner.scale_batch_size(model)` entry point is unchanged, which the rest of the test file covers.
