### PR TITLE
fix: drop references to wandb's removed RunDisabled class

### DIFF
--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -493,7 +493,6 @@ nitpick_ignore = [
     ("py:meth", "validation_step"),
     ("py:class", "wandb.Artifact"),
     ("py:func", "wandb.init"),
-    ("py:class", "wandb.sdk.lib.RunDisabled"),
     ("py:class", "wandb.wandb_run.Run"),
     ("py:class", "litlogger.Experiment"),
 ]

--- a/src/lightning/pytorch/loggers/wandb.py
+++ b/src/lightning/pytorch/loggers/wandb.py
@@ -42,7 +42,6 @@ from lightning.pytorch.utilities.rank_zero import rank_zero_only, rank_zero_warn
 
 if TYPE_CHECKING:
     from wandb import Artifact
-    from wandb.sdk.lib import RunDisabled
     from wandb.wandb_run import Run
 
 _WANDB_AVAILABLE = RequirementCache("wandb>=0.12.10")
@@ -302,7 +301,7 @@ class WandbLogger(Logger):
         anonymous: Optional[bool] = None,
         project: Optional[str] = None,
         log_model: Union[Literal["all"], bool] = False,
-        experiment: Union["Run", "RunDisabled", None] = None,
+        experiment: Optional["Run"] = None,
         prefix: str = "",
         checkpoint_name: Optional[str] = None,
         add_file_policy: Literal["mutable", "immutable"] = "mutable",
@@ -375,7 +374,7 @@ class WandbLogger(Logger):
 
     @property
     @rank_zero_experiment
-    def experiment(self) -> Union["Run", "RunDisabled"]:
+    def experiment(self) -> "Run":
         r"""Actual wandb object. To use wandb features in your :class:`~lightning.pytorch.core.LightningModule` do the
         following.
 
@@ -387,7 +386,6 @@ class WandbLogger(Logger):
 
         """
         import wandb
-        from wandb.sdk.lib import RunDisabled
         from wandb.wandb_run import Run
 
         if self._experiment is None:
@@ -410,7 +408,7 @@ class WandbLogger(Logger):
                 self._experiment = wandb.init(**self._wandb_init)
 
                 # define default x-axis
-                if isinstance(self._experiment, (Run, RunDisabled)) and getattr(
+                if isinstance(self._experiment, Run) and getattr(
                     self._experiment, "define_metric", None
                 ):
                     if self._wandb_init.get("sync_tensorboard"):

--- a/src/lightning/pytorch/loggers/wandb.py
+++ b/src/lightning/pytorch/loggers/wandb.py
@@ -408,9 +408,7 @@ class WandbLogger(Logger):
                 self._experiment = wandb.init(**self._wandb_init)
 
                 # define default x-axis
-                if isinstance(self._experiment, Run) and getattr(
-                    self._experiment, "define_metric", None
-                ):
+                if isinstance(self._experiment, Run) and getattr(self._experiment, "define_metric", None):
                     if self._wandb_init.get("sync_tensorboard"):
                         self._experiment.define_metric("*", step_metric="global_step")
                     else:

--- a/tests/tests_pytorch/loggers/conftest.py
+++ b/tests/tests_pytorch/loggers/conftest.py
@@ -75,7 +75,6 @@ def wandb_mock(monkeypatch):
     monkeypatch.setitem(sys.modules, "wandb.sdk", wandb_sdk)
 
     wandb_sdk_lib = ModuleType("lib")
-    wandb_sdk_lib.RunDisabled = RunType
     monkeypatch.setitem(sys.modules, "wandb.sdk.lib", wandb_sdk_lib)
 
     wandb_wandb_run = ModuleType("wandb_run")


### PR DESCRIPTION
wandb deprecated `RunDisabled` in v0.17.6 (wandb/wandb#8064): since then, `wandb.init(mode="disabled")` returns a regular no-op `wandb.Run`, and `RunDisabled` has been an empty compatibility shim that emits a deprecation warning on attribute access. The shim is being removed in an upcoming wandb release (wandb/wandb#12586), after which importing it raises `ImportError`.

This PR drops the remaining references so the integration keeps working with upcoming wandb releases, while remaining compatible with older ones.

Details:
- `WandbLogger.experiment` imports `RunDisabled` at runtime, so every `WandbLogger` user would crash once the class is removed from wandb.
- With older wandb (< 0.17.6, still allowed by the `wandb>=0.12.10` requirement), disabled-mode stub runs no longer pass the `isinstance` gate before `define_metric` — that call was a no-op on those stubs anyway, so behavior is unchanged.
- Also removes the docs nitpick entry and the `RunDisabled` attribute from the wandb mock in `tests_pytorch/loggers/conftest.py`.
