### PR TITLE
docs: explain optimizer access in manual optimization

### DIFF
--- a/docs/source-pytorch/model/manual_optimization.rst
+++ b/docs/source-pytorch/model/manual_optimization.rst
@@ -43,6 +43,11 @@ Here is a minimal example of manual optimization.
    Be careful where you call ``optimizer.zero_grad()``, or your model won't converge.
    It is good practice to call ``optimizer.zero_grad()`` before ``self.manual_backward(loss)``.
 
+.. warning::
+   In manual optimization, call ``step()`` on the optimizer returned by ``self.optimizers()``.
+   Stepping a raw optimizer reference bypasses the :class:`~lightning.pytorch.core.optimizer.LightningOptimizer` wrapper,
+   so Lightning cannot count the step for ``Trainer.global_step``, logging, and checkpointing.
+
 
 Access your Own Optimizer
 =========================


### PR DESCRIPTION
## What does this PR do?

Clarifies the manual optimization guide by explaining why optimizer steps should use the wrapper returned by `self.optimizers()`. Stepping a raw optimizer bypasses Lightning's optimizer-step tracking, which affects `Trainer.global_step`, logging, and checkpointing.

Fixes #17281

This PR introduces no breaking changes or new dependencies.

### Tests

- `uvx --from sphinx-lint sphinx-lint docs/source-pytorch/model/manual_optimization.rst`
- `uvx codespell docs/source-pytorch/model/manual_optimization.rst`
- `git diff --check upstream/master...HEAD`

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? Yes, #17281 is labeled `help wanted` and `docs`.
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? This is a documentation-only change.
- Did you write any **new necessary tests**? N/A for documentation-only changes.
- [x] Did you verify new and **existing tests pass** locally with your changes? The focused documentation checks listed above pass.
- Did you list all the **breaking changes** introduced by this pull request? N/A; there are no breaking changes.
- Did you **update the CHANGELOG**? N/A for documentation-only changes.

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>
