### PR TITLE
Negate the deprecated offline flag in CometLogger

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -37,7 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `RichProgressBar` showing a nonsensical negative epoch total (e.g. `Epoch 5/-2`) when `Trainer(max_epochs=-1)` (unlimited epochs) is used and training stops via another condition ([#21925](https://github.com/Lightning-AI/pytorch-lightning/issues/21925))
 
-- Fixed `CometLogger` treating the deprecated `offline` flag as if it meant `online`, so `offline=True` started an online experiment
+- Fixed ``CometLogger`` treating the deprecated ``offline`` flag as if it meant ``online``, so ``offline=True`` started an online experiment ([#21921](https://github.com/Lightning-AI/pytorch-lightning/pull/21921))
 
 - Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `RichProgressBar` showing a nonsensical negative epoch total (e.g. `Epoch 5/-2`) when `Trainer(max_epochs=-1)` (unlimited epochs) is used and training stops via another condition ([#21925](https://github.com/Lightning-AI/pytorch-lightning/issues/21925))
 
+- Fixed `CometLogger` treating the deprecated `offline` flag as if it meant `online`, so `offline=True` started an online experiment
+
 - Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
 
 - Fixed PyTorch Lightning profiler not capturing dataloader worker initialization time ([#21771](https://github.com/Lightning-AI/pytorch-lightning/issues/21771))

--- a/src/lightning/pytorch/loggers/comet.py
+++ b/src/lightning/pytorch/loggers/comet.py
@@ -238,7 +238,7 @@ class CometLogger(Logger):
         if "offline" in kwargs:
             log.warning("The parameter `offline is deprecated, please use `online` instead.")
             if online is None:
-                online = kwargs.pop("offline")
+                online = not kwargs.pop("offline")
             else:
                 log.warning("You specified both `offline` and `online` parameters, please use `online` only")
 

--- a/tests/tests_pytorch/loggers/test_comet.py
+++ b/tests/tests_pytorch/loggers/test_comet.py
@@ -30,6 +30,18 @@ def _patch_comet_atexit(monkeypatch):
 
 
 @mock.patch.dict(os.environ, {})
+def test_comet_logger_deprecated_offline_flag(comet_mock):
+    """The deprecated `offline` flag is the inverse of `online`."""
+    comet_start = comet_mock.start
+
+    CometLogger(api_key="key", offline=True)
+    assert comet_start.call_args.kwargs["online"] is False
+
+    CometLogger(api_key="key", offline=False)
+    assert comet_start.call_args.kwargs["online"] is True
+
+
+@mock.patch.dict(os.environ, {})
 def test_comet_logger_online(comet_mock):
     """Test comet online with mocks."""
 


### PR DESCRIPTION
The compatibility shim for the deprecated `offline` kwarg assigns it straight onto `online`:

```python
# handle old "offline" experiment flag
if "offline" in kwargs:
    log.warning("The parameter `offline is deprecated, please use `online` instead.")
    if online is None:
        online = kwargs.pop("offline")
```

`offline` and `online` are opposites, so the flag is inverted. `online` flows to `self._online` and then to `comet_ml.start(online=self._online)`:

```
CometLogger(offline=True)   ->  comet_ml.start(online=True)     # expected False
CometLogger(offline=False)  ->  comet_ml.start(online=False)    # expected True
```

`CometLogger(offline=True)` therefore starts a fully online experiment and uploads the run, which is the opposite of what the caller asked for. Before `online` was introduced in #20275 the code was `self.mode = "offline" if offline else "online"`, so the inversion is exactly what the shim is meant to preserve.

The two neighbouring shims in the same block map synonyms — `project_name` onto `project`, `save_dir` onto `offline_directory` — where a direct assignment is right. This one maps antonyms, which is easy to miss.

Only callers still passing the deprecated `offline` kwarg are affected; anyone on `online` is unchanged.

Added `test_comet_logger_deprecated_offline_flag`, which checks both directions. It fails on `master` and passes here; `tests/tests_pytorch/loggers/test_comet.py` goes 8 -> 9 passing.

One thing worth flagging for reviewers: there is a separate bug just below at the `disabled=True` block (#21617, being fixed in #21619 / #21634). Until that lands, this change moves `offline=True` from "silently uploads online" to "silently disabled" rather than to a working offline experiment. That is still strictly better — no unintended upload — but the two want to land together to give `offline=True` its intended behaviour.
