### PR TITLE
docs: drop intersphinx dependency on lightning.ai `objects.inv`

### DIFF
--- a/docs/source-fabric/conf.py
+++ b/docs/source-fabric/conf.py
@@ -262,11 +262,13 @@ epub_exclude_files = ["search.html"]
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "typing_extensions": ("https://typing-extensions.readthedocs.io/en/stable/", None),
-    "torch": ("https://pytorch.org/docs/stable/", None),
-    "pytorch_lightning": ("https://lightning.ai/docs/pytorch/stable/", None),
+    "torch": ("https://docs.pytorch.org/docs/stable/", None),
     "tensorboardX": ("https://tensorboardx.readthedocs.io/en/stable/", None),
     "deepspeed": ("https://deepspeed.readthedocs.io/en/stable/", None),
-    "torch_xla": ("https://pytorch.org/xla/release/2.0/", None),
+    "torch_xla": ("https://docs.pytorch.org/xla/release/2.0/", None),
+    # NOTE: the Lightning docs are no longer built with Sphinx, so they do not publish an
+    #  `objects.inv` for intersphinx to resolve against
+    # "pytorch_lightning": ("https://lightning.ai/docs/pytorch/stable/", None),
 }
 nitpicky = True
 

--- a/docs/source-fabric/index.rst
+++ b/docs/source-fabric/index.rst
@@ -223,6 +223,7 @@ Get Started
     Glossary <glossary/index>
     How-tos <guide/index>
     Style Guide <fundamentals/code_structure>
+    Versioning Policy <versioning>
 
 
 .. raw:: html

--- a/docs/source-fabric/versioning.rst
+++ b/docs/source-fabric/versioning.rst
@@ -1,0 +1,5 @@
+.. NOTE: the content of this page lives in the PyTorch Lightning docs and is shared from there.
+   Fabric needs its own copy so that references such as `versioning:Experimental API` resolve
+   inside this build, instead of relying on a cross-project intersphinx inventory.
+
+.. include:: ../source-pytorch/versioning.rst

--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -342,14 +342,15 @@ epub_exclude_files = ["search.html"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "torch": ("https://pytorch.org/docs/stable/", None),
+    "torch": ("https://docs.pytorch.org/docs/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "PIL": ("https://pillow.readthedocs.io/en/stable/", None),
-    "torchmetrics": ("https://lightning.ai/docs/torchmetrics/stable/", None),
     "tensorboardX": ("https://tensorboardx.readthedocs.io/en/stable/", None),
-    # needed for referencing Fabric from lightning scope
-    "lightning.fabric": ("https://lightning.ai/docs/fabric/stable/", None),
     # TODO: these are missing objects.inv
+    # NOTE: the Lightning docs (incl. TorchMetrics and Fabric) are no longer built with Sphinx,
+    #  so they do not publish an `objects.inv` for intersphinx to resolve against
+    # "torchmetrics": ("https://lightning.ai/docs/torchmetrics/stable/", None),
+    # "lightning.fabric": ("https://lightning.ai/docs/fabric/stable/", None),
     # "comet_ml": ("https://www.comet.com/docs/v2/", None),
     # "wandb": ("https://docs.wandb.ai//", None),
 }
@@ -385,6 +386,15 @@ nitpick_ignore = [
     ("py:class", "jsonargparse.core.ArgumentParser"),
     ("py:class", "jsonargparse.namespace.Namespace"),
     ("py:class", "transformer_engine.common.recipe.DelayedScaling"),
+    # these were resolved through the intersphinx inventories dropped above
+    ("py:class", "torchmetrics.Metric"),
+    ("py:class", "torchmetrics.metric.Metric"),
+    ("py:class", "torchmetrics.collections.MetricCollection"),
+    ("py:class", "lightning.fabric.accelerators.accelerator.Accelerator"),
+    ("py:class", "lightning.fabric.loggers.logger.Logger"),
+    ("py:class", "lightning.fabric.loggers.csv_logs.CSVLogger"),
+    ("py:class", "lightning.fabric.loggers.tensorboard.TensorBoardLogger"),
+    ("py:class", "lightning.fabric.plugins.precision.precision.Precision"),
     ("py:class", "lightning.fabric.accelerators.xla.XLAAccelerator"),
     ("py:class", "lightning.fabric.loggers.csv_logs._ExperimentWriter"),
     ("py:class", "lightning.fabric.loggers.logger._DummyExperiment"),


### PR DESCRIPTION
## What does this PR do?

Fixes the docs builds, red on every PR and on `master` since ~Aug 20.

<img width="605" height="229" alt="image" src="https://github.com/user-attachments/assets/e96e1742-37b4-48e0-8743-ec4c9ba4704d" />

The Lightning docs are no longer built with Sphinx and no longer publish an `objects.inv`, so every `intersphinx` mapping pointing at lightning.ai fails to load. Since we build with `nitpicky = True` and `-W`, each unresolvable reference becomes a hard error — failing all six `docs-make` jobs.

This drops the dependency rather than waiting for the inventories to come back:

- remove the `pytorch_lightning`, `torchmetrics` and `lightning.fabric` mappings
- share the versioning policy page with the Fabric docs, so the `versioning:*` labels resolve locally — **no docstring or page has to change**
- `nitpick_ignore` the few targets that were only linkable through those inventories
- point the torch inventories at `docs.pytorch.org`, where `pytorch.org` now redirects

<details>
  <summary>The actual failure</summary>

```
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://lightning.ai/docs/pytorch/stable/objects.inv' not readable due to
ValueError: unknown or unsupported inventory version: invalid inventory header: <!doctype html>
```

The URL returns the docs app shell with a `200` rather than a `404`, so Sphinx tries to parse HTML as an inventory instead of skipping it.

</details>

<details>
  <summary>Why sharing the versioning page works</summary>

`versioning:Experimental API` and `versioning:Compatibility matrix` are autosectionlabels from `docs/source-pytorch/versioning.rst`, which is why the Fabric build could only reach them through the PyTorch inventory. A small Fabric page that `.. include::`s that file recreates the labels inside the Fabric build, so all 15 existing `:ref:`s keep working, stay version-relative, and no longer depend on anything hosted.

</details>

<details>
  <summary>This also fixes a live 404</summary>

On the published Fabric docs the compatibility-matrix link resolves to `/docs/fabric/2.6.5/versioning.md#compatibility-matrix`, a page that does not exist — the Fabric manifest has no `versioning` page at all. Both [the home page](https://lightning.ai/docs/fabric/stable/) and [the install page](https://lightning.ai/docs/fabric/stable/home/installation) currently link into a 404. With this change the target exists.

</details>

<details>
  <summary>Trade-off</summary>

Without an inventory we lose automatic deep links into the TorchMetrics / Fabric API pages, so a few class names (e.g. `torchmetrics.Metric` in the `LightningModule.log` signature) render as plain text instead of hyperlinks. The mappings are left commented out in `conf.py` so they can be restored if `objects.inv` is ever published again.

</details>

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes? (the full docs build needs `lai-sphinx-theme` from the S3 bucket, so I'm relying on CI; the `include` mechanism itself was verified with a minimal `-W --keep-going` + `nitpicky` build, where both labels resolved locally)
- [ ] Did you list all the **breaking changes** introduced by this pull request?

</details>

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.
