### PR TITLE
Fix lr_finder suggestion discarding every sample when skip_end=0

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `RichProgressBar` showing a nonsensical negative epoch total (e.g. `Epoch 5/-2`) when `Trainer(max_epochs=-1)` (unlimited epochs) is used and training stops via another condition ([#21925](https://github.com/Lightning-AI/pytorch-lightning/issues/21925))
 
+- Fixed `_LRFinder.suggestion()` discarding every sample when `skip_end=0`, which reported a missing suggestion instead of using the full loss curve ([#21923](https://github.com/Lightning-AI/pytorch-lightning/pull/21923))
+
 - Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
 
 - Fixed PyTorch Lightning profiler not capturing dataloader worker initialization time ([#21771](https://github.com/Lightning-AI/pytorch-lightning/issues/21771))

--- a/src/lightning/pytorch/tuner/lr_finder.py
+++ b/src/lightning/pytorch/tuner/lr_finder.py
@@ -172,8 +172,12 @@ class _LRFinder:
             loss samples.
 
         """
-        losses = torch.tensor(self.results["loss"][skip_begin:-skip_end])
-        lrs = torch.tensor(self.results["lr"][skip_begin:-skip_end])
+        # `-skip_end` is `0` when skip_end is 0, and `[skip_begin:0]` selects nothing, so a request
+        # to skip nothing from the end threw away every point. Index the end from the front instead,
+        # clamped so a skip_end reaching past skip_begin still leaves an empty window as before.
+        end = max(len(self.results["loss"]) - skip_end, 0)
+        losses = torch.tensor(self.results["loss"][skip_begin:end])
+        lrs = torch.tensor(self.results["lr"][skip_begin:end])
         is_finite = torch.isfinite(losses)
         losses = losses[is_finite]
         lrs = lrs[is_finite]
@@ -190,7 +194,7 @@ class _LRFinder:
         gradients = torch.gradient(losses, spacing=[lrs])[0]  # Compute the gradient of losses w.r.t. learning rates
         min_grad = torch.argmin(gradients).item()
         all_losses_idx = torch.arange(len(self.results["loss"]))
-        idx_non_skipped = all_losses_idx[skip_begin:-skip_end]
+        idx_non_skipped = all_losses_idx[skip_begin:end]
         idx_finite = idx_non_skipped[is_finite]
         self._optimal_idx = idx_finite[min_grad].item()  # type: ignore
         return self.results["lr"][self._optimal_idx]

--- a/tests/tests_pytorch/tuner/test_lr_finder.py
+++ b/tests/tests_pytorch/tuner/test_lr_finder.py
@@ -397,6 +397,20 @@ def test_suggestion_not_enough_finite_points(losses, skip_begin, skip_end, expec
             assert lr is not None
 
 
+def test_suggestion_with_skip_end_zero():
+    """`skip_end=0` asks for nothing to be skipped, so the last sample has to stay in the window."""
+    lr_finder = _LRFinder(mode="exponential", lr_min=1e-8, lr_max=1, num_training=100)
+    # the steepest drop is between the last two points, so it is only reachable when nothing is skipped
+    lr_finder.results = {"lr": [0.1, 0.2, 0.3, 0.4], "loss": [10.0, 9.0, 8.0, 1.0]}
+
+    assert lr_finder.suggestion(skip_begin=0, skip_end=0) == 0.4
+    assert lr_finder._optimal_idx == 3
+
+    # the default still drops the last sample
+    assert lr_finder.suggestion(skip_begin=0, skip_end=1) == 0.1
+    assert lr_finder._optimal_idx == 0
+
+
 def test_lr_attribute_when_suggestion_invalid(tmp_path):
     """Tests learning rate finder ends before `num_training` steps."""
 


### PR DESCRIPTION
## What does this PR do?

`_LRFinder.suggestion()` slices the recorded curve with `[skip_begin:-skip_end]`. When `skip_end` is `0`, `-skip_end` is also `0`, so that becomes `[skip_begin:0]` and selects nothing: asking to skip nothing from the end threw away every sample instead.

The caller gets `None` back, plus an error telling them to grow their dataset, on data that was perfectly usable:

```python
lr_finder = _LRFinder(mode="exponential", lr_min=1e-8, lr_max=1, num_training=100)
lr_finder.results = {"lr": [0.1, 0.2, 0.3, 0.4], "loss": [10.0, 9.0, 8.0, 1.0]}

lr_finder.suggestion(skip_begin=0, skip_end=0)
# None, and:
#   Failed to compute suggestion for learning rate because there are not enough
#   points. Increase the loop iteration limits or the size of your dataset/dataloader.
lr_finder.suggestion(skip_begin=0, skip_end=1)   # 0.1, works
```

`skip_end=0` is the only value affected, and it is the natural way to ask for the full curve when the last point matters (the steepest drop is often right at the end, exactly what the default `skip_end=1` is there to guard against, so opting out of it should be possible).

The end of the window is now indexed from the front. It is clamped at `0` so a `skip_end` reaching past `skip_begin` still leaves an empty window and the existing not-enough-points error, and `idx_non_skipped` uses the same bound so the reported `_optimal_idx` keeps lining up with the loss array. Every other `skip_end` value slices exactly as it did before.

## Test

New `test_suggestion_with_skip_end_zero` in `tests/tests_pytorch/tuner/test_lr_finder.py`. It builds a curve whose steepest drop is between the last two points, so the suggestion is only reachable when nothing is skipped, and pins the `skip_end=1` behaviour alongside it.

```
$ pytest tests/tests_pytorch/tuner/test_lr_finder.py -k "skip_end_zero or not_enough_finite" -q
9 passed, 29 deselected

# without the source change
FAILED tests/tests_pytorch/tuner/test_lr_finder.py::test_suggestion_with_skip_end_zero
  assert None == 0.4
1 failed, 8 passed, 29 deselected

$ pytest tests/tests_pytorch/tuner/test_lr_finder.py -q
37 passed, 1 skipped
```

The eight pre-existing `test_suggestion_not_enough_finite_points` cases pass either way, including `(skip_begin=0, skip_end=2, losses=[0, 1, 2])`, which still errors.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you **update the CHANGELOG**?

</details>

## PR review

Anyone in the community is welcome to review the PR.
