### PR TITLE
Avoid negative epoch totals for unlimited training

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `RichProgressBar` showing a nonsensical negative epoch total (e.g. `Epoch 5/-2`) when `Trainer(max_epochs=-1)` (unlimited epochs) is used and training stops via another condition.
+
 - Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
 
 - Fixed PyTorch Lightning profiler not capturing dataloader worker initialization time ([#21771](https://github.com/Lightning-AI/pytorch-lightning/issues/21771))

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed `RichProgressBar` showing a nonsensical negative epoch total (e.g. `Epoch 5/-2`) when `Trainer(max_epochs=-1)` (unlimited epochs) is used and training stops via another condition.
+- Fixed `RichProgressBar` showing a nonsensical negative epoch total (e.g. `Epoch 5/-2`) when `Trainer(max_epochs=-1)` (unlimited epochs) is used and training stops via another condition ([#21925](https://github.com/Lightning-AI/pytorch-lightning/issues/21925))
 
 - Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
 

--- a/src/lightning/pytorch/callbacks/progress/rich_progress.py
+++ b/src/lightning/pytorch/callbacks/progress/rich_progress.py
@@ -655,7 +655,7 @@ class RichProgressBar(ProgressBar):
 
     def _get_train_description(self, current_epoch: int) -> str:
         train_description = f"Epoch {current_epoch}"
-        if self.trainer.max_epochs is not None:
+        if self.trainer.max_epochs is not None and self.trainer.max_epochs >= 0:
             train_description += f"/{self.trainer.max_epochs - 1}"
         if len(self.validation_description) > len(train_description):
             # Padding is required to avoid flickering due of uneven lengths of "Epoch X"

--- a/tests/tests_pytorch/callbacks/progress/test_rich_progress_bar.py
+++ b/tests/tests_pytorch/callbacks/progress/test_rich_progress_bar.py
@@ -447,6 +447,18 @@ def test_rich_progress_bar_padding():
 
 
 @RunIf(rich=True)
+def test_rich_progress_bar_infinite_epochs():
+    """`max_epochs=-1` means "no limit on epochs" and should not be treated as a real epoch count."""
+    progress_bar = RichProgressBar()
+    trainer = Mock()
+    trainer.max_epochs = -1
+    progress_bar._trainer = trainer
+
+    train_description = progress_bar._get_train_description(current_epoch=2)
+    assert train_description.strip() == "Epoch 2"
+
+
+@RunIf(rich=True)
 def test_rich_progress_bar_can_be_pickled(tmp_path):
     bar = RichProgressBar()
     trainer = Trainer(


### PR DESCRIPTION
## What does this PR do?

Fixes: #21925.

`RichProgressBar` shows an epoch total next to the current epoch, e.g. `Epoch 5/10`. When `Trainer(max_epochs=-1)` is used (Lightning's convention for "no limit on epochs") and training instead stops due to another condition (e.g. `max_steps`), the bar incorrectly displayed a nonsensical negative total, e.g. `Epoch 5/-2`.

The root cause is in `RichProgressBar._get_train_description()`: it only checked `self.trainer.max_epochs is not None` before appending `f"/{self.trainer.max_epochs - 1}"`. Since `-1` is not `None`, it was treated as a real epoch count and `-1 - 1` produced `-2`. The fix adds a check for `self.trainer.max_epochs >= 0`, so the total is omitted entirely when epochs are unlimited, and the bar now shows a plain `Epoch 2`.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

No breaking changes.

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary) — not needed, no documented/public behavior changed beyond the display fix.
- [x] Did you write any **new necessary tests**? (not for typos and docs) — yes, added `test_rich_progress_bar_infinite_epochs`.
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request? — none.
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors) — yes.

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>
