### PR TITLE
Fix step scheduler frequency across epochs

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed step-interval LR scheduler frequencies resetting at epoch boundaries ([#21926](https://github.com/Lightning-AI/pytorch-lightning/pull/21926))
+
 - Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))
 
 - Fixed PyTorch Lightning profiler not capturing dataloader worker initialization time ([#21771](https://github.com/Lightning-AI/pytorch-lightning/issues/21771))

--- a/src/lightning/pytorch/loops/training_epoch_loop.py
+++ b/src/lightning/pytorch/loops/training_epoch_loop.py
@@ -479,7 +479,7 @@ class _TrainingEpochLoop(loops._Loop):
             if update_plateau_schedulers ^ config.reduce_on_plateau:
                 continue
 
-            current_idx = self.batch_idx if interval == "step" else trainer.current_epoch
+            current_idx = self.total_batch_idx if interval == "step" else trainer.current_epoch
             current_idx += 1  # account for both batch and epoch starts from 0
             # Take step if call to update_learning_rates matches the interval key and
             # the current step modulo the schedulers frequency is zero

--- a/tests/tests_pytorch/trainer/optimization/test_optimizers.py
+++ b/tests/tests_pytorch/trainer/optimization/test_optimizers.py
@@ -472,6 +472,31 @@ def test_lr_scheduler_epoch_step_frequency(mocked_sched, check_val_every_n_epoch
     assert mocked_sched.call_count == expected_steps
 
 
+def test_lr_scheduler_step_frequency_across_epochs(tmp_path):
+    class TestModel(BoringModel):
+        def configure_optimizers(self):
+            optimizer = torch.optim.SGD(self.parameters(), lr=1.0)
+            scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.5)
+            return {
+                "optimizer": optimizer,
+                "lr_scheduler": {"scheduler": scheduler, "interval": "step", "frequency": 3},
+            }
+
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        accelerator="cpu",
+        devices=1,
+        limit_train_batches=2,
+        limit_val_batches=0,
+        max_epochs=3,
+        enable_progress_bar=False,
+        logger=False,
+    )
+    trainer.fit(TestModel())
+
+    assert trainer.optimizers[0].param_groups[0]["lr"] == 0.25
+
+
 @pytest.mark.parametrize(("every_n_train_steps", "epoch_interval"), [(None, True), (2, False), (2, True)])
 def test_lr_scheduler_state_updated_before_saving(tmp_path, every_n_train_steps, epoch_interval):
     batches = 2


### PR DESCRIPTION
## What does this PR do?

Fixes #17544.

Step-interval LR scheduler frequency currently uses the batch index within the current epoch. When the configured frequency is larger than the number of batches per epoch, that index resets before the scheduler can step. This change uses the loop's existing total batch index so the frequency applies continuously across epoch boundaries, as requested by the maintainer in the issue.

This is a fresh implementation on current `master`. I reviewed the closed attempts #20211 and #20248; #20211 went stale after its requested regression test remained incomplete, and #20248 was closed as a duplicate of it. The new regression test covers the exact cross-epoch behavior without mocks: 3 epochs × 2 batches at frequency 3 must produce two scheduler updates.

This contribution was prepared with AI assistance and independently reviewed and tested before submission.

### Verification

The regression test was first run against the original production line and failed as expected:

```text
1 failed, 2 warnings
E assert 1.0 == 0.25
```

With the fix:

```text
pytest -q tests/tests_pytorch/trainer/optimization/test_optimizers.py
35 passed, 1 skipped, 43 warnings in 1.06s

ruff check src/lightning/pytorch/loops/training_epoch_loop.py tests/tests_pytorch/trainer/optimization/test_optimizers.py
All checks passed!

ruff format --check src/lightning/pytorch/loops/training_epoch_loop.py tests/tests_pytorch/trainer/optimization/test_optimizers.py
2 files already formatted

git diff --check
# exit 0
```

<details>
  <summary><b>Before submitting</b></summary>

- The change was discussed and explicitly opened to community contribution in #17544.
- [x] I read the contributor guideline, including the Pull Request section.
- [x] The PR does one thing.
- No documentation change is needed; this restores the expected meaning of the existing `frequency` option.
- [x] A focused regression test was added.
- [x] The complete affected test file and pinned Ruff checks pass locally.
- This is a behavior correction for the reported bug; no public API is changed.
- [x] The PyTorch changelog was updated with this PR number.

</details>