### PR TITLE
Fix FSDP non-finite gradient norm handling

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `FSDPStrategy` ignoring `error_if_nonfinite` when clipping gradients by norm ([#21929](https://github.com/Lightning-AI/pytorch-lightning/pull/21929))
+
 - Fixed type checking for the `BitsandbytesPrecision` plugin and raised the supported `bitsandbytes` ceiling to `<0.50` (compatible with 0.48/0.49) ([#21858](https://github.com/Lightning-AI/pytorch-lightning/pull/21858))
 
 - Fixed DeepSpeed checkpoint path validation rejecting remote filesystem URIs (S3, GCS, HDFS) ([#21636](https://github.com/Lightning-AI/pytorch-lightning/pull/21636))

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -419,7 +419,14 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
                 f" Got: {module.__class__.__name__}."
             )
         self.precision.unscale_gradients(optimizer)
-        return module.clip_grad_norm_(max_norm=max_norm, norm_type=norm_type)
+        total_norm = module.clip_grad_norm_(max_norm=max_norm, norm_type=norm_type)
+        if error_if_nonfinite and torch.logical_or(total_norm.isnan(), total_norm.isinf()):
+            raise RuntimeError(
+                f"The total norm of order {float(norm_type)} for gradients from `parameters` is non-finite, so it "
+                "cannot be clipped. To disable this error and scale the gradients by the non-finite norm anyway, "
+                "set `error_if_nonfinite=False`"
+            )
+        return total_norm
 
     @override
     def save_checkpoint(

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -240,6 +240,31 @@ def test_grad_clipping_norm_error():
         strategy.clip_gradients_norm(Mock(), Mock(), Mock())
 
 
+@pytest.mark.parametrize("total_norm", [float("nan"), float("inf"), float("-inf")])
+def test_grad_clipping_norm_error_if_nonfinite(total_norm):
+    strategy = FSDPStrategy()
+    module = MagicMock(spec=FullyShardedDataParallel)
+    module.clip_grad_norm_.return_value = torch.tensor(total_norm)
+    optimizer = Mock()
+
+    with pytest.raises(RuntimeError, match="The total norm of order 2.0 for gradients.*is non-finite"):
+        strategy.clip_gradients_norm(module, optimizer, max_norm=1.0, error_if_nonfinite=True)
+
+    module.clip_grad_norm_.assert_called_once_with(max_norm=1.0, norm_type=2.0)
+
+
+def test_grad_clipping_norm_nonfinite_allowed():
+    strategy = FSDPStrategy()
+    module = MagicMock(spec=FullyShardedDataParallel)
+    module.clip_grad_norm_.return_value = torch.tensor(float("nan"))
+    optimizer = Mock()
+
+    norm = strategy.clip_gradients_norm(module, optimizer, max_norm=1.0, error_if_nonfinite=False)
+
+    assert torch.isnan(norm)
+    module.clip_grad_norm_.assert_called_once_with(max_norm=1.0, norm_type=2.0)
+
+
 def test_save_checkpoint_storage_options(tmp_path):
     """Test that the FSDP strategy does not accept storage options for saving checkpoints."""
     strategy = FSDPStrategy()

--- a/tests/tests_fabric/strategies/test_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_fsdp_integration.py
@@ -602,6 +602,22 @@ def test_clip_gradients(clip_type, precision):
     optimizer.zero_grad()
 
 
+@RunIf(min_cuda_gpus=2, standalone=True)
+def test_clip_gradients_norm_error_if_nonfinite():
+    fabric = Fabric(accelerator="cuda", devices=2, strategy=FSDPStrategy())
+    fabric.launch()
+
+    model = torch.nn.Linear(2, 2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    model, optimizer = fabric.setup(model, optimizer)
+
+    loss = model(torch.ones(1, 2, device=fabric.device)).sum() * torch.tensor(float("nan"), device=fabric.device)
+    fabric.backward(loss)
+
+    with pytest.raises(RuntimeError, match="The total norm of order 2.0 for gradients.*is non-finite"):
+        fabric.clip_gradients(model, optimizer, max_norm=1.0, error_if_nonfinite=True)
+
+
 @pytest.mark.filterwarnings("ignore::FutureWarning")
 @RunIf(min_cuda_gpus=2, standalone=True, min_torch="2.3.0")
 def test_save_sharded_and_consolidate_and_load(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Makes `FSDPStrategy.clip_gradients_norm()` honor the public `error_if_nonfinite` argument.

PyTorch FSDP's `clip_grad_norm_()` does not accept this argument, so Lightning previously returned a non-finite norm and allowed training to continue. The strategy now checks the returned global norm and raises the same style of `RuntimeError` as `torch.nn.utils.clip_grad_norm_` when requested.

The change preserves the existing behavior when `error_if_nonfinite=False`.

### Current PyTorch FSDP limitation

PyTorch FSDP currently exposes only a combined norm-computation-and-clipping operation. This change restores Fabric's documented fail-fast behavior before `optimizer.step()`, but FSDP may already have mutated gradients before returning a non-finite norm. Achieving exact parity with `torch.nn.utils.clip_grad_norm_(error_if_nonfinite=True)`, which validates before modifying gradients, likely requires an upstream PyTorch API change.

Maintainer guidance is welcome on whether to accept this narrower fail-fast fix or block it on an upstream PyTorch change that validates the FSDP global norm before mutation.

Tests added:

- Unit coverage for `nan`, `inf`, and `-inf`, plus the opt-out behavior.
- A two-GPU integration test through the public `Fabric.clip_gradients()` API.

Local validation:

- `tests/tests_fabric/strategies/test_fsdp.py`: 42 passed, 1 skipped.
- `tests/tests_fabric/strategies`: 144 passed, 180 skipped.
- Ruff and mypy checks pass for the changed files.
- The two-GPU integration test collects but skips locally because CUDA is unavailable; this draft PR is intended to exercise that path in CI.

Fixes #21928

No breaking changes.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the contributor guideline, Pull Request section?
- [x] Does this PR do only one thing?
- [x] Did you write necessary tests?
- [x] Did you verify new and existing relevant tests pass locally?
- [x] Did you list all breaking changes?
- [x] Did you update the CHANGELOG?

</details>
