### PR TITLE
Fix the uneven first step in the lr_finder learning-rate ladder

### DIFF
--- a/src/lightning/pytorch/tuner/lr_finder.py
+++ b/src/lightning/pytorch/tuner/lr_finder.py
@@ -468,13 +468,11 @@ class _LinearLR(LRScheduler):
 
     @override
     def get_lr(self) -> list[float]:
-        curr_iter = self.last_epoch + 1
-        r = curr_iter / self.num_iter
-
-        if self.last_epoch > 0:
-            val = [base_lr + r * (self.end_lr - base_lr) for base_lr in self.base_lrs]
-        else:
-            val = list(self.base_lrs)
+        # `num_iter` evenly spaced points covering both boundaries. Using `(last_epoch + 1) /
+        # num_iter` together with the `last_epoch == 0` special case skipped one rung and left the
+        # first interval twice as wide as the rest.
+        r = self.last_epoch / max(self.num_iter - 1, 1)
+        val = [base_lr + r * (self.end_lr - base_lr) for base_lr in self.base_lrs]
         self._lr = val
         return val
 
@@ -505,13 +503,10 @@ class _ExponentialLR(LRScheduler):
 
     @override
     def get_lr(self) -> list[float]:
-        curr_iter = self.last_epoch + 1
-        r = curr_iter / self.num_iter
-
-        if self.last_epoch > 0:
-            val = [base_lr * (self.end_lr / base_lr) ** r for base_lr in self.base_lrs]
-        else:
-            val = list(self.base_lrs)
+        # Same ladder as `_LinearLR`, geometric instead of arithmetic: on the old fraction the
+        # first ratio was the square of every other one.
+        r = self.last_epoch / max(self.num_iter - 1, 1)
+        val = [base_lr * (self.end_lr / base_lr) ** r for base_lr in self.base_lrs]
         self._lr = val
         return val
 

--- a/tests/tests_pytorch/tuner/test_lr_finder.py
+++ b/tests/tests_pytorch/tuner/test_lr_finder.py
@@ -28,7 +28,7 @@ from lightning.pytorch.callbacks import EarlyStopping
 from lightning.pytorch.callbacks.finetuning import BackboneFinetuning
 from lightning.pytorch.callbacks.lr_finder import LearningRateFinder
 from lightning.pytorch.demos.boring_classes import BoringModel
-from lightning.pytorch.tuner.lr_finder import _LRFinder
+from lightning.pytorch.tuner.lr_finder import _ExponentialLR, _LinearLR, _LRFinder
 from lightning.pytorch.tuner.tuning import Tuner
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from lightning.pytorch.utilities.types import STEP_OUTPUT
@@ -619,6 +619,27 @@ def test_gradient_correctness():
     suggestion = lr_finder.suggestion(skip_begin=2, skip_end=2)
     assert suggestion is not None
     assert abs(suggestion - math.pi) < 1e-2, "Suggestion should be close to pi for this synthetic example"
+
+
+@pytest.mark.parametrize("num_iter", [3, 5, 10, 100])
+def test_lr_ladder_is_evenly_spaced(num_iter):
+    """The finder tests `num_iter` learning rates evenly spaced between `min_lr` and `max_lr`."""
+    lr_min, lr_max = 1e-3, 1.0
+    model = torch.nn.Linear(1, 1)
+
+    def ladder(cls):
+        optimizer = torch.optim.SGD(model.parameters(), lr=lr_min)
+        scheduler = cls(optimizer, end_lr=lr_max, num_iter=num_iter)
+        lrs = []
+        for _ in range(num_iter):
+            lrs.append(optimizer.param_groups[0]["lr"])
+            optimizer.step()
+            scheduler.step()
+        return lrs
+
+    fractions = [i / (num_iter - 1) for i in range(num_iter)]
+    assert ladder(_LinearLR) == pytest.approx([lr_min + r * (lr_max - lr_min) for r in fractions])
+    assert ladder(_ExponentialLR) == pytest.approx([lr_min * (lr_max / lr_min) ** r for r in fractions])
 
 
 def test_lr_finder_callback_applies_lr_after_restore(tmp_path):


### PR DESCRIPTION
## What is wrong

`lr_find(num_training=N)` is documented as testing N learning rates between `min_lr` and `max_lr`, but the ladder is not evenly spaced: the first step is twice as wide as every other one in `linear` mode, and the square of every other one in `exponential` mode (the default).

Driving the two schedulers directly, `min_lr=1e-3`, `max_lr=1.0`:

```
num_iter=10, master
  linear      gaps   = [0.1998, 0.0999, 0.0999, 0.0999, 0.0999, 0.0999, 0.0999, 0.0999, 0.0999]
  exponential ratios = [3.9811, 1.9953, 1.9953, 1.9953, 1.9953, 1.9953, 1.9953, 1.9953, 1.9953]

num_iter=10, with this change
  linear      gaps   = [0.111, 0.111, ...]
  exponential ratios = [2.1544, 2.1544, ...]
```

## Why

Both schedulers compute `r = (last_epoch + 1) / num_iter` and then special-case `last_epoch == 0` back to `base_lr`. The special case fixes the first point, but the fraction has already advanced, so step 1 lands on `2 / num_iter` and the rung at `1 / num_iter` is never visited. `r = last_epoch / (num_iter - 1)` gives `num_iter` evenly spaced points and leaves both endpoints exactly where they are today, so the special case is no longer needed.

This is what `results["lr"]` records and what `plot()` draws, so the skew is visible to anyone reading the curve.

## Test

New `test_lr_ladder_is_evenly_spaced` in `tests/tests_pytorch/tuner/test_lr_finder.py`, driving both schedulers over `num_iter` in 3, 5, 10, 100 with no `Trainer`. It fails on master for every parameter set and passes with this change.
