### PR TITLE
refactor: use public `LRScheduler` instead of private `_LRScheduler` in annotations

### DIFF
--- a/docs/source-fabric/conf.py
+++ b/docs/source-fabric/conf.py
@@ -288,7 +288,7 @@ nitpick_ignore_regex = [
     ("py:class", "torch.distributed.fsdp.wrap.ModuleWrapPolicy"),
     ("py:class", "torch.distributed.fsdp.sharded_grad_scaler.ShardedGradScaler"),
     ("py:class", "torch.amp.grad_scaler.GradScaler"),
-    ("py:class", "torch.optim.lr_scheduler._LRScheduler"),
+    ("py:class", "torch.optim.lr_scheduler.LRScheduler"),
     # Mocked optional packages
     ("py:class", "deepspeed.*"),
     ("py:.*", "torch_xla.*"),

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `_atomic_save` swallowing `PermissionError`, which made checkpoint saving report success without writing a file ([#21799](https://github.com/Lightning-AI/pytorch-lightning/pull/21799))
 
+- Fixed the `scheduler` type hint on `Fabric.setup` and `Strategy.setup_module_and_optimizers` to use the public `LRScheduler` instead of the private `_LRScheduler` ([#21934](https://github.com/Lightning-AI/pytorch-lightning/pull/21934))
+
 ---
 
 ## [2.6.4] - 2026-05-20

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -76,7 +76,7 @@ from lightning.fabric.wrappers import (
 )
 
 if TYPE_CHECKING:
-    from torch.optim.lr_scheduler import _LRScheduler
+    from torch.optim.lr_scheduler import LRScheduler
 
 
 def _do_nothing(*_: Any) -> None:
@@ -230,7 +230,7 @@ class Fabric:
         self,
         module: nn.Module,
         *optimizers: Optimizer,
-        scheduler: Optional["_LRScheduler"] = None,
+        scheduler: Optional["LRScheduler"] = None,
         move_to_device: bool = True,
         _reapply_compile: bool = True,
     ) -> Any:  # no specific return because the way we want our API to look does not play well with mypy

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -47,7 +47,7 @@ from lightning.fabric.utilities.types import _PATH
 if TYPE_CHECKING:
     from deepspeed import DeepSpeedEngine
     from fsspec import AbstractFileSystem
-    from torch.optim.lr_scheduler import _LRScheduler
+    from torch.optim.lr_scheduler import LRScheduler
 
 _DEEPSPEED_AVAILABLE = RequirementCache("deepspeed")
 _DEEPSPEED_GREATER_EQUAL_0_16 = RequirementCache("deepspeed>=0.16.0")
@@ -337,7 +337,7 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
 
     @override
     def setup_module_and_optimizers(
-        self, module: Module, optimizers: list[Optimizer], scheduler: Optional["_LRScheduler"] = None
+        self, module: Module, optimizers: list[Optimizer], scheduler: Optional["LRScheduler"] = None
     ) -> tuple["DeepSpeedEngine", list[Optimizer], Any]:
         """Set up a model and multiple optimizers together, along with an optional learning rate scheduler. Currently,
         only a single optimizer is supported.
@@ -616,7 +616,7 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
         )
 
     def _initialize_engine(
-        self, model: Module, optimizer: Optional[Optimizer] = None, scheduler: Optional["_LRScheduler"] = None
+        self, model: Module, optimizer: Optional[Optimizer] = None, scheduler: Optional["LRScheduler"] = None
     ) -> tuple["DeepSpeedEngine", Optimizer, Any]:
         """Initialize one model and one optimizer with an optional learning rate scheduler.
 

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
     from torch.distributed.device_mesh import DeviceMesh
     from torch.distributed.fsdp.fully_sharded_data_parallel import CPUOffload, MixedPrecision, ShardingStrategy
     from torch.distributed.fsdp.wrap import ModuleWrapPolicy
-    from torch.optim.lr_scheduler import _LRScheduler
+    from torch.optim.lr_scheduler import LRScheduler
 
     _POLICY = Union[set[type[Module]], Callable[[Module, bool, int], bool], ModuleWrapPolicy]
     _SHARDING_STRATEGY = Union[ShardingStrategy, Literal["FULL_SHARD", "SHARD_GRAD_OP", "NO_SHARD", "HYBRID_SHARD"]]
@@ -266,8 +266,8 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
 
     @override
     def setup_module_and_optimizers(
-        self, module: Module, optimizers: list[Optimizer], scheduler: Optional["_LRScheduler"] = None
-    ) -> tuple[Module, list[Optimizer], Optional["_LRScheduler"]]:
+        self, module: Module, optimizers: list[Optimizer], scheduler: Optional["LRScheduler"] = None
+    ) -> tuple[Module, list[Optimizer], Optional["LRScheduler"]]:
         """Wraps the model into a :class:`~torch.distributed.fsdp.fully_sharded_data_parallel.FullyShardedDataParallel`
         module and sets `use_orig_params=True` to keep the reference to the original parameters in the optimizer."""
         use_orig_params = self._fsdp_kwargs.get("use_orig_params")

--- a/src/lightning/fabric/strategies/strategy.py
+++ b/src/lightning/fabric/strategies/strategy.py
@@ -34,7 +34,7 @@ from lightning.fabric.utilities.init import _EmptyInit
 from lightning.fabric.utilities.types import _PATH, Optimizable, ReduceOp, _Stateful
 
 if TYPE_CHECKING:
-    from torch.optim.lr_scheduler import _LRScheduler
+    from torch.optim.lr_scheduler import LRScheduler
 
 TBroadcast = TypeVar("TBroadcast")
 TReduce = TypeVar("TReduce")
@@ -148,8 +148,8 @@ class Strategy(ABC):
         return stack
 
     def setup_module_and_optimizers(
-        self, module: Module, optimizers: list[Optimizer], scheduler: Optional["_LRScheduler"] = None
-    ) -> tuple[Module, list[Optimizer], Optional["_LRScheduler"]]:
+        self, module: Module, optimizers: list[Optimizer], scheduler: Optional["LRScheduler"] = None
+    ) -> tuple[Module, list[Optimizer], Optional["LRScheduler"]]:
         """Set up a model and multiple optimizers together.
 
         The returned objects are expected to be in the same order they were passed in. The default implementation will

--- a/src/lightning/fabric/strategies/xla_fsdp.py
+++ b/src/lightning/fabric/strategies/xla_fsdp.py
@@ -44,7 +44,7 @@ from lightning.fabric.utilities.rank_zero import rank_zero_only, rank_zero_warn
 from lightning.fabric.utilities.types import _PATH, Optimizable, ReduceOp
 
 if TYPE_CHECKING:
-    from torch.optim.lr_scheduler import _LRScheduler
+    from torch.optim.lr_scheduler import LRScheduler
     from torch_xla.distributed.parallel_loader import MpDeviceLoader
 
 _POLICY_SET = set[type[Module]]
@@ -197,8 +197,8 @@ class XLAFSDPStrategy(ParallelStrategy, _Sharded):
 
     @override
     def setup_module_and_optimizers(
-        self, module: Module, optimizers: list[Optimizer], scheduler: Optional["_LRScheduler"] = None
-    ) -> tuple[Module, list[Optimizer], Optional["_LRScheduler"]]:
+        self, module: Module, optimizers: list[Optimizer], scheduler: Optional["LRScheduler"] = None
+    ) -> tuple[Module, list[Optimizer], Optional["LRScheduler"]]:
         """Returns NotImplementedError since for XLAFSDP optimizer setup must happen after module setup."""
         raise NotImplementedError(
             f"The `{type(self).__name__}` does not support the joint setup of module and optimizer(s)."

--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -215,7 +215,7 @@ class LightningArgumentParser(ArgumentParser):
         """Adds arguments from a learning rate scheduler class to a nested key of the parser.
 
         Args:
-            lr_scheduler_class: Any subclass of ``torch.optim.lr_scheduler.{_LRScheduler, ReduceLROnPlateau}``. Use
+            lr_scheduler_class: Any subclass of ``torch.optim.lr_scheduler.{LRScheduler, ReduceLROnPlateau}``. Use
                 tuple to allow subclasses.
             nested_key: Name of the nested namespace to store arguments.
             link_to: Dot notation of a parser key to set arguments or AUTOMATIC.


### PR DESCRIPTION
## What does this PR do?

Fixes #21930.

PyTorch renamed `_LRScheduler` to `LRScheduler` in 2.0, keeping the old name as a *subclass* of the new one. So annotating `scheduler: Optional["_LRScheduler"]` rejects ordinary schedulers — `fabric.setup(model, optimizer, scheduler)` fails type checking even though it is correct at runtime.

- Switched the `scheduler` annotations in Fabric's `setup` and `setup_module_and_optimizers` to the public `LRScheduler`
- Updated the matching Sphinx `nitpick_ignore` entry and one docstring reference

Annotations only, no runtime change. Every import involved is already under `TYPE_CHECKING`, and the minimum supported `torch >=2.6.0` always has the public name.
