### PR TITLE
docs: Add :emphasize-lines: directives to code_structure.rst code blocks (#12119)

### DIFF
--- a/docs/source-fabric/fundamentals/code_structure.rst
+++ b/docs/source-fabric/fundamentals/code_structure.rst
@@ -17,6 +17,7 @@ The Main Function
 At the highest level, every Python script should contain the following boilerplate code to guard the entry point for the main function:
 
 .. code-block:: python
+    :emphasize-lines: 4-5
 
     def main():
         # Here goes all the rest of the code
@@ -41,6 +42,7 @@ Model Training
 Here is a skeleton for training a model in a function ``train()``:
 
 .. code-block:: python
+    :emphasize-lines: 3,6,11,15,18
 
     import lightning as L
 
@@ -89,6 +91,7 @@ Here is how the code would be structured if we did that periodically during trai
 
 
 .. code-block:: python
+    :emphasize-lines: 3,6,11,15,19,24,28,33,39
 
     import lightning as L
 


### PR DESCRIPTION
## Summary

Addresses lightning-AI/pytorch-lightning#12119.

Adds `:emphasize-lines:` Sphinx directives to the Python code blocks in `docs/source-fabric/fundamentals/code_structure.rst` so the most important structural lines are highlighted in the rendered docs:

- **The Main Function**: highlights the `if __name__ == "__main__"` guard lines.
- **Model Training**: highlights `fabric.setup(model, optimizer)`, `fabric.setup_dataloaders(...)`, and the `train(...)` call.
- **Training, Validation, Testing**: highlights the validation/test invocations inside training and main.

No content changes — only highlighting metadata.

## Test plan

- Viewed the rendered RST directives — line numbers verified to match the intended lines in each block.