### PR TITLE
Keep the protocol on last-checkpoint paths from a remote dirpath

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `LightningCLI` emitting `jsonargparse` deprecation warnings ([#21900](https://github.com/Lightning-AI/pytorch-lightning/issues/21900))
 
+- Fixed `ckpt_path="last"` never finding the last checkpoint when `ModelCheckpoint` saves to a remote filesystem ([#18261](https://github.com/Lightning-AI/pytorch-lightning/issues/18261))
+
 - Fixed `RichProgressBar` showing a nonsensical negative epoch total (e.g. `Epoch 5/-2`) when `Trainer(max_epochs=-1)` (unlimited epochs) is used and training stops via another condition ([#21925](https://github.com/Lightning-AI/pytorch-lightning/issues/21925))
 
 - Fixed crash when calling ``self.log()`` inside a ``torch.compile``-wrapped ``LightningModule`` on PyTorch 2.12/2.13 by disabling Dynamo tracing at the ``LightningModule.log`` boundary ([#21836](https://github.com/Lightning-AI/pytorch-lightning/issues/21836))

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -873,7 +873,13 @@ class ModelCheckpoint(Checkpoint):
             return path.suffix == self.FILE_EXTENSION and bool(re.match(last_pattern, path.stem))
 
         if self._fs.exists(ckpt_path):
-            return {os.path.normpath(p) for p in self._fs.ls(ckpt_path, detail=False) if _is_last(Path(p))}
+            candidates = [p for p in self._fs.ls(ckpt_path, detail=False) if _is_last(Path(p))]
+            if _is_local_file_protocol(ckpt_path):
+                return {os.path.normpath(p) for p in candidates}
+            # `ls` returns remote paths without their protocol, and `normpath` would corrupt one
+            # ("gs://bucket" -> "gs:/bucket"). Either way the path resolves to the local filesystem,
+            # so the checkpoint is never found again.
+            return {self._fs.unstrip_protocol(p) for p in candidates}
         return set()
 
     def __warn_if_dir_not_empty(self, dirpath: _PATH) -> None:

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -25,6 +25,7 @@ from unittest import mock
 from unittest.mock import Mock, call, patch
 
 import cloudpickle
+import fsspec
 import pytest
 import torch
 import yaml
@@ -34,6 +35,7 @@ from torch.utils.data.dataloader import DataLoader
 
 import lightning.pytorch as pl
 from lightning.fabric.utilities.cloud_io import _load as pl_load
+from lightning.fabric.utilities.cloud_io import get_filesystem
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import Callback, ModelCheckpoint
 from lightning.pytorch.demos.boring_classes import BoringModel, RandomIterableDataset
@@ -2021,6 +2023,46 @@ def test_find_last_checkpoints(name, extension, folder_contents, expected, tmp_p
     callback.FILE_EXTENSION = extension
     files = callback._find_last_checkpoints(trainer)
     assert files == {str(tmp_path / p) for p in expected}
+
+
+def test_find_last_checkpoints_remote_keeps_protocol():
+    """The paths returned for a remote dirpath must still resolve to the remote filesystem."""
+    fs = fsspec.filesystem("memory")
+    fs.mkdirs("/find_last_remote", exist_ok=True)
+    for name in ("last.ckpt", "epoch=0-step=1.ckpt"):
+        with fs.open(f"/find_last_remote/{name}", "wb") as file:
+            file.write(b"")
+
+    callback = ModelCheckpoint(dirpath="memory://find_last_remote")
+    files = callback._find_last_checkpoints(Trainer())
+
+    assert files == {"memory:///find_last_remote/last.ckpt"}
+    # this is what the checkpoint connector does with them
+    assert all(get_filesystem(path).exists(path) for path in files)
+
+
+def test_resume_from_last_checkpoint_on_remote_filesystem():
+    """`ckpt_path="last"` must find the last checkpoint a remote `dirpath` saved."""
+    dirpath = "memory://resume_last_remote"
+    fsspec.filesystem("memory").mkdirs("/resume_last_remote", exist_ok=True)
+
+    def make_trainer(max_epochs):
+        return Trainer(
+            default_root_dir=dirpath,
+            callbacks=[ModelCheckpoint(dirpath=dirpath, save_last=True)],
+            max_epochs=max_epochs,
+            limit_train_batches=1,
+            limit_val_batches=1,
+            logger=False,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+        )
+
+    make_trainer(1).fit(BoringModel())
+
+    trainer = make_trainer(2)
+    trainer.fit(BoringModel(), ckpt_path="last")
+    assert trainer.ckpt_path == "memory:///resume_last_remote/last.ckpt"
 
 
 def test_expand_home():


### PR DESCRIPTION
## What does this PR do?

Fixes #18261

`ckpt_path="last"` never resumes when `ModelCheckpoint` saves to a remote filesystem. It warns that no last checkpoint exists and trains from scratch, even though the file is there and `save_last=True` is set.

**Cause:** `_find_last_checkpoints` runs `os.path.normpath` over what `self._fs.ls` returned. On a remote filesystem `ls` gives paths without their protocol, and `normpath` collapses one that is present (`gs://bucket` becomes `gs:/bucket`). Either way the checkpoint connector's `get_filesystem(path)` resolves the candidate against the local disk, `fs.exists` is False, every candidate is dropped, and the warning even points at `save_last`, which is not the problem.

**Fix:** keep `normpath` for local paths, reattach the protocol otherwise. The rest of this file already routes on `_is_local_file_protocol` for exactly this reason, and `cloud_io._resolve_path` documents the same `gs://` corruption; this one function was missed.

```python
candidates = [p for p in self._fs.ls(ckpt_path, detail=False) if _is_last(Path(p))]
if _is_local_file_protocol(ckpt_path):
    return {os.path.normpath(p) for p in candidates}
return {self._fs.unstrip_protocol(p) for p in candidates}
```

`unstrip_protocol` is a no-op when the protocol is already there, and it exists in `fsspec` 2022.5.0, the floor this repo pins.

## Test

Two tests in `tests_pytorch/checkpointing/test_model_checkpoint.py`, using the `memory://` filesystem the connector tests already use. The second one fits, then resumes, and asserts the trainer actually loaded the checkpoint.

```
pytest tests_pytorch/checkpointing/test_model_checkpoint.py

  on master:      138 passed
  with the tests: 2 failed, 138 passed
     assert {'/find_last_remote/last.ckpt'} == {'memory:///find_last_remote/last.ckpt'}
     assert None == 'memory:///resume_last_remote/last.ckpt'
  with this PR:   140 passed
```

`tests_pytorch/checkpointing/` plus `test_checkpoint_connector.py` give an identical 347-failure set before and after (legacy-checkpoint downloads and a TensorFlow filesystem clash, both unrelated). `ruff check` and `ruff format --check` are clean on both files.
