### PR TITLE
test: skip symlink case without Windows privilege

### DIFF
--- a/tests/tests_pytorch/loggers/test_tensorboard.py
+++ b/tests/tests_pytorch/loggers/test_tensorboard.py
@@ -319,7 +319,14 @@ def test_tensorboard_with_symlink(tmp_path, monkeypatch):
     dest = os.path.join(".", "sym_lightning_logs")
 
     os.makedirs(source, exist_ok=True)
-    os.symlink(source, dest)
+    try:
+        os.symlink(source, dest)
+    except OSError as ex:
+        # Windows requires an elevated process or Developer Mode for symlinks.
+        # Keep reporting every other setup error instead of turning it into a skip.
+        if os.name == "nt" and getattr(ex, "winerror", None) == 1314:
+            pytest.skip(f"Can't create symlinks: {ex}")
+        raise
 
     logger = TensorBoardLogger(save_dir=dest, name="")
     _ = logger.version


### PR DESCRIPTION
## Summary\n\nSkip 	est_tensorboard_with_symlink when Windows refuses symlink creation with WinError 1314, which is expected for non-elevated contributors without Developer Mode. Other OSError values are still re-raised so genuine setup failures remain visible.\n\n## Verification\n\n- 	ests/tests_pytorch/loggers/test_tensorboard.py: 19 passed\n- uff check tests/tests_pytorch/loggers/test_tensorboard.py\n- compileall and git diff --check pass\n\nCloses #21932.