### PR TITLE
tests: skip test_tensorboard_with_symlink on Windows without symlink privilege

### DIFF
--- a/tests/tests_pytorch/loggers/test_tensorboard.py
+++ b/tests/tests_pytorch/loggers/test_tensorboard.py
@@ -319,7 +319,17 @@ def test_tensorboard_with_symlink(tmp_path, monkeypatch):
     dest = os.path.join(".", "sym_lightning_logs")
 
     os.makedirs(source, exist_ok=True)
-    os.symlink(source, dest)
+    try:
+        os.symlink(source, dest)
+    except OSError as ex:
+        # Windows refuses symlink creation unless the process is elevated or
+        # Developer Mode is enabled, which is not the default. CI runners hold the
+        # privilege, so this only bites contributors running the suite locally.
+        # Any other OSError -- a missing parent, an existing dest -- is a real
+        # failure and must not be turned into a passing skip.
+        if os.name == "nt" and getattr(ex, "winerror", None) == 1314:
+            pytest.skip(f"Can't create symlinks: {ex}")
+        raise
 
     logger = TensorBoardLogger(save_dir=dest, name="")
     _ = logger.version


### PR DESCRIPTION
Fixes #21932.

On Windows, `os.symlink()` raises `OSError` with `WinError 1314` when the process lacks symlink privilege (non-elevated, Developer Mode off). CI runners have the privilege, so this only affects local contributors.

The fix guards the `symlink` call and skips only for `WinError 1314` on Windows, re-raising all other `OSError`s to catch genuine failures.

**Before:** 1 failed / 17 passed (WinError 1314 on local Windows)
**After:** 0 failed / 17 passed (skipped with clear reason)

Only the specific error (WinError 1314 on Windows) is skipped — everything else re-raises.