### PR TITLE
Fix resumed training drawing the first epoch with sampler epoch 0 when the dataloader uses workers

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed the first epoch after resuming from a checkpoint drawing its indices with sampler epoch 0 when the ``DataLoader`` uses worker processes ([#21938](https://github.com/Lightning-AI/pytorch-lightning/issues/21938))
+
 - Fixed `LightningCLI` emitting `jsonargparse` deprecation warnings ([#21900](https://github.com/Lightning-AI/pytorch-lightning/issues/21900))
 
 - Fixed `RichProgressBar` showing a nonsensical negative epoch total (e.g. `Epoch 5/-2`) when `Trainer(max_epochs=-1)` (unlimited epochs) is used and training stops via another condition ([#21925](https://github.com/Lightning-AI/pytorch-lightning/issues/21925))

--- a/src/lightning/pytorch/loops/fit_loop.py
+++ b/src/lightning/pytorch/loops/fit_loop.py
@@ -270,6 +270,11 @@ class _FitLoop(_Loop):
 
         self._load_combined_loader_states()
 
+        # worker processes draw their first indices as soon as the iterator exists, so the sampler epoch must be
+        # restored before that when resuming from a checkpoint
+        for dl in combined_loader.flattened:
+            _set_sampler_epoch(dl, self.epoch_progress.current.processed)
+
         self._data_fetcher = _select_data_fetcher(trainer, RunningStage.TRAINING)
         self._data_fetcher.setup(combined_loader)
         with trainer.profiler.profile("setup_train_dataloader"):

--- a/tests/tests_pytorch/loops/test_evaluation_loop.py
+++ b/tests/tests_pytorch/loops/test_evaluation_loop.py
@@ -74,8 +74,8 @@ def test_evaluation_loop_sampler_set_epoch_called(tmp_path, use_batch_sampler):
     train_sampler = train_dataloader.batch_sampler.sampler if use_batch_sampler else train_dataloader.sampler
     val_sampler = val_dataloader.batch_sampler.sampler if use_batch_sampler else val_dataloader.sampler
 
-    # One for each epoch
-    assert train_sampler.set_epoch.mock_calls == [call(0), call(1)]
+    # Once when the dataloader is set up, then one for each epoch
+    assert train_sampler.set_epoch.mock_calls == [call(0), call(0), call(1)]
     # One for each epoch + sanity check
     assert val_sampler.set_epoch.mock_calls == [call(0), call(0), call(1)]
 

--- a/tests/tests_pytorch/loops/test_loops.py
+++ b/tests/tests_pytorch/loops/test_loops.py
@@ -1294,3 +1294,42 @@ def test_fit_loop_save_and_restore_dataloaders(
     trainer = Trainer(**trainer_kwargs, max_steps=4)
     trainer.fit(model, ckpt_path=(tmp_path / "checkpoint.ckpt"))
     assert model.seen_data == batches_after
+
+
+def test_resume_sets_sampler_epoch_before_workers_draw_indices(tmp_path):
+    """Test that a resumed run restores the sampler epoch before the dataloader workers start drawing indices."""
+
+    class EpochRecordingSampler(torch.utils.data.RandomSampler):
+        def __init__(self, data_source):
+            super().__init__(data_source)
+            self.epoch = 0
+            self.iter_epochs = []
+
+        def set_epoch(self, epoch):
+            self.epoch = epoch
+
+        def __iter__(self):
+            # like `DistributedSampler`, the epoch is read when the first index is drawn
+            self.iter_epochs.append(self.epoch)
+            yield from super().__iter__()
+
+    trainer_kwargs = {
+        "default_root_dir": tmp_path,
+        "accelerator": "cpu",
+        "limit_train_batches": 2,
+        "enable_checkpointing": False,
+        "enable_model_summary": False,
+        "enable_progress_bar": False,
+        "logger": False,
+    }
+    dataset = RandomDataset(32, 64)
+    trainer = Trainer(**trainer_kwargs, max_epochs=1)
+    trainer.fit(BoringModel(), DataLoader(dataset, sampler=EpochRecordingSampler(dataset), num_workers=1))
+    trainer.save_checkpoint(tmp_path / "checkpoint.ckpt")
+
+    # workers prefetch as soon as the iterator exists, so the epoch must already be restored at that point
+    sampler = EpochRecordingSampler(dataset)
+    trainer = Trainer(**trainer_kwargs, max_epochs=2)
+    dataloader = DataLoader(dataset, sampler=sampler, num_workers=1)
+    trainer.fit(BoringModel(), dataloader, ckpt_path=tmp_path / "checkpoint.ckpt")
+    assert sampler.iter_epochs == [1]


### PR DESCRIPTION
## What does this PR do?

Since #20775 the first epoch of a run resumed from an end-of-epoch checkpoint iterates the training dataloader with the sampler's epoch 0 permutation whenever the `DataLoader` uses worker processes. `FitLoop.setup_data()` creates the iterator before `on_advance_start()` sets the sampler epoch, and a multi-process iterator prefetches its first indices at creation. #20775 stopped the epoch loop from recreating that iterator on resume, so the epoch-0 permutation is the one that gets trained on.

The sampler epoch is now set in `setup_data()` before the iterator is created, using the same `epoch_progress.current.processed` that `on_advance_start()` uses. Later epochs are unchanged.

`test_evaluation_loop_sampler_set_epoch_called` counted one `set_epoch` call per epoch; it now sees the extra call made at dataloader setup, so its expectation is updated.

Fixes #21938

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? Yes, #21938
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? Not needed
- Did you write any **new necessary tests**? Yes, `test_resume_sets_sampler_epoch_before_workers_draw_indices` fails on master with `[0] == [1]` and passes with the fix
- [x] Did you verify new and **existing tests pass** locally with your changes? `tests/tests_pytorch/loops` passes (246 passed, 3 skipped, macOS CPU)
- Did you list all the **breaking changes** introduced by this pull request? None
- Did you **update the CHANGELOG**? Yes

</details>
