### PR TITLE
feat(callbacks): add `min_delta` parameter to `ModelCheckpoint` (#14353)

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `min_delta` parameter to `ModelCheckpoint` to prevent saving checkpoints for negligible metric improvements ([#14353](https://github.com/Lightning-AI/pytorch-lightning/issues/14353))
+
 - Added `suggest_integrations` flag to `Trainer` to control whether optional integration suggestions (e.g., litmodels, litlogger) are shown in logs ([#21632](https://github.com/Lightning-AI/pytorch-lightning/pull/21632))
 
 - Fixed ``ModelParallelStrategy`` single-file checkpointing when ``torch.compile`` wraps the model so optimizer states no longer raise ``KeyError`` during save ([#21357](https://github.com/Lightning-AI/pytorch-lightning/issues/21357))

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added `min_delta` parameter to `ModelCheckpoint` to prevent saving checkpoints for negligible metric improvements ([#14353](https://github.com/Lightning-AI/pytorch-lightning/issues/14353))
+- Added `min_delta` parameter to `ModelCheckpoint` to prevent saving checkpoints for negligible metric improvements ([#21942](https://github.com/Lightning-AI/pytorch-lightning/pull/21942))
 
 - Added `suggest_integrations` flag to `Trainer` to control whether optional integration suggestions (e.g., litmodels, litlogger) are shown in logs ([#21632](https://github.com/Lightning-AI/pytorch-lightning/pull/21632))
 

--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -180,6 +180,8 @@ class ModelCheckpoint(Checkpoint):
             (``val_check_interval != 1``), checkpointing is performed after validation.
         enable_version_counter: Whether to append a version to the existing file name.
             If ``False``, then the checkpoint files will be overwritten.
+        min_delta: Minimum change in the monitored quantity to qualify as an improvement, i.e. an absolute
+            change of less than or equal to `min_delta`, will count as no improvement. Default: ``0.0``.
 
     Note:
         For extra customization, ModelCheckpoint includes the following attributes:
@@ -206,8 +208,9 @@ class ModelCheckpoint(Checkpoint):
     Raises:
         MisconfigurationException:
             If ``save_top_k`` is smaller than ``-1``,
-            if ``monitor`` is ``None`` and ``save_top_k`` is none of ``None``, ``-1``, and ``0``, or
-            if ``mode`` is none of ``"min"`` or ``"max"``.
+            if ``monitor`` is ``None`` and ``save_top_k`` is none of ``None``, ``-1``, and ``0``,
+            if ``mode`` is none of ``"min"`` or ``"max"``, or
+            if ``min_delta`` is smaller than ``0.0``.
         ValueError:
             If ``trainer.save_checkpoint`` is ``None``.
 
@@ -277,6 +280,7 @@ class ModelCheckpoint(Checkpoint):
         every_n_epochs: Optional[int] = None,
         save_on_train_epoch_end: Optional[bool] = None,
         enable_version_counter: bool = True,
+        min_delta: float = 0.0,
     ):
         super().__init__()
         self.monitor = monitor
@@ -288,6 +292,7 @@ class ModelCheckpoint(Checkpoint):
         self.auto_insert_metric_name = auto_insert_metric_name
         self._save_on_train_epoch_end = save_on_train_epoch_end
         self._enable_version_counter = enable_version_counter
+        self.min_delta = min_delta
         self._last_global_step_saved = 0  # no need to save when no steps were taken
         self._last_time_checked: Optional[float] = None
         self.current_score: Optional[Tensor] = None
@@ -550,6 +555,7 @@ class ModelCheckpoint(Checkpoint):
             "kth_best_model_path": self.kth_best_model_path,
             "kth_value": self.kth_value,
             "last_model_path": self.last_model_path,
+            "min_delta": self.min_delta,
         }
 
     @override
@@ -562,6 +568,7 @@ class ModelCheckpoint(Checkpoint):
             self.kth_value = state_dict.get("kth_value", self.kth_value)
             self.best_k_models = state_dict.get("best_k_models", self.best_k_models)
             self.last_model_path = state_dict.get("last_model_path", self.last_model_path)
+            self.min_delta = state_dict.get("min_delta", self.min_delta)
         else:
             warnings.warn(
                 f"The dirpath has changed from {dirpath_from_ckpt!r} to {self.dirpath!r},"
@@ -672,6 +679,8 @@ class ModelCheckpoint(Checkpoint):
             )
         if self._every_n_epochs < 0:
             raise MisconfigurationException(f"Invalid value for every_n_epochs={self._every_n_epochs}. Must be >= 0")
+        if self.min_delta < 0:
+            raise MisconfigurationException(f"Invalid value for min_delta={self.min_delta}. Must be >= 0")
 
         every_n_train_steps_triggered = self._every_n_train_steps >= 1
         every_n_epochs_triggered = self._every_n_epochs >= 1
@@ -744,7 +753,10 @@ class ModelCheckpoint(Checkpoint):
             return True
 
         monitor_op = {"min": torch.lt, "max": torch.gt}[self.mode]
-        should_update_best_and_save = monitor_op(current, self.best_k_models[self.kth_best_model_path])
+        min_delta_adjusted = self.min_delta if self.mode == "max" else -self.min_delta
+        should_update_best_and_save = monitor_op(
+            current - min_delta_adjusted, self.best_k_models[self.kth_best_model_path].to(current.device)
+        )
 
         # If using multiple devices, make sure all processes are unanimous on the decision.
         should_update_best_and_save = trainer.strategy.reduce_boolean_decision(bool(should_update_best_and_save))

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -2180,3 +2180,92 @@ def test_save_last_only_when_checkpoint_saved(tmp_path):
     assert len(checkpoint_files) == expected_files, (
         f"Expected {expected_files} files, got {len(checkpoint_files)}: {checkpoint_names}"
     )
+
+
+def test_model_checkpoint_min_delta_validation():
+    """Test that min_delta must be non-negative."""
+    with pytest.raises(MisconfigurationException, match="Invalid value for min_delta=-0.5"):
+        ModelCheckpoint(min_delta=-0.5)
+
+
+def test_model_checkpoint_min_delta_min_mode():
+    """Test min_delta logic with mode='min'."""
+    checkpoint = ModelCheckpoint(monitor="val_loss", mode="min", min_delta=0.1, save_top_k=1)
+    trainer = Trainer(logger=False)
+
+    checkpoint.best_k_models["model_1.ckpt"] = torch.tensor(1.0)
+    checkpoint.kth_best_model_path = "model_1.ckpt"
+
+    # Improvement of 0.05 <= min_delta (0.1) -> should NOT update
+    assert not checkpoint.check_monitor_top_k(trainer, torch.tensor(0.95))
+    # Exactly min_delta improvement (1.0 - 0.9 = 0.1) -> should NOT update
+    assert not checkpoint.check_monitor_top_k(trainer, torch.tensor(0.90))
+    # Improvement of 0.15 > min_delta (0.1) -> SHOULD update
+    assert checkpoint.check_monitor_top_k(trainer, torch.tensor(0.85))
+
+
+def test_model_checkpoint_min_delta_max_mode():
+    """Test min_delta logic with mode='max'."""
+    checkpoint = ModelCheckpoint(monitor="val_acc", mode="max", min_delta=0.1, save_top_k=1)
+    trainer = Trainer(logger=False)
+
+    checkpoint.best_k_models["model_1.ckpt"] = torch.tensor(0.5)
+    checkpoint.kth_best_model_path = "model_1.ckpt"
+
+    # Improvement of 0.05 <= min_delta (0.1) -> should NOT update
+    assert not checkpoint.check_monitor_top_k(trainer, torch.tensor(0.55))
+    # Exactly min_delta improvement (0.6 - 0.5 = 0.1) -> should NOT update
+    assert not checkpoint.check_monitor_top_k(trainer, torch.tensor(0.60))
+    # Improvement of 0.15 > min_delta (0.1) -> SHOULD update
+    assert checkpoint.check_monitor_top_k(trainer, torch.tensor(0.65))
+
+
+def test_model_checkpoint_min_delta_state_dict():
+    """Test state_dict and load_state_dict preserve min_delta."""
+    checkpoint = ModelCheckpoint(min_delta=0.25)
+    state = checkpoint.state_dict()
+    assert state["min_delta"] == 0.25
+
+    new_checkpoint = ModelCheckpoint()
+    new_checkpoint.load_state_dict(state)
+    assert new_checkpoint.min_delta == 0.25
+
+
+def test_model_checkpoint_min_delta_integration(tmp_path):
+    """Integration test verifying min_delta prevents checkpoint writes for sub-delta improvements."""
+
+    class DynamicLossModel(BoringModel):
+        losses = [1.0, 0.95, 0.80]
+
+        def validation_step(self, batch, batch_idx):
+            loss = torch.tensor(self.losses[self.current_epoch])
+            self.log("val_loss", loss)
+            return loss
+
+    model = DynamicLossModel()
+    checkpoint = ModelCheckpoint(
+        dirpath=tmp_path,
+        filename="best-{epoch}-{val_loss:.2f}",
+        monitor="val_loss",
+        mode="min",
+        min_delta=0.1,
+        save_top_k=1,
+    )
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        max_epochs=3,
+        callbacks=[checkpoint],
+        logger=False,
+        enable_progress_bar=False,
+        limit_train_batches=1,
+        limit_val_batches=1,
+    )
+    trainer.fit(model)
+
+    # Epoch 0 (val_loss=1.00) saved.
+    # Epoch 1 (val_loss=0.95) delta=0.05 < 0.10, skipped!
+    # Epoch 2 (val_loss=0.80) delta=0.20 > 0.10, saved!
+    saved_files = [f.name for f in tmp_path.glob("*.ckpt")]
+    assert "best-epoch=2-val_loss=0.80.ckpt" in saved_files
+    assert "best-epoch=1-val_loss=0.95.ckpt" not in saved_files
+    assert checkpoint.best_model_score == torch.tensor(0.80)


### PR DESCRIPTION
## What does this PR do?

Fixes #14353

Adds a `min_delta` parameter (default: `0.0`) to `ModelCheckpoint`, allowing users to specify the minimum change in the monitored quantity required to qualify as an improvement before saving a new checkpoint.

### Motivation
In large model training, metrics often improve by infinitesimal amounts (e.g., `1e-7`). Currently, `ModelCheckpoint` strictly checks inequality (`current < best` or `current > best`), triggering expensive multi-gigabyte disk saves and evicting top checkpoints for statistically negligible improvements. `EarlyStopping` already supports `min_delta`, and this change brings parity and consistency to `ModelCheckpoint`.

### Key Changes
1. **`ModelCheckpoint.__init__`**: Added `min_delta: float = 0.0` with validation ensuring `min_delta >= 0.0` (raises `MisconfigurationException` if negative). Preserves 100% backward compatibility.
2. **`check_monitor_top_k`**: Updated decision logic to require metric improvement `> min_delta` (`mode="max"`) or `< -min_delta` (`mode="min"`).
3. **State Persistence**: Serialized and restored `min_delta` in `state_dict` and `load_state_dict`.
4. **Tests**: Added 5 unit and integration tests in `tests/tests_pytorch/checkpointing/test_model_checkpoint.py` verifying `min` and `max` modes, boundary behavior, validation exceptions, state persistence, and end-to-end multi-epoch saving.
5. **Documentation & Changelog**: Updated docstrings in `ModelCheckpoint` and added an entry to `src/lightning/pytorch/CHANGELOG.md`.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? Yes, approved by maintainer @rohitgr7 in #14353
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request? (None, defaults to 0.0)
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

</details>

cc @rohitgr7
