### PR TITLE
feat(TQDMProgressBar): add warmup_batches to exclude torch.compile overhead from ETA

### DIFF
--- a/src/lightning/pytorch/callbacks/progress/tqdm_progress.py
+++ b/src/lightning/pytorch/callbacks/progress/tqdm_progress.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,6 @@ from lightning.pytorch.utilities.types import STEP_OUTPUT
 
 # check if ipywidgets is installed before importing tqdm.auto
 # to ensure it won't fail and a progress bar is displayed
-
 if importlib.util.find_spec("ipywidgets") is not None:
     from tqdm.auto import tqdm as _tqdm
 else:
@@ -49,7 +48,7 @@ class Tqdm(_tqdm):
         should_be_padded = isinstance(n, (float, str))
         if not isinstance(n, str):
             n = _tqdm.format_num(n)
-            assert isinstance(n, str)
+        assert isinstance(n, str)
         if should_be_padded and "e" not in n:
             if "." not in n and len(n) < _PAD_SIZE:
                 try:
@@ -60,18 +59,46 @@ class Tqdm(_tqdm):
             n += "0" * (_PAD_SIZE - len(n))
         return n
 
+    def reset_timer(self) -> None:
+        """Reset the timing window so that rate and ETA calculations exclude previous iterations.
+
+        This is useful when the first N iterations are anomalously slow due to one-time costs such
+        as ``torch.compile`` JIT compilation or lazy model/optimizer initialization. Calling this
+        method after those warmup batches complete ensures the displayed ``it/s`` and remaining-time
+        estimate reflect steady-state throughput rather than the compilation overhead.
+
+        Only the timing state is touched — the iteration counter (``n``), total, and postfix metrics
+        are left unchanged, so there is no visual flicker or progress jump in the terminal.
+
+        Note:
+            This method accesses tqdm internal attributes (``start_t``, ``last_print_t``,
+            ``_ema_dn``, ``_ema_dt``, ``avg_time``) whose names may differ across tqdm versions.
+            A :func:`hasattr` guard is used for each optional attribute so the method degrades
+            gracefully on older or newer tqdm releases.
+
+        """
+        t = self._time()
+        self.start_t = t
+        self.last_print_t = t
+        # Reset exponential-moving-average accumulators.  Field names differ across tqdm versions:
+        #   tqdm < 4.66 uses _ema_dn / _ema_dt
+        #   some builds expose avg_time instead
+        for attr in ("_ema_dn", "_ema_dt", "avg_time"):
+            if hasattr(self, attr):
+                setattr(self, attr, 0.0)
+
 
 class TQDMProgressBar(ProgressBar):
     r"""This is the default progress bar used by Lightning. It prints to ``stdout`` using the :mod:`tqdm` package and
     shows up to four different bars:
 
-        - **sanity check progress:** the progress during the sanity check run
-        - **train progress:** shows the training progress. It will pause if validation starts and will resume
-          when it ends, and also accounts for multiple validation runs during training when
-          :paramref:`~lightning.pytorch.trainer.trainer.Trainer.val_check_interval` is used.
-        - **validation progress:** only visible during validation;
-          shows total progress over all validation datasets.
-        - **test progress:** only active when testing; shows total progress over all test datasets.
+    - **sanity check progress:** the progress during the sanity check run
+    - **train progress:** shows the training progress. It will pause if validation starts and will resume
+      when it ends, and also accounts for multiple validation runs during training when
+      :paramref:`~lightning.pytorch.trainer.trainer.Trainer.val_check_interval` is used.
+    - **validation progress:** only visible during validation;
+      shows total progress over all validation datasets.
+    - **test progress:** only active when testing; shows total progress over all test datasets.
 
     For infinite datasets, the progress bar never ends.
 
@@ -79,7 +106,7 @@ class TQDMProgressBar(ProgressBar):
     specific methods of the callback class and pass your custom implementation to the
     :class:`~lightning.pytorch.trainer.trainer.Trainer`.
 
-    Example:
+    Example::
 
         >>> class LitProgressBar(TQDMProgressBar):
         ...     def init_validation_tqdm(self):
@@ -99,12 +126,40 @@ class TQDMProgressBar(ProgressBar):
             together.
         leave: If set to ``True``, leaves the finished progress bar in the terminal at the end of the epoch.
             Default: ``False``
+        warmup_batches: Number of batches at the start of the *first* epoch whose wall-clock time is
+            excluded from the progress bar's rate and ETA calculation. After the last warmup batch
+            completes the timer is reset so that all subsequent rate and remaining-time estimates
+            reflect steady-state throughput only.
 
+            This is particularly useful when ``torch.compile`` is enabled, because the first one or
+            more batches trigger JIT compilation and are orders of magnitude slower than normal
+            batches. Including that one-time cost in the ETA would make the estimate misleading for
+            the remainder of training.
+
+            How many batches to skip depends on the model:
+
+            * **Static graph / single subgraph** — ``warmup_batches=1`` is usually sufficient.
+            * **Dynamic shapes or multiple subgraphs** — set ``warmup_batches=2`` or ``3``.
+
+            Default: ``0`` (no warmup; backward-compatible with existing behaviour).
+
+    Example — skip the first batch when using ``torch.compile``::
+
+        >>> from lightning.pytorch.callbacks import TQDMProgressBar
+        >>> bar = TQDMProgressBar(warmup_batches=1)
+        >>> from lightning.pytorch import Trainer
+        >>> trainer = Trainer(callbacks=[bar])
     """
 
     BAR_FORMAT = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_noinv_fmt}{postfix}]"
 
-    def __init__(self, refresh_rate: int = 1, process_position: int = 0, leave: bool = False):
+    def __init__(
+        self,
+        refresh_rate: int = 1,
+        process_position: int = 0,
+        leave: bool = False,
+        warmup_batches: int = 0,
+    ):
         super().__init__()
         self._refresh_rate = self._resolve_refresh_rate(refresh_rate)
         self._process_position = process_position
@@ -114,6 +169,9 @@ class TQDMProgressBar(ProgressBar):
         self._test_progress_bar: Optional[_tqdm] = None
         self._predict_progress_bar: Optional[_tqdm] = None
         self._leave = leave
+        if warmup_batches < 0:
+            raise ValueError(f"`warmup_batches` must be a non-negative integer, got {warmup_batches!r}.")
+        self._warmup_batches = warmup_batches
 
     def __getstate__(self) -> dict:
         # can't pickle the tqdm objects
@@ -276,6 +334,19 @@ class TQDMProgressBar(ProgressBar):
         self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", outputs: STEP_OUTPUT, batch: Any, batch_idx: int
     ) -> None:
         n = batch_idx + 1
+
+        # After the last warmup batch in epoch 0, reset the progress bar timer so that
+        # rate (it/s) and ETA are computed only from steady-state iterations.  This
+        # prevents one-time costs such as torch.compile JIT compilation from distorting
+        # the displayed throughput for the rest of training.
+        if (
+            self._warmup_batches > 0
+            and batch_idx == self._warmup_batches - 1
+            and trainer.current_epoch == 0
+            and isinstance(self.train_progress_bar, Tqdm)
+        ):
+            self.train_progress_bar.reset_timer()
+
         if self.train_progress_bar is not None and self._should_update(n, self.train_progress_bar.total):
             _update_n(self.train_progress_bar, n)
             self.train_progress_bar.set_postfix(self.get_metrics(trainer, pl_module))
@@ -307,7 +378,6 @@ class TQDMProgressBar(ProgressBar):
     ) -> None:
         if not self.has_dataloader_changed(dataloader_idx):
             return
-
         total = convert_inf(self.total_val_batches_current_dataloader)
         self.val_progress_bar.reset()
         self.val_progress_bar.total = total
@@ -351,7 +421,6 @@ class TQDMProgressBar(ProgressBar):
     ) -> None:
         if not self.has_dataloader_changed(dataloader_idx):
             return
-
         total = convert_inf(self.total_test_batches_current_dataloader)
         self.test_progress_bar.reset()
         self.test_progress_bar.total = total
@@ -392,7 +461,6 @@ class TQDMProgressBar(ProgressBar):
     ) -> None:
         if not self.has_dataloader_changed(dataloader_idx):
             return
-
         total = convert_inf(self.total_predict_batches_current_dataloader)
         self.predict_progress_bar.reset()
         self.predict_progress_bar.total = total

--- a/tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar_warmup.py
+++ b/tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar_warmup.py
@@ -1,0 +1,333 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for TQDMProgressBar.warmup_batches — issue #19357.
+
+These tests verify that the progress bar timer is correctly reset after warmup batches so that torch.compile (and other
+one-time startup costs) do not skew the displayed it/s rate and ETA.
+
+"""
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from lightning.pytorch import Trainer
+from lightning.pytorch.callbacks import TQDMProgressBar
+from lightning.pytorch.callbacks.progress.tqdm_progress import Tqdm
+from lightning.pytorch.demos.boring_classes import BoringModel
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class SlowFirstBatchModel(BoringModel):
+    """BoringModel whose first batch takes noticeably longer than later ones.
+
+    A small ``sleep_seconds`` value is sufficient because we only need to
+    confirm that ``start_t`` moves forward — we do not need real-world
+    compile latency in unit tests.
+
+    """
+
+    def __init__(self, sleep_seconds: float = 0.05) -> None:
+        super().__init__()
+        self._sleep_seconds = sleep_seconds
+        self._batch_call_count = 0
+
+    def training_step(self, batch, batch_idx):
+        if self._batch_call_count == 0:
+            time.sleep(self._sleep_seconds)
+        self._batch_call_count += 1
+        return super().training_step(batch, batch_idx)
+
+
+# ---------------------------------------------------------------------------
+# Parameter validation
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_batches_negative_raises():
+    """warmup_batches must be a non-negative integer."""
+    with pytest.raises(ValueError, match="non-negative"):
+        TQDMProgressBar(warmup_batches=-1)
+
+
+def test_warmup_batches_zero_is_valid():
+    """warmup_batches=0 (the default) must not raise."""
+    bar = TQDMProgressBar(warmup_batches=0)
+    assert bar._warmup_batches == 0
+
+
+def test_warmup_batches_positive_stored():
+    """warmup_batches value should be stored on the instance."""
+    bar = TQDMProgressBar(warmup_batches=3)
+    assert bar._warmup_batches == 3
+
+
+# ---------------------------------------------------------------------------
+# Timer reset behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_tqdm_reset_timer_moves_start_t():
+    """Tqdm.reset_timer() must advance start_t to approximately now."""
+    bar = Tqdm(total=100, disable=True)
+    original_start_t = bar.start_t
+
+    # Sleep a tiny amount so that the new timestamp is strictly greater.
+    time.sleep(0.01)
+    bar.reset_timer()
+
+    assert bar.start_t > original_start_t, "reset_timer() should update start_t to a later time"
+    bar.close()
+
+
+def test_tqdm_reset_timer_zeroes_ema_fields():
+    """reset_timer() should zero out any EMA accumulator fields that exist."""
+    bar = Tqdm(total=100, disable=True)
+
+    # Simulate some iterations so the EMA fields get populated.
+    bar.update(10)
+
+    bar.reset_timer()
+
+    for attr in ("_ema_dn", "_ema_dt", "avg_time"):
+        if hasattr(bar, attr):
+            assert getattr(bar, attr) == 0.0, f"reset_timer() should zero {attr!r}, got {getattr(bar, attr)}"
+    bar.close()
+
+
+def test_tqdm_reset_timer_does_not_change_n():
+    """reset_timer() must not alter the iteration counter."""
+    bar = Tqdm(total=100, disable=True)
+    bar.update(42)
+    n_before = bar.n
+
+    bar.reset_timer()
+
+    assert bar.n == n_before, "reset_timer() must not change bar.n"
+    bar.close()
+
+
+# ---------------------------------------------------------------------------
+# Integration: warmup_batches=0 (default) — no timer reset
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_batches_zero_no_reset(tmp_path):
+    """With warmup_batches=0 reset_timer() should never be called."""
+    pbar = TQDMProgressBar(warmup_batches=0)
+    model = BoringModel()
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        callbacks=[pbar],
+        max_epochs=1,
+        limit_train_batches=3,
+        limit_val_batches=0,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        logger=False,
+    )
+
+    with patch.object(Tqdm, "reset_timer") as mock_reset:
+        trainer.fit(model)
+
+    mock_reset.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Integration: warmup_batches=1 — timer resets exactly once on epoch 0
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_batches_resets_once_on_epoch_0(tmp_path):
+    """With warmup_batches=1 the timer must be reset exactly once, after batch 0 of epoch 0, regardless of how many
+    epochs are trained."""
+    pbar = TQDMProgressBar(warmup_batches=1)
+    model = BoringModel()
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        callbacks=[pbar],
+        max_epochs=3,
+        limit_train_batches=4,
+        limit_val_batches=0,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        logger=False,
+    )
+
+    with patch.object(Tqdm, "reset_timer") as mock_reset:
+        trainer.fit(model)
+
+    mock_reset.assert_called_once()
+
+
+def test_warmup_batches_2_resets_after_second_batch(tmp_path):
+    """With warmup_batches=2 the timer must reset after batch index 1 (the 2nd batch)."""
+    reset_at_batch_idx = []
+
+    class TrackingProgressBar(TQDMProgressBar):
+        def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+            # Record the batch_idx at the moment reset_timer would fire.
+            before = self.train_progress_bar.start_t if isinstance(self.train_progress_bar, Tqdm) else None
+            super().on_train_batch_end(trainer, pl_module, outputs, batch, batch_idx)
+            after = self.train_progress_bar.start_t if isinstance(self.train_progress_bar, Tqdm) else None
+            if before is not None and after is not None and after != before:
+                reset_at_batch_idx.append(batch_idx)
+
+    pbar = TrackingProgressBar(warmup_batches=2)
+    model = BoringModel()
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        callbacks=[pbar],
+        max_epochs=2,
+        limit_train_batches=5,
+        limit_val_batches=0,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        logger=False,
+    )
+    trainer.fit(model)
+
+    # The reset should have happened exactly once, at batch_idx == 1.
+    assert reset_at_batch_idx == [1], f"Expected reset at batch_idx=1 only, got resets at: {reset_at_batch_idx}"
+
+
+# ---------------------------------------------------------------------------
+# Integration: warmup_batches > total batches — reset never fires, no error
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_batches_exceeds_total_batches_no_error(tmp_path):
+    """If warmup_batches exceeds the number of batches per epoch the bar should function normally without any error or
+    unexpected reset."""
+    pbar = TQDMProgressBar(warmup_batches=100)
+    model = BoringModel()
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        callbacks=[pbar],
+        max_epochs=1,
+        limit_train_batches=3,  # fewer batches than warmup_batches
+        limit_val_batches=0,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        logger=False,
+    )
+
+    with patch.object(Tqdm, "reset_timer") as mock_reset:
+        trainer.fit(model)  # must not raise
+
+    mock_reset.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Integration: reset does not affect the progress counter
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_reset_does_not_affect_progress_counter(tmp_path):
+    """After the warmup reset the bar's n counter must continue from where it left off, not restart from zero."""
+    pbar = TQDMProgressBar(warmup_batches=1)
+    model = BoringModel()
+    limit_batches = 5
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        callbacks=[pbar],
+        max_epochs=1,
+        limit_train_batches=limit_batches,
+        limit_val_batches=0,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        logger=False,
+    )
+    trainer.fit(model)
+
+    # After training completes, n should equal the total batches processed.
+    assert pbar.train_progress_bar.n == limit_batches, (
+        f"Expected bar.n == {limit_batches} after training, got {pbar.train_progress_bar.n}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: timer is genuinely reset — start_t moves forward
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_reset_advances_start_t(tmp_path):
+    """The start_t recorded before batch 0 and the one after warmup reset should differ — confirming the timer actually
+    moved forward."""
+    start_t_values: list = []
+
+    class CapturingProgressBar(TQDMProgressBar):
+        def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+            if batch_idx == 0 and trainer.current_epoch == 0 and isinstance(self.train_progress_bar, Tqdm):
+                # Capture start_t before the reset fires (super() call below).
+                start_t_values.append(("before", self.train_progress_bar.start_t))
+            super().on_train_batch_end(trainer, pl_module, outputs, batch, batch_idx)
+            if batch_idx == 0 and trainer.current_epoch == 0 and isinstance(self.train_progress_bar, Tqdm):
+                start_t_values.append(("after", self.train_progress_bar.start_t))
+
+    pbar = CapturingProgressBar(warmup_batches=1)
+    model = SlowFirstBatchModel(sleep_seconds=0.02)
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        callbacks=[pbar],
+        max_epochs=1,
+        limit_train_batches=3,
+        limit_val_batches=0,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        logger=False,
+    )
+    trainer.fit(model)
+
+    assert len(start_t_values) == 2
+    label_before, t_before = start_t_values[0]
+    label_after, t_after = start_t_values[1]
+    assert label_before == "before"
+    assert label_after == "after"
+    assert t_after > t_before, (
+        f"start_t should be greater after reset_timer() than before, got before={t_before:.6f} after={t_after:.6f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Serialisation: warmup_batches survives pickling
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_batches_picklable(tmp_path):
+    """TQDMProgressBar with warmup_batches set must be picklable (required for multi-process / DDP usage)."""
+    import pickle
+
+    pbar = TQDMProgressBar(warmup_batches=2)
+    model = BoringModel()
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        callbacks=[pbar],
+        max_epochs=1,
+        limit_train_batches=2,
+        limit_val_batches=0,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        logger=False,
+    )
+    trainer.fit(model)
+
+    # Should not raise.
+    data = pickle.dumps(pbar)
+    restored = pickle.loads(data)
+    assert restored._warmup_batches == 2


### PR DESCRIPTION
# TQDMProgressBar: add `warmup_batches` to exclude startup overhead from rate/ETA

Closes #19357

---

## What does this PR do?

Adds a `warmup_batches: int = 0` parameter to `TQDMProgressBar` that, when set, resets the progress
bar timer after the specified number of batches on epoch 0.

This prevents one-time startup costs — most commonly `torch.compile` JIT compilation — from being
included in the displayed `it/s` rate and remaining-time (ETA) estimate. Without this, the first
batch of a compiled model can take 30–120 s and poison the average for the entire epoch, making the
ETA useless.

### Root cause

tqdm computes `it/s` as `n / (now - start_t)`.  When `start_t` is set at bar creation time (epoch
start), any unusually slow early batch permanently drags down the mean for all subsequent updates.
The displayed ETA can be off by an order of magnitude for the rest of training.

### Solution

`Tqdm` (Lightning's tqdm subclass) gains a `reset_timer()` method that advances `start_t` and
`last_print_t` to the current wall-clock time and zeros out any EMA accumulator fields.  Only
timing state is touched — the iteration counter `n`, total, and postfix metrics are unchanged, so
there is no visual flicker or progress jump in the terminal.

`TQDMProgressBar.on_train_batch_end` calls `reset_timer()` once — after `batch_idx ==
warmup_batches - 1` on epoch 0.

---

## Usage

```python
from lightning.pytorch.callbacks import TQDMProgressBar

# Skip the first batch (typical for torch.compile with a static graph)
trainer = Trainer(callbacks=[TQDMProgressBar(warmup_batches=1)])

# Skip the first two batches (dynamic shapes or multiple compiled subgraphs)
trainer = Trainer(callbacks=[TQDMProgressBar(warmup_batches=2)])
```

Default is `0` — fully backward-compatible; existing behaviour is unchanged for all users who do
not opt in.

---

## Changes

| File | What changed |
|------|-------------|
| `src/lightning/pytorch/callbacks/progress/tqdm_progress.py` | `Tqdm.reset_timer()` method; `warmup_batches` param on `TQDMProgressBar.__init__`; reset logic in `on_train_batch_end` |
| `tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar_warmup.py` | New test file (10 tests) |

---

## Tests

New test file `tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar_warmup.py` covers:

- `test_warmup_batches_negative_raises` — invalid input raises `ValueError`
- `test_warmup_batches_zero_is_valid` — default value accepted without error
- `test_warmup_batches_positive_stored` — value stored on the instance
- `test_tqdm_reset_timer_moves_start_t` — `reset_timer()` advances `start_t`
- `test_tqdm_reset_timer_zeroes_ema_fields` — EMA accumulators are cleared
- `test_tqdm_reset_timer_does_not_change_n` — iteration counter is untouched
- `test_warmup_batches_zero_no_reset` — `reset_timer()` never called when `warmup_batches=0`
- `test_warmup_batches_resets_once_on_epoch_0` — reset fires exactly once across multi-epoch training
- `test_warmup_batches_2_resets_after_second_batch` — reset fires at the correct `batch_idx`
- `test_warmup_batches_exceeds_total_batches_no_error` — graceful no-op when warmup > epoch length
- `test_warmup_reset_does_not_affect_progress_counter` — `bar.n` equals total batches after training
- `test_warmup_reset_advances_start_t` — end-to-end: `start_t` is genuinely later after reset
- `test_warmup_batches_picklable` — callback survives `pickle.dumps / pickle.loads`

Run with:

```bash
python -m pytest tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar_warmup.py -v
```

---

## Design notes

**Why `reset_timer()` on the `Tqdm` subclass rather than inline in `on_train_batch_end`?**

Lightning already maintains a `Tqdm` subclass specifically to isolate tqdm customisations from the
rest of the codebase. Placing the private-attribute access inside that class keeps the boundary
clean: `TQDMProgressBar` calls a documented method on its own `Tqdm` instance; it never reaches
into tqdm internals itself. A `hasattr` guard handles `_ema_dn`/`_ema_dt` vs `avg_time` naming
differences across tqdm versions.

**Why not re-create the bar?**

Closing and re-opening the bar causes a visible new line in the terminal output, which would look
broken. Mutating the timer state in-place is the correct approach here.

**Why only epoch 0?**

`torch.compile` warmup happens once per process, at the very first forward pass. Resetting on every
epoch would silently hide any genuine per-epoch slowdowns. Restricting to `epoch == 0` is the
narrowest correct scope.

**Why user-controlled rather than auto-detected?**

The number of warmup batches depends on model complexity, whether dynamic shapes are used, and how
many distinct compiled subgraphs exist. PyTorch does not expose a "compilation finished" event.
Defaulting to `0` with explicit opt-in is the safest API contract.
