### PR TITLE
Do not run the wrapped module's property getter when setting an attribute

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `_FabricModule.__setattr__` running the wrapped module's `property` getter, so a getter that guards an uninitialized value raised out of the assignment ([#21944](https://github.com/Lightning-AI/pytorch-lightning/pull/21944))
+
 - Fixed type checking for the `BitsandbytesPrecision` plugin and raised the supported `bitsandbytes` ceiling to `<0.50` (compatible with 0.48/0.49) ([#21858](https://github.com/Lightning-AI/pytorch-lightning/pull/21858))
 
 - Fixed DeepSpeed checkpoint path validation rejecting remote filesystem URIs (S3, GCS, HDFS) ([#21636](https://github.com/Lightning-AI/pytorch-lightning/pull/21636))

--- a/src/lightning/fabric/wrappers.py
+++ b/src/lightning/fabric/wrappers.py
@@ -271,7 +271,8 @@ class _FabricModule(_DeviceDtypeModuleMixin):
 
         # Get the _original_module attribute
         original_module = self._original_module
-        original_has_attr = hasattr(original_module, name)
+        # Can't use hasattr because it would run a `property` getter, which can raise or have side effects
+        original_has_attr = name in dir(original_module)
         # Can't use super().__getattr__ because nn.Module only checks _parameters, _buffers, and _modules
         # Can't use self.__getattr__ because it would pass through to the original module
         fabric_has_attr = name in dir(self)

--- a/tests/tests_fabric/test_wrappers.py
+++ b/tests/tests_fabric/test_wrappers.py
@@ -242,6 +242,37 @@ def test_fabric_module_setattr():
         assert repr(fabric_module) == "test"
 
 
+def test_fabric_module_setattr_does_not_run_property_getter():
+    """Assigning through the wrapper must not read the attribute off the original module first."""
+
+    class OriginalModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(2, 3)
+            self._guarded = None
+            self.reads = 0
+
+        @property
+        def guarded(self):
+            # A getter that refuses to hand out an uninitialized value is a common pattern
+            self.reads += 1
+            if self._guarded is None:
+                raise ValueError("not set yet")
+            return self._guarded
+
+        @guarded.setter
+        def guarded(self, value):
+            self._guarded = value
+
+    original_module = OriginalModule()
+    fabric_module = _FabricModule(original_module, Mock(), original_module=original_module)
+
+    fabric_module.guarded = 5
+    assert original_module.guarded == 5
+    # the assignment itself must not have gone through the getter
+    assert original_module.reads == 1
+
+
 def test_fabric_module_state_dict_access():
     """Test that state_dict access passes through to the original module."""
 


### PR DESCRIPTION
Fixes #18842.

## What breaks

Assigning an attribute through a `_FabricModule` runs the wrapped module's property getter first:

```python
class Model(nn.Module):
    @property
    def zsp(self):
        if self._zsp is None:
            raise ValueError("model is not trained")
        return self._zsp

    @zsp.setter
    def zsp(self, v):
        self._zsp = v

model = fabric.setup(Model())
model.zsp = tensor      # ValueError: model is not trained
```

The setter is never reached. Any getter with a side effect also fires on every assignment.

## Why

`__setattr__` decides where to route the assignment with

```python
original_has_attr = hasattr(original_module, name)
```

`hasattr` calls the getter, and it only swallows `AttributeError`, so a guard like the one above propagates out of the assignment.

## The change

`name in dir(original_module)` answers the same question without invoking the descriptor. The line two below it already uses that idiom for the wrapper, with a comment saying why the obvious lookup cannot be used. `nn.Module.__dir__` includes parameters, buffers and submodules, so buffers and submodules still route the same way.

## Test

`test_fabric_module_setattr_does_not_run_property_getter` in `tests/tests_fabric/test_wrappers.py` assigns through a wrapper over a module whose getter raises while unset, and counts getter calls to pin that the assignment itself performs none.

```
tests/tests_fabric/test_wrappers.py tests/tests_fabric/test_fabric.py
  before: 4 failed, 136 passed, 39 skipped
  after:  3 failed, 137 passed, 39 skipped
```

The 3 remaining failures are the `[deepspeed]` parametrizations of `test_setup_dataloaders_replace_*_sampler`; they fail identically on the unmodified file in this environment.
