### PR TITLE
Remove the call tracker's forward hooks and reset its flag on every call

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed the `_FabricModule` call tracker leaking a forward hook per submodule on every failed call and carrying its verdict into the next call ([#21945](https://github.com/Lightning-AI/pytorch-lightning/pull/21945))
+
 - Fixed type checking for the `BitsandbytesPrecision` plugin and raised the supported `bitsandbytes` ceiling to `<0.50` (compatible with 0.48/0.49) ([#21858](https://github.com/Lightning-AI/pytorch-lightning/pull/21858))
 
 - Fixed DeepSpeed checkpoint path validation rejecting remote filesystem URIs (S3, GCS, HDFS) ([#21636](https://github.com/Lightning-AI/pytorch-lightning/pull/21636))

--- a/src/lightning/fabric/wrappers.py
+++ b/src/lightning/fabric/wrappers.py
@@ -209,11 +209,17 @@ class _FabricModule(_DeviceDtypeModuleMixin):
 
         @wraps(method)
         def _wrapped_method(*args: Any, **kwargs: Any) -> Any:
+            nonlocal module_called
+            module_called = False
             handles = []
-            for module in self._original_module.modules():
-                handles.append(module.register_forward_hook(hook))
+            try:
+                for module in self._original_module.modules():
+                    handles.append(module.register_forward_hook(hook))
 
-            output = method(*args, **kwargs)
+                output = method(*args, **kwargs)
+            finally:
+                for handle in handles:
+                    handle.remove()
 
             if module_called:
                 raise RuntimeError(
@@ -221,8 +227,6 @@ class _FabricModule(_DeviceDtypeModuleMixin):
                     " model. To avoid issues with the currently selected strategy, explicitly mark it as a"
                     f" forward method with `fabric_model.mark_forward_method({name!r})` after `fabric.setup()`."
                 )
-            for handle in handles:
-                handle.remove()
             return output
 
         return _wrapped_method

--- a/tests/tests_fabric/test_wrappers.py
+++ b/tests/tests_fabric/test_wrappers.py
@@ -131,6 +131,62 @@ def test_fabric_module_method_lookup():
     assert fabric_module.method_with_self_invocation() == 102
 
 
+def test_fabric_module_method_lookup_cleans_up_hooks():
+    """The call tracker must not leave its hooks behind or carry its verdict into the next call."""
+
+    class OriginalModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.submodule = torch.nn.Linear(2, 3)
+
+        def forward(self, x):
+            return x
+
+        def maybe_call_submodule(self, call):
+            if call:
+                self.submodule(torch.rand(2, 2))
+            return 100
+
+        def raises(self):
+            raise ValueError("boom")
+
+    class ModuleWrapper(torch.nn.Module):
+        def __init__(self, module):
+            super().__init__()
+            self.wrapped = module
+
+        def forward(self, *args, **kwargs):
+            return self.wrapped(*args, **kwargs)
+
+    original_module = OriginalModule()
+    fabric_module = _FabricModule(
+        forward_module=ModuleWrapper(original_module),
+        strategy=Mock(precision=Precision()),
+        original_module=original_module,
+    )
+
+    def hook_count():
+        return sum(len(module._forward_hooks) for module in original_module.modules())
+
+    assert hook_count() == 0
+
+    method = fabric_module.maybe_call_submodule
+    assert method(call=False) == 100
+    assert hook_count() == 0
+
+    with pytest.raises(RuntimeError, match=r"You are calling the method `OriginalModule.maybe_call_submodule\(\)`"):
+        method(call=True)
+    assert hook_count() == 0
+
+    # the verdict from the failed call must not leak into the next one
+    assert method(call=False) == 100
+
+    # an exception raised by the method itself must not leave hooks behind either
+    with pytest.raises(ValueError, match="boom"):
+        fabric_module.raises()
+    assert hook_count() == 0
+
+
 def test_fabric_module_mark_forward_method():
     class OriginalModule(torch.nn.Module):
         attribute = 1


### PR DESCRIPTION
## What breaks

`_wrap_method_with_module_call_tracker` puts a forward hook on every submodule so it can tell whether a method reached the model, then removes the hooks only after the check passes. Two things follow.

**The hooks leak on every failure.** The `remove()` loop sits after the `raise`, so the tracker's own `RuntimeError` leaves them registered, and so does any exception the wrapped method raises itself. They fire on every later forward and are never cleaned up.

```
hooks on the original module: 0
call a method that touches a submodule -> RuntimeError (expected)
hooks on the original module: 2
call it again                          -> RuntimeError
hooks on the original module: 4
```

**The verdict sticks.** `module_called` lives in the enclosing scope and is only initialised when the method is wrapped, so once a bound method has tripped the guard it keeps raising for calls that touch nothing:

```python
method = fabric_model.maybe_call_submodule
method(call=False)   # 100
method(call=True)    # RuntimeError, correct
method(call=False)   # RuntimeError, wrong
```

## The change

Reset `module_called` at the top of each call, and remove the handles in a `finally` so both the raise path and an exception from the method itself clean up. The check and its message are unchanged.

## Test

`test_fabric_module_method_lookup_cleans_up_hooks` in `tests/tests_fabric/test_wrappers.py` counts `_forward_hooks` after a success, after the tracker's `RuntimeError`, and after an exception raised by the method, and calls the same bound method again after a failure.

```
tests/tests_fabric/test_wrappers.py
  before: 1 failed, 28 passed, 14 skipped
  after:  29 passed, 14 skipped
```
