### PR TITLE
Fix batch size tuning after validation errors

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed batch size tuning failing to restore training parameters after an error during validation ([#21946](https://github.com/Lightning-AI/pytorch-lightning/pull/21946))
+
 - Fixed `LightningCLI` emitting `jsonargparse` deprecation warnings ([#21900](https://github.com/Lightning-AI/pytorch-lightning/issues/21900))
 
 - Fixed `RichProgressBar` showing a nonsensical negative epoch total (e.g. `Epoch 5/-2`) when `Trainer(max_epochs=-1)` (unlimited epochs) is used and training stops via another condition ([#21925](https://github.com/Lightning-AI/pytorch-lightning/issues/21925))

--- a/src/lightning/pytorch/tuner/batch_size_scaling.py
+++ b/src/lightning/pytorch/tuner/batch_size_scaling.py
@@ -19,6 +19,7 @@ from typing import Any, Optional
 
 import lightning.pytorch as pl
 from lightning.pytorch.utilities.memory import garbage_collection_cuda, is_oom_error
+from lightning.pytorch.utilities.model_helpers import _ModuleMode
 from lightning.pytorch.utilities.parsing import lightning_getattr, lightning_setattr
 from lightning.pytorch.utilities.rank_zero import rank_zero_info, rank_zero_warn
 
@@ -401,7 +402,14 @@ def _try_loop_run(trainer: "pl.Trainer", params: dict[str, Any]) -> None:
     assert loop is not None
     loop.load_state_dict(deepcopy(params["loop_state_dict"]))
     loop.restarting = False
-    loop.run()
+    stage = trainer.state.stage
+    module_mode = _ModuleMode()
+    module_mode.capture(trainer.lightning_module)
+    try:
+        loop.run()
+    finally:
+        trainer.state.stage = stage
+        module_mode.restore(trainer.lightning_module)
 
 
 def _reset_progress(trainer: "pl.Trainer") -> None:

--- a/tests/tests_pytorch/tuner/test_scale_batch_size.py
+++ b/tests/tests_pytorch/tuner/test_scale_batch_size.py
@@ -482,6 +482,107 @@ def test_dataloader_batch_size_updated_on_failure(_, tmp_path, scale_method, exp
     assert trainer.train_dataloader.batch_size == expected_batch_size
 
 
+@pytest.mark.parametrize("mode", ["power", "binsearch"])
+@pytest.mark.parametrize("method", ["fit", "validate", "test", "predict"])
+def test_scale_batch_size_recovers_from_evaluation_oom(tmp_path, mode, method):
+    model = BatchSizeModel(batch_size=2)
+    hook = {"fit": "validation_step", "validate": "validation_step", "test": "test_step", "predict": "predict_step"}[
+        method
+    ]
+    original_step = getattr(model, hook)
+    failed_batch_sizes = []
+
+    def step(batch, *args, **kwargs):
+        if len(batch) > 2:
+            failed_batch_sizes.append(len(batch))
+            raise torch.OutOfMemoryError("CUDA out of memory.")
+        return original_step(batch, *args, **kwargs)
+
+    setattr(model, hook, step)
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        accelerator="cpu",
+        logger=False,
+        enable_checkpointing=False,
+        max_epochs=1,
+        num_sanity_val_steps=0,
+        val_check_interval=1,
+    )
+    attributes = (
+        "max_steps",
+        "limit_train_batches",
+        "limit_val_batches",
+        "limit_test_batches",
+        "limit_predict_batches",
+    )
+    before = {name: getattr(trainer, name) for name in attributes}
+    result = Tuner(trainer).scale_batch_size(
+        model, method=method, mode=mode, init_val=2, max_trials=4, steps_per_trial=1, margin=0.0
+    )
+
+    assert failed_batch_sizes
+    assert result == model.batch_size == 2
+    assert {name: getattr(trainer, name) for name in attributes} == before
+    assert not list(tmp_path.glob(".scale_batch_size_*.ckpt"))
+
+
+@pytest.mark.parametrize("mode", ["power", "binsearch"])
+def test_scale_batch_size_restores_module_modes_after_validation_oom(tmp_path, mode):
+    class CustomModel(BatchSizeModel):
+        def __init__(self):
+            super().__init__(batch_size=4)
+            self.layer = torch.nn.Sequential(torch.nn.Linear(32, 2), torch.nn.Dropout(), torch.nn.BatchNorm1d(2))
+            self.layer[1].eval()
+            self.batch_sizes = []
+
+        def training_step(self, batch, batch_idx):
+            self.batch_sizes.append(len(batch))
+            assert self.training
+            assert not self.layer[1].training
+            assert self.layer[2].training
+            return super().training_step(batch, batch_idx)
+
+        def validation_step(self, batch, batch_idx):
+            if len(batch) > 2:
+                raise torch.OutOfMemoryError("CUDA out of memory.")
+            return super().validation_step(batch, batch_idx)
+
+    model = CustomModel()
+    modes = {name: module.training for name, module in model.named_modules()}
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        accelerator="cpu",
+        logger=False,
+        enable_checkpointing=False,
+        max_epochs=1,
+        num_sanity_val_steps=0,
+        val_check_interval=1,
+    )
+    result = Tuner(trainer).scale_batch_size(model, mode=mode, init_val=4, max_trials=4, steps_per_trial=1, margin=0.0)
+    assert result == 2
+    assert model.batch_sizes[:2] == [4, 2]
+    assert {name: module.training for name, module in model.named_modules()} == modes
+
+
+def test_scale_batch_size_preserves_validation_error(tmp_path):
+    class CustomModel(BatchSizeModel):
+        def validation_step(self, *args, **kwargs):
+            raise ValueError("validation failed")
+
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        accelerator="cpu",
+        logger=False,
+        enable_checkpointing=False,
+        max_epochs=1,
+        num_sanity_val_steps=0,
+        val_check_interval=1,
+    )
+    with pytest.raises(ValueError, match="validation failed"):
+        Tuner(trainer).scale_batch_size(CustomModel(batch_size=2), steps_per_trial=1)
+    assert not list(tmp_path.glob(".scale_batch_size_*.ckpt"))
+
+
 def test_batch_size_finder_callback_val_batches(tmp_path):
     """Test that `BatchSizeFinder` does not limit the number of val batches during training."""
     steps_per_trial = 2


### PR DESCRIPTION
## What does this PR do?

Batch size tuning can fail with `KeyError: 'limit_eval_batches'` after a validation error leaves the trainer in the validation stage. Restore the original trainer stage and module training modes after each trial so OOM retries use the correct loop and model modes, and other validation errors propagate without being masked.

Fixes #18985.

Tested: `pytest tests/tests_pytorch/tuner/test_scale_batch_size.py -q -rs`.

<details>
<summary><b>Before submitting</b></summary>

- Discussion and reproduction: [#18985](https://github.com/Lightning-AI/pytorch-lightning/issues/18985#issuecomment-5607551540).
- [x] Read the contributor guideline and Pull Request section.
- [x] This PR does one thing.
- [x] Verified new and existing batch-size tuner tests locally.
- Added regression tests and a PyTorch changelog entry.

</details>

## PR review

<details>
<summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review?
- [ ] Check that all items from **Before submitting** are resolved.
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR.
- [ ] Add labels and milestones (and optionally projects) so the PR can be classified.

</details>