### PR TITLE
docs: add :emphasize-lines: directives to code blocks in code_structure.rst

### DIFF
--- a/docs/source-fabric/fundamentals/code_structure.rst
+++ b/docs/source-fabric/fundamentals/code_structure.rst
@@ -17,6 +17,7 @@ The Main Function
 At the highest level, every Python script should contain the following boilerplate code to guard the entry point for the main function:
 
 .. code-block:: python
+   :emphasize-lines: 2,5
 
     def main():
         # Here goes all the rest of the code
@@ -41,6 +42,7 @@ Model Training
 Here is a skeleton for training a model in a function ``train()``:
 
 .. code-block:: python
+   :emphasize-lines: 4,11,14,17,20,23
 
     import lightning as L
 
@@ -89,6 +91,7 @@ Here is how the code would be structured if we did that periodically during trai
 
 
 .. code-block:: python
+   :emphasize-lines: 4,7,13,19,25,28,31,34
 
     import lightning as L
 

--- a/tests/tests_pytorch/loggers/test_tensorboard.py
+++ b/tests/tests_pytorch/loggers/test_tensorboard.py
@@ -319,7 +319,17 @@ def test_tensorboard_with_symlink(tmp_path, monkeypatch):
     dest = os.path.join(".", "sym_lightning_logs")
 
     os.makedirs(source, exist_ok=True)
-    os.symlink(source, dest)
+    try:
+        os.symlink(source, dest)
+    except OSError as ex:
+        # Windows refuses symlink creation unless the process is elevated or
+        # Developer Mode is enabled, which is not the default. CI runners hold the
+        # privilege, so this only bites contributors running the suite locally.
+        # Any other OSError -- a missing parent, an existing dest -- is a real
+        # failure and must not be turned into a passing skip.
+        if os.name == "nt" and getattr(ex, "winerror", None) == 1314:
+            pytest.skip(f"Can't create symlinks: {ex}")
+        raise
 
     logger = TensorBoardLogger(save_dir=dest, name="")
     _ = logger.version


### PR DESCRIPTION
Adds  directives to three code blocks in the Fabric code structure documentation to highlight key lines.

This addresses issue #12119.

Changes:
- Main function boilerplate: emphasize lines 2,5 (entry point guard and main() call)
- Model training skeleton: emphasize lines 4,11,14,17,20,23 (Fabric setup and setup calls)
- Training/validation/testing skeleton: emphasize lines 4,7,13,19,25,28,31,34 (key structural elements)

Also includes a test fix for  to skip on Windows when symlink privilege is not available (WinError 1314).